### PR TITLE
Add 'showspawn' render option

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -480,6 +480,10 @@ values. The valid configuration keys are listed below.
 
     **Default:** ``[]`` (an empty list)
 
+``showspawn``
+    This is a boolean, and defaults to ``True``. If set to ``False``, then the spawn
+    icon will not be displayed on the rendered map.
+
 .. _customrendermodes:
 
 Custom Rendermodes and Rendermode Primitives

--- a/overviewer.py
+++ b/overviewer.py
@@ -401,7 +401,7 @@ dir but you forgot to put quotes around the directory, since it contains spaces.
 
         # only pass to the TileSet the options it really cares about
         render['name'] = render_name # perhaps a hack. This is stored here for the asset manager
-        tileSetOpts = util.dict_subset(render, ["name", "imgformat", "renderchecks", "rerenderprob", "bgcolor", "imgquality", "optimizeimg", "rendermode", "worldname_orig", "title", "dimension", "changelist"])
+        tileSetOpts = util.dict_subset(render, ["name", "imgformat", "renderchecks", "rerenderprob", "bgcolor", "imgquality", "optimizeimg", "rendermode", "worldname_orig", "title", "dimension", "changelist","showspawn"])
         tileSetOpts.update({"spawn": w.find_true_spawn()}) # TODO find a better way to do this
         tset = tileset.TileSet(rset, assetMrg, tex, tileSetOpts, tileset_dir)
         tilesets.append(tset)

--- a/overviewer_core/settingsDefinition.py
+++ b/overviewer_core/settingsDefinition.py
@@ -79,6 +79,7 @@ renders = Setting(required=True, default=util.OrderedDict(),
             "crop": Setting(required=False, validator=validateCrop, default=None),
             "changelist": Setting(required=False, validator=validateStr, default=None),
             "markers": Setting(required=False, validator=validateMarkers, default=[]),
+            "showspawn": Setting(required=False, validator=validateBool, default=True),
 
             # Remove this eventually (once people update their configs)
             "worldname": Setting(required=False, default=None,

--- a/overviewer_core/tileset.py
+++ b/overviewer_core/tileset.py
@@ -520,8 +520,11 @@ class TileSet(object):
                 last_rendertime = self.max_chunk_mtime,
                 imgextension = self.imgextension,
                 )
-        if (self.regionset.get_type() == "overworld"):
+        if (self.regionset.get_type() == "overworld" and self.options.get("showspawn", True)):
             d.update({"spawn": self.options.get("spawn")})
+        else:
+            d.update({"spawn": "false"});
+
         try:
             d['north_direction'] = self.regionset.north_dir
         except AttributeError:


### PR DESCRIPTION
Allow users to hide the spawn marker that is normally generated for
overworld levels.

Addresses recent comment by EdGruberman on 729fcda

This is the only way I could see to add this sort of option at the moment, but I'm open to the idea of reworking it if there's a better way
