### PR TITLE
Fix issue with os.path.exists if config file includes "\ " ...

### DIFF
--- a/overviewer_core/settingsValidators.py
+++ b/overviewer_core/settingsValidators.py
@@ -40,6 +40,9 @@ def checkBadEscape(s):
     if "\r" in fixed_string:
         fixed_string = s.replace("\r", r"\r")
         fixed = True
+    if "\ " in fixed_string:
+        fixed_string = s.replace("\ ", " ")
+        fixed = True
     return (fixed, fixed_string)
 
 


### PR DESCRIPTION
os.path.exists would not return True if in the config file, "\ " was present in a world name with a space in it. 
(ie "/home/tom/.minecraft/saves/Cloud\ Nine" --standard space escaping).
Added a block in settingsValidators to handle this by replacing "\ " with " ".
