### PR TITLE
Fix cache images, this is a workaround.

### DIFF
--- a/chunk.py
+++ b/chunk.py
@@ -710,8 +710,10 @@ class ChunkRenderer(object):
 
         # Since there are 16x16x128 blocks in a chunk, the image will be 384x1728
         # (height is 128*12 high, plus the size of the horizontal plane: 16*12)
-        # but actually, (unknown reason at the moment) it is 18 pixels taller, 
-        # so is 384x1746
+        # but actually it should be 18 pixels taller, so is 384x1746
+        # The real problem is in iterate_chunkblocks.
+        # This is a workaround! (but doesn't need to re-render the entire cache)
+        
         if not img:
             img = Image.new("RGBA", (384, 1746), (38,92,255,0))
 

--- a/quadtree.py
+++ b/quadtree.py
@@ -390,7 +390,9 @@ class QuadtreeGen(object):
         """Get chunks that are relevant to the tile rendering function that's
         rendering that range"""
         chunklist = []
-        for row in xrange(rowstart-17, rowend+1):
+        for row in xrange(rowstart-17, rowend+1): # It should be -16, this is a workaround
+                                                  # for the cropped chunks problem.
+                                                  # the problem is in chunk.py iterate_chunkblocks
             for col in xrange(colstart, colend+1):
                 c = self.world.chunkmap.get((col, row), None)
                 if c:


### PR DESCRIPTION
Fixes the cropped cache images, in a hacky way. This fix make 18 pixels taller the image in chunk.py, and adds another row of chunks in quadtree.py.

This is a workaround, but with this you don't have to re-render the whole cache.
