### PR TITLE
gmap api v3 update

### DIFF
--- a/template.html
+++ b/template.html
@@ -205,6 +205,7 @@
       navigationControl: true,
       scaleControl: false,
       mapTypeControl: false,
+      streetViewControl: false,
       mapTypeId: 'mcmap'
     };
     map = new google.maps.Map(document.getElementById("mcmap"), mapOptions);


### PR DESCRIPTION
Google released an update to v3 of the gmap api which enables streetview by default. This change explicitly disables it.
