### PR TITLE
Add redstone to the list of transparent blocks.

### DIFF
--- a/chunk.py
+++ b/chunk.py
@@ -109,7 +109,7 @@ def iterate_chunkblocks(xoff,yoff):
 
 
 # This set holds blocks ids that can be seen through, for occlusion calculations
-transparent_blocks = set([0, 6, 8, 9, 18, 20, 37, 38, 39, 40, 44, 50, 51, 52, 53,
+transparent_blocks = set([0, 6, 8, 9, 18, 20, 37, 38, 39, 40, 44, 50, 51, 52, 53, 55,
     59, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 74, 75, 76, 77, 78, 79, 81, 83, 85])
 
 # This set holds block ids that are solid blocks


### PR DESCRIPTION
Fixes the issue:

https://github.com/brownan/Minecraft-Overviewer/issues#issue/213
