### PR TITLE
Edit scripts to move overviewer.dat to render dir

### DIFF
--- a/contrib/findSigns.py
+++ b/contrib/findSigns.py
@@ -5,16 +5,14 @@ This script will scan through every chunk looking for signs and write out an
 updated overviewer.dat file.  This can be useful if your overviewer.dat file
 is either out-of-date or non-existant.  
 
-To run, simply give a path to your world directory, for example:
+To run, simply give a path to your world directory and the path to your
+output directory. For example:
 
-    python contrib/findSigns.py ../world.test/
+    python contrib/findSigns.py ../world.test/ output_dir/
 
 Once that is done, simply re-run the overviewer to generate markers.js:
 
     python overviewer.py ../world.test/ output_dir/
-
-Note: if your cachedir is not the same as your world-dir, you'll need to manually
-move overviewer.dat into the correct location.
 
 '''
 import sys
@@ -23,15 +21,21 @@ import os
 import cPickle
 
 sys.path.append(".")
-import nbt
+from overviewer_core import nbt
 
 from pprint import pprint
 
 worlddir = sys.argv[1]
+outputdir = sys.argv[2]
 if os.path.exists(worlddir):
     print "Scanning chunks in ", worlddir
 else:
     sys.exit("Bad WorldDir")
+
+if os.path.exists(outputdir):
+    print "Output directory is ", outputdir
+else:
+    sys.exit("Bad OutputDir")
 
 matcher = re.compile(r"^r\..*\.mcr$")
 
@@ -63,8 +67,12 @@ for dirpath, dirnames, filenames in os.walk(worlddir):
                             print "Found sign at (%d, %d, %d): %r" % (newPOI['x'], newPOI['y'], newPOI['z'], newPOI['msg'])
 
 
+if os.path.isfile(os.path.join(worlddir, "overviewer.dat")):
+    print "Overviewer.dat detected in WorldDir - this is no longer the correct location\n"
+    print "You may wish to delete the old file. A new overviewer.dat will be created\n"
+    print "Old file: ", os.path.join(worlddir, "overviewer.dat")
 
-pickleFile = os.path.join(worlddir,"overviewer.dat")
+pickleFile = os.path.join(outputdir,"overviewer.dat")
 with open(pickleFile,"wb") as f:
     cPickle.dump(dict(POI=POI), f)
 

--- a/overviewer.py
+++ b/overviewer.py
@@ -241,7 +241,7 @@ def main():
         logging.info("Notice: Not using biome data for tinting")
     
     # First do world-level preprocessing
-    w = world.World(worlddir, useBiomeData=useBiomeData, regionlist=regionlist)
+    w = world.World(worlddir, destdir, useBiomeData=useBiomeData, regionlist=regionlist)
     w.go(options.procs)
 
     logging.info("Rending the following tilesets: %s", ",".join(options.rendermode))
@@ -281,7 +281,7 @@ def delete_all(worlddir, tiledir):
     # TODO should we delete tiledir here too?
     
     # delete the overviewer.dat persistant data file
-    datfile = os.path.join(worlddir,"overviewer.dat")
+    datfile = os.path.join(tiledir,"overviewer.dat")
     if os.path.exists(datfile):
         os.unlink(datfile)
         logging.info("Deleting {0}".format(datfile))

--- a/overviewer_core/world.py
+++ b/overviewer_core/world.py
@@ -69,8 +69,9 @@ class World(object):
 
     mincol = maxcol = minrow = maxrow = 0
     
-    def __init__(self, worlddir, useBiomeData=False,regionlist=None):
+    def __init__(self, worlddir, outputdir, useBiomeData=False,regionlist=None):
         self.worlddir = worlddir
+        self.outputdir = outputdir
         self.useBiomeData = useBiomeData
                 
         #find region files, or load the region list
@@ -111,8 +112,20 @@ class World(object):
         # info self.persistentData.  This dictionary can hold any information
         # that may be needed between runs.
         # Currently only holds into about POIs (more more details, see quadtree)
-        # TODO maybe store this with the tiles, not with the world?
+        
         self.pickleFile = os.path.join(self.worlddir, "overviewer.dat")
+        if os.path.exists(self.pickleFile):
+            logging.warning("overviewer.dat detected in WorldDir - this is no longer the correct location")
+            logging.warning("Moving overviewer.dat to OutputDir")
+            import shutil
+            try:
+                shutil.move(self.pickleFile, self.outputdir)
+                logging.info("overviewer.dat moved")
+            except BaseException as ex:
+                logging.error("Unable to move overviewer.dat")
+                logging.debug(ex.str())
+
+        self.pickleFile = os.path.join(self.outputdir, "overviewer.dat")    
         if os.path.exists(self.pickleFile):
             with open(self.pickleFile,"rb") as p:
                 self.persistentData = cPickle.load(p)


### PR DESCRIPTION
Overviewer.dat is moved on first run and a warning is issued

findSigns.py has also been updated and will issue a warning if an old overviewer.dat is found, but creates a new file in the output directory and advises that you delete the old one.
