### PR TITLE
Some extra JS options

### DIFF
--- a/config.js
+++ b/config.js
@@ -2,6 +2,7 @@
   var config = {
     tileSize:     384,
     defaultZoom:  2,
+    minZoom:      {minzoom},
     maxZoom:      {maxzoom},
     // center on this point, in world coordinates, ex:
     //center:       [0,0,0],

--- a/googlemap.py
+++ b/googlemap.py
@@ -90,6 +90,8 @@ class MapGen(object):
 
         config = open(configpath, 'r').read()
         config = config.replace(
+                "{minzoom}", str(0))
+        config = config.replace(
                 "{maxzoom}", str(zoomlevel))
         
         config = config.replace("{spawn_coords}",

--- a/web_assets/functions.js
+++ b/web_assets/functions.js
@@ -659,7 +659,7 @@ for (idx in mapTypeData) {
         getTileUrl: getTileUrlGenerator(view.path, view.base, imgformat),
         tileSize: new google.maps.Size(config.tileSize, config.tileSize),
         maxZoom:  config.maxZoom,
-        minZoom:  0,
+        minZoom:  config.minZoom,
         isPng:    !(imgformat.match(/^png$/i) == null)
     };
   


### PR DESCRIPTION
The first commit adds support for per-rendermode background color setting which can be nice to give the night map a darker background or something like that, the default is the same as it was so there's no change unless you specifically edit the config.js file. The other adds a minzoom setting since in some cases the highest (most zoomed out) level(s) can be somewhat useless due to the lost detail, defaults to 0 so it's the same as before. Demo map here:
http://ne.xen.im/js-bg-color_demo/
