### PR TITLE
Remove location marker with click

### DIFF
--- a/overviewer_core/data/web_assets/overviewer.js
+++ b/overviewer_core/data/web_assets/overviewer.js
@@ -313,6 +313,9 @@ var overviewer = {
                              'title':   jQuery.trim(item.msg),
                              'icon':    overviewerConfig.CONST.image.queryMarker
                         });
+                        google.maps.event.addListener(marker, 'click', function(){ marker.setVisible(false); });
+
+
                         continue;
                     }
 


### PR DESCRIPTION
The "querypos" marker that appears when linked to a location on the map will be removable by a click.
