### PR TITLE
Make built in rendermodes show up in Table of Contents

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -643,7 +643,7 @@ are referencing the previously defined list, not one of the built-in
 rendermodes.
 
 Built-in Rendermodes
---------------------
+====================
 The built-in rendermodes are nothing but pre-defined lists of rendermode
 primitives for your convenience. Here are their definitions::
 


### PR DESCRIPTION
I made the table of contents show the built in rendermodes.
