### PR TITLE
regin click should show clicked spot in xyz not lat/lng

### DIFF
--- a/web_assets/overviewer.js
+++ b/web_assets/overviewer.js
@@ -775,9 +775,11 @@ var overviewer = {
                     overviewer.collections.infoWindow.close();
                 }
                 // Replace our Info Window's content and position
+                var point = overviewer.util.fromLatLngToWorld(event.latLng.lat(),event.latLng.lng());
                 var contentString = '<b>Region: ' + shape.name + '</b><br />' +
-                    'Clicked Location: <br />' + event.latLng.lat() + ', ' +
-                    event.latLng.lng() + '<br />';
+                    'Clicked Location: <br />' + Math.round(point.x,1) + ', ' + point.y
+                     + ', ' + Math.round(point.z,1)
+                     + '<br />';
                 infowindow.setContent(contentString);
                 infowindow.setPosition(event.latLng);
                 infowindow.open(overviewer.map);


### PR DESCRIPTION
regions should show the user the xyz of the clicked region, not the lat/lng... i'll add more calls to these in the coming days, but i'l make separate pull requests for each.

http://minecraft.writhem.com/dev/ click on one of the regions...
