### PR TITLE
Patch: render minecart tracks

### DIFF
--- a/chunk.py
+++ b/chunk.py
@@ -59,6 +59,11 @@ def get_skylight_array(level):
     """
     return numpy.frombuffer(level['SkyLight'], dtype=numpy.uint8).reshape((16,16,64))
 
+def get_blockdata_array(level):
+    """Returns the ancillary data from the 'Data' byte array.  Data is packed
+    in a similar manner to skylight data"""
+    return numpy.frombuffer(level['Data'], dtype=numpy.uint8).reshape((16,16,64))
+
 # This set holds blocks ids that can be seen through, for occlusion calculations
 transparent_blocks = set([0, 6, 8, 9, 18, 20, 37, 38, 39, 40, 44, 50, 51, 52, 53,
     59, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 74, 75, 76, 77, 79, 81, 83, 85])
@@ -237,6 +242,13 @@ class ChunkRenderer(object):
             blocks = blocks.copy()
             blocks[skylight_expanded != 0] = 21
 
+        blockData = get_blockdata_array(self.level)
+        blockData_expanded = numpy.empty((16,16,128), dtype=numpy.uint8)
+        # Even elements get the lower 4 bits
+        blockData_expanded[:,:,::2] = blockData & 0x0F
+        # Odd elements get the upper 4 bits
+        blockData_expanded[:,:,1::2] = blockData >> 4
+
 
         # Each block is 24x24
         # The next block on the X axis adds 12px to x and subtracts 6px from y in the image
@@ -255,7 +267,17 @@ class ChunkRenderer(object):
                 for z in xrange(128):
                     try:
                         blockid = blocks[x,y,z]
-                        t = textures.blockmap[blockid]
+
+                        # the following blocks don't have textures that can be pre-computed from the blockid
+                        # alone.  additional data is required.
+                        # TODO torches, redstone torches, crops, ladders, stairs, 
+                        #      levers, doors, buttons, and signs all need to be handled here (and in textures.py)
+                        if blockid in (66,): ## minecart track
+                            ancilData = blockData_expanded[x,y,z]
+                            t =  textures.generate_special_texture(blockid, ancilData)
+
+                        else:
+                            t = textures.blockmap[blockid]
                         if not t:
                             continue
 


### PR DESCRIPTION
Minetracks are now (mostly) rendered correctly, with a correct orientation.  Example: https://andrewchin.net/tmp/output_4/img.-j.-a.nocave.a0c99c.png

This code also sets up the basic pattern for rendering other blocks/items that don't have textures that can be pre-computed (basically anything with orientation or state -- ladders, steps, doors, torches, switches, etc)
