### PR TITLE
Signs search

### DIFF
--- a/web_assets/overviewer.css
+++ b/web_assets/overviewer.css
@@ -100,3 +100,34 @@ body {
     background-color: #fff; /* fallback */
     background-color: rgba(255,255,255,0.8);
 }
+
+#searchControl {
+    padding: 5px;
+    height: 20px;
+    font-family: Arial, sans-serif;
+}
+
+#searchControl > input {
+    border: 2px solid #000;
+    font-size: 12pt;
+    width: 20em;
+    background-colour: #fff;
+}
+
+div#searchDropDown {
+    border: 1px solid #000;
+    width: 17em;
+    font-size: 14pt;
+    background-color: #fff;
+    display: none;
+}
+
+div.searchResultItem  {
+    overflow: hidden;
+    text-overflow: ellipsis;    
+}
+
+div.searchResultItem img {
+    width: 24px;
+    height: 24px;
+}


### PR DESCRIPTION
This is a live instant search box for signs.  It puts an entry box in the top right corner along with the other map controls.  It only searches in enabled sign types (from the Signposts dropdown).

I'm pretty happy with it.  See it in action at http://minecraft4.orospakr.ca:8082/

Outstanding issues (I'll understand if you decide to not merge it on account of these):
- My CSS is terrible.  I'm bad at it, I freely admit.  Sign text wraps poorly in the search dropdown.
- I have to break encapsulation a little in order to get access to the created Google markers and icons from the markerDatas hash.
- It doesn't have many configuration opportunities.
