### PR TITLE
Add new option "--advanced-help". Options previously marked

### DIFF
--- a/overviewer.py
+++ b/overviewer.py
@@ -145,7 +145,7 @@ def main():
 
     if options.advanced_help:
         parser.advanced_help()
-	sys.exit(0)
+        sys.exit(0)
 
     if len(args) < 1:
         logging.error("You need to give me your world number or directory")

--- a/overviewer_core/configParser.py
+++ b/overviewer_core/configParser.py
@@ -12,7 +12,7 @@ class ConfigOptionParser(object):
         self.cmdParser = optparse.OptionParser(usage=kwargs.get("usage",""))
         self.configFile = kwargs.get("config","settings.py")
         self.configVars = []
-	self.advancedHelp = []
+    self.advancedHelp = []
         # these are arguments not understood by OptionParser, so they must be removed
         # in add_option before being passed to the OptionParser
 
@@ -38,10 +38,10 @@ class ConfigOptionParser(object):
         self.configVars.append(kwargs.copy())
 
         if kwargs.get("advanced"):
-	    kwargs['help'] = optparse.SUPPRESS_HELP
-	    self.advancedHelp.append((args, kwargs.copy()))
+        kwargs['help'] = optparse.SUPPRESS_HELP
+        self.advancedHelp.append((args, kwargs.copy()))
         else:
-	    kwargs["help"]=kwargs["helptext"]
+        kwargs["help"]=kwargs["helptext"]
 
         for arg in self.customArgs:
             if arg in kwargs.keys(): del kwargs[arg]
@@ -54,15 +54,15 @@ class ConfigOptionParser(object):
         self.cmdParser.print_help()
 
     def advanced_help(self):
-	self.cmdParser.set_conflict_handler('resolve') # Allows us to overwrite the previous definitions
-	for opt in self.advancedHelp:
+    self.cmdParser.set_conflict_handler('resolve') # Allows us to overwrite the previous definitions
+    for opt in self.advancedHelp:
             opt[1]['help']="[!]" + opt[1]['helptext']
             for arg in self.customArgs:
                 if arg in opt[1].keys(): del opt[1][arg]
             if opt[1].get("type", None):
                 opt[1]['type'] = 'string' # we'll do our own converting later
             self.cmdParser.add_option(*opt[0], **opt[1])
-	    self.cmdParser.epilog = "Advanced options indicated by [!]. These options should not normally be required, and may have caveats regarding their use. See README file for more details"
+            self.cmdParser.epilog = "Advanced options indicated by [!]. These options should not normally be required, and may have caveats regarding their use. See README file for more details"
             self.print_help()
 
 


### PR DESCRIPTION
configFileOnly are now marked as "advanced" and will not appear in
default help text.

From a discussion on IRC it seems that the intention behind config file only options was to reduce clutter in the help text. This pull requests suppresses display of these options in the default help text but allows them to be used from the command line. The --advanced-help option displays the full list of options, marking advanced options with "[!]" and adds a small notice at the bottom of the list.
