### PR TITLE
setup.py now checks for Imaging directory in Python include path (#402)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from distutils.command.build import build
 from distutils.command.clean import clean
 from distutils.command.build_ext import build_ext
 from distutils.dir_util import remove_tree
+from distutils.sysconfig import get_python_inc
 from distutils import log
 import os, os.path
 import glob
@@ -52,7 +53,10 @@ except AttributeError:
 try:
     pil_include = os.environ['PIL_INCLUDE_DIR'].split(os.pathsep)
 except:
-    pil_include = []
+    pil_include = [ os.path.join(get_python_inc(plat_specific=1), 'Imaging') ]
+    if not os.path.exists(pil_include[0]):
+        pil_include = [ ]
+        
 
 # used to figure out what files to compile
 render_modes = ['normal', 'overlay', 'lighting', 'night', 'spawn', 'cave']


### PR DESCRIPTION
When building Minecraft-Overviewer I've also ran into problem described in #402 (no `Imaging.h` in include path). I've investigated my Python include directory, and it came up that PIL headers are installed not in main include directory (like in Ubuntu or Mandriva), but in `Imaging` subdirectory. 
I'm using Fedora and yum, but I know that few other distros do it in the same way (also, it appears to be the good way, according to [Distutils docs](http://docs.python.org/distutils/setupscript.html#preprocessor-options)).

This patch keeps both types of systems satisfied (it first searches for a `Imaging` subdirectory, then falls back to main include directory).
