### PR TITLE
Fixed a bug with exceptions

### DIFF
--- a/quadtree.py
+++ b/quadtree.py
@@ -539,7 +539,7 @@ def render_worldtile(chunks, colstart, colend, rowstart, rowend, path):
         try:
             chunkimg = Image.open(chunkfile)
             chunkimg.load()
-        except IOError, e:
+        except (IOError, IndexError), e:
             # If for some reason the chunk failed to load (perhaps a previous
             # run was canceled and the file was only written half way,
             # corrupting it), then this could error.


### PR DESCRIPTION
We were getting a bug on our map generator where an exception was being called in PngImageLibrary, as the chunk it was trying to read was blank. This created an IndexError when it tried to use the i32 function.
