### PR TITLE
Smooth lighting fix.

### DIFF
--- a/overviewer_core/src/primitives/smooth-lighting.c
+++ b/overviewer_core/src/primitives/smooth-lighting.c
@@ -143,7 +143,7 @@ do_shading_with_rule(RenderPrimitiveSmoothLighting *self, RenderState *state, st
     int cz = state->z + face.dz;
     
     /* first, check for occlusion if the block is in the local chunk */
-    if (lighting_is_face_occluded(state, 0, cx, cy, cz))
+    if (lighting_is_face_occluded(state, 1, cx, cy, cz))
         return;
     
     /* calculate the lighting colors for each point */


### PR DESCRIPTION
This seems to fix black dotted lines in smooth lighting rendermode. It just turns on the checking for adjacent blocks in adjacent chunks in the lighting face occlusion.

I think it doesn't break anything but I haven't looked to overviewer's code in a few months so have a look just in case I miss something. 

Edit: Also, this seems to slightly improve the render speed for smooth lighting.
