### PR TITLE
Update findSigns.py to work with configurable north directions

### DIFF
--- a/contrib/findSigns.py
+++ b/contrib/findSigns.py
@@ -97,5 +97,5 @@ if os.path.isfile(os.path.join(worlddir, "overviewer.dat")):
 
 pickleFile = os.path.join(outputdir,"overviewer.dat")
 with open(pickleFile,"wb") as f:
-    cPickle.dump(dict(POI=POI), f)
+    cPickle.dump(dict(POI=POI,north_direction=north_direction), f)
 


### PR DESCRIPTION
Although it is not necessary to know the north direction in order to find signs, it makes sense to add it the overviewer.dat file generated by the script. That way the script can still be used to replace a corrupt/deleted/lost/eaten overviewer.dat file, regardless of it's north direction.

Closes Issue #485
