### PR TITLE
Fix centering of maps on first load

### DIFF
--- a/overviewer_core/data/js_src/views.js
+++ b/overviewer_core/data/js_src/views.js
@@ -10,7 +10,7 @@ overviewer.views.WorldView = Backbone.View.extend({
 
         var curTileSet = this.model.get("tileSets").at(0);
         var spawn = curTileSet.get("spawn");
-        if (spawn=="false") {
+        if (spawn == "false") {
             var spawn = [0,64,0];
         }
         this.options.lastViewport = [spawn[0],spawn[1],spawn[2],curTileSet.get("defaultZoom")];
@@ -148,7 +148,7 @@ overviewer.views.GoogleMapView = Backbone.View.extend({
 
         var curTset = curWorld.get("tileSets").at(0);
         var spawn = curTset.get("spawn");
-        if (spawn==false) {
+        if (spawn == "false") {
             var spawn = [0,64,0];
         }
         var mapcenter = overviewer.util.fromWorldToLatLng(


### PR DESCRIPTION
I fixed the centering of the maps on first load so it will center to spawn for that map or 0,64,0 if no spawn for that map.

We may want to come up with a better way to fill spawn for nether and end than that default but that is a different feature idea.
