### PR TITLE
Changed the #! path for python

### DIFF
--- a/genPOI.py
+++ b/genPOI.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python
 
 '''
 genPOI.py


### PR DESCRIPTION
the /python2 path crashes the genpoi script on the latest debian
release with the python package installed
