### PR TITLE
Save png images with an adaptive palette

### DIFF
--- a/overviewer_core/tileset.py
+++ b/overviewer_core/tileset.py
@@ -869,6 +869,7 @@ class TileSet(object):
             if imgformat == 'jpg':
                 img.save(tmppath, "jpeg", quality=self.options['imgquality'], subsampling=0)
             else: # png
+                img = img.convert('RGB').convert('P', palette=Image.ADAPTIVE)
                 img.save(tmppath, "png")
 
             if self.options['optimizeimg']:


### PR DESCRIPTION
Reduces file size significantly without any noticeable loss in quality. (If even any at all.)
This is extremely hacky, someone should go over this _!_oneliner_!_. Apparently PIL can't convert directly from RGBA to P, so it uses RGB first. Weird.
