### PR TITLE
Script to update contributor list automatically

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,2 +1,5 @@
 Andrew Brown <brownan@gmail.com> <andrew@fry.(none)>
 Alex Headley <aheadley@waysaboutstuff.com> <aheadley@nexcess.net>
+Alex Headley <aheadley@waysaboutstuff.com> aheadley
+Michael Fallows <michael@fallo.ws> redorkulated
+Maciej Malecki <maciej.malecki@hotmail.com> Maciej Małecki


### PR DESCRIPTION
The script uses `git shortlog` to create a list of contributors that are not yet included in CONTRIBUTORS.rst

The email address is taken as definitive.
People with the same name, but different email addresses are supported.
Aliases, different email addresses for the same person, are handled by git with .mailmap

The contributors are merged to the short-term contributor list.

I did not update the contributor list yet, to give a nice test case for the person pulling this ;-)
I count 17 new contributors in master.

I made 2 entries in .mailmap. There might be more aliases known to the devs.
An alternative would be to handle aliases in the python script, but I didn't see a reason not to use .mailmap.
