### PR TITLE
Fix cache images size.

### DIFF
--- a/chunk.py
+++ b/chunk.py
@@ -516,6 +516,8 @@ class ChunkRenderer(object):
 
         # Since there are 16x16x128 blocks in a chunk, the image will be 384x1728
         # (height is 128*12 high, plus the size of the horizontal plane: 16*12)
+        # but actually, (unknown reason at the moment) it is 18 pixels taller, 
+        # so is 384x1746
         if not img:
             img = Image.new("RGBA", (384, 1746), (38,92,255,0))
 

--- a/quadtree.py
+++ b/quadtree.py
@@ -390,7 +390,7 @@ class QuadtreeGen(object):
         """Get chunks that are relevant to the tile rendering function that's
         rendering that range"""
         chunklist = []
-        for row in xrange(rowstart-16, rowend+1):
+        for row in xrange(rowstart-17, rowend+1):
             for col in xrange(colstart, colend+1):
                 c = self.world.chunkmap.get((col, row), None)
                 if c:


### PR DESCRIPTION
The cache chunk images are wrong size, this is a very small fix with the correct size. I tested it mixing different sizes of cache images and there is no problem, so nobody has to re-render the cache.
