### PR TITLE
minecraft-overviewer does not deal with higher-resolution textures

### DIFF
--- a/textures.py
+++ b/textures.py
@@ -92,13 +92,19 @@ def _get_terrain_image():
 def _split_terrain(terrain):
     """Builds and returns a length 256 array of each 16x16 chunk of texture"""
     textures = []
+    (terrain_width, terrain_height) = terrain.size
+    texture_resolution = terrain_width / 16
     for y in xrange(16):
         for x in xrange(16):
-            left = x*16
-            upper = y*16
-            right = left+16
-            lower = upper+16
-            region = terrain.crop((left,upper,right,lower))
+            left = x*texture_resolution
+            upper = y*texture_resolution
+            right = left+texture_resolution
+            lower = upper+texture_resolution
+            region = terrain.transform(
+                      (16, 16),
+                      Image.EXTENT,
+                      (left,upper,right,lower),
+                      Image.BICUBIC)
             textures.append(region)
 
     return textures


### PR DESCRIPTION
I use a texture pack that has 32x32 textures, some crazy people use 64x64. minecraft-overviewer does not expect seem to handle that possibility so far, so it picks the wrong pixels trying to render my world. With my patch, the texture size is assumed to be 1/16th the terrain.png size.
