### PR TITLE
Add --changelist and --changelist-format

### DIFF
--- a/overviewer_core/quadtree.py
+++ b/overviewer_core/quadtree.py
@@ -479,6 +479,8 @@ class QuadtreeGen(object):
             tileimg.save(imgpath, quality=self.imgquality, subsampling=0)
         else: # png
             tileimg.save(imgpath)
+        #Add tile to list of rendered tiles
+        poi_queue.put(['rendered',imgpath])
 
         if self.optimizeimg:
             optimize_image(imgpath, self.imgformat, self.optimizeimg)

--- a/overviewer_core/rendernode.py
+++ b/overviewer_core/rendernode.py
@@ -36,7 +36,7 @@ from time import gmtime, strftime, sleep
 
 
 """
-This module has routines related to distributing the render job to multipule nodes
+This module has routines related to distributing the render job to multiple nodes
 
 """
 
@@ -109,6 +109,9 @@ class RenderNode(object):
 
         self.options = options
         self.quadtrees = quadtrees
+        #List of changed tiles
+        self.rendered_tiles = []
+
         #bind an index value to the quadtree so we can find it again
         #and figure out which worlds are where
         i = 0
@@ -162,7 +165,8 @@ class RenderNode(object):
                 
         quadtrees = self.quadtrees
         
-        # do per-quadtree init.
+        # do per-quadtree init
+
         max_p = 0        
         total = 0
         for q in quadtrees:
@@ -203,6 +207,10 @@ class RenderNode(object):
                                         world.POI.append(item[1])
                                 elif item[0] == "removePOI":
                                     world.persistentData['POI'] = filter(lambda x: x['chunk'] != item[1], world.persistentData['POI'])
+
+                                elif item[0] == "rendered":
+                                    self.rendered_tiles.append(item[1])
+
                         except Queue.Empty:
                             pass
                     while count_to_remove > 0:
@@ -231,6 +239,9 @@ class RenderNode(object):
                             world.POI.append(item[1])
                     elif item[0] == "removePOI":
                         world.persistentData['POI'] = filter(lambda x: x['chunk'] != item[1], world.persistentData['POI'])
+                    elif item[0] == "rendered":
+                        self.rendered_tiles.append(item[1])
+
             except Queue.Empty:
                 pass
 
@@ -278,7 +289,7 @@ class RenderNode(object):
         # Do the final one right here:
         for q in quadtrees:
             q.render_innertile(os.path.join(q.destdir, q.tiledir), "base")
-        
+
     def _apply_render_worldtiles(self, pool,batch_size):
         """Returns an iterator over result objects. Each time a new result is
         requested, a new task is added to the pool and a result returned.

--- a/overviewer_core/world.py
+++ b/overviewer_core/world.py
@@ -86,7 +86,7 @@ class World(object):
         #  stores Points Of Interest to be mapped with markers
         #  a list of dictionaries, see below for an example
         self.POI = []
-
+        
         # if it exists, open overviewer.dat, and read in the data structure
         # info self.persistentData.  This dictionary can hold any information
         # that may be needed between runs.


### PR DESCRIPTION
Allow output of changed tiles to a file specified with --changelist. The
file contains the name of each tile on a line. The path can be relative
or absolute, chosen using --changelist-format.

The code assumes that all innertiles will have been updated when a
worldtile changes, and prints the corresponding filenames to the list
directly, rather than add message passing to the innertile methods.

Closes issue #478
