### PR TITLE
Cave mode causes crash on "high" maps

### DIFF
--- a/chunk.py
+++ b/chunk.py
@@ -531,7 +531,7 @@ class ChunkRenderer(object):
                 ):
                     continue
             elif cave and (
-                    y == 15 and x == 0
+                    y == 15 and x == 0 and z != 127
             ):
                 # If it's on the facing edge, only render if what's
                 # above it is transparent


### PR DESCRIPTION
Index out of bounds exception is thrown due to missing test in chunk.py.

See: http://github.com/brownan/Minecraft-Overviewer/issues#issue/10/comment/479954
