### PR TITLE
Fix new map format, to support the 4096 ids

### DIFF
--- a/overviewer_core/world.py
+++ b/overviewer_core/world.py
@@ -305,7 +305,7 @@ class RegionSet(object):
         * For each chunk section:
 
           * The "Blocks" byte string is transformed into a 16x16x16 numpy array
-          * The AddBlocks array, if it exists, is bitshifted left 8 bits and
+          * The Add array, if it exists, is bitshifted left 8 bits and
             added into the Blocks array
           * The "SkyLight" byte string is transformed into a 16x16x128 numpy
             array
@@ -381,11 +381,11 @@ class RegionSet(object):
             # Cast up to uint16, blocks can have up to 12 bits of data
             blocks = blocks.astype(numpy.uint16)
             blocks = blocks.reshape((16,16,16))
-            if "AddBlocks" in section:
+            if "Add" in section:
                 # This section has additional bits to tack on to the blocks
-                # array. AddBlocks is a packed array with 4 bits per slot, so
+                # array. Add is a packed array with 4 bits per slot, so
                 # it needs expanding
-                additional = numpy.frombuffer(section['AddBlocks'], dtype=numpy.uint8)
+                additional = numpy.frombuffer(section['Add'], dtype=numpy.uint8)
                 additional = additional.astype(numpy.uint16).reshape((16,16,8))
                 additional_expanded = numpy.empty((16,16,16), dtype=numpy.uint16)
                 additional_expanded[:,:,::2] = (additional & 0x0F) << 8
@@ -393,7 +393,7 @@ class RegionSet(object):
                 blocks += additional_expanded
                 del additional
                 del additional_expanded
-                del section['AddBlocks'] # Save some memory
+                del section['Add'] # Save some memory
             section['Blocks'] = blocks
 
             # Turn the skylight array into a 16x16x16 matrix. The array comes
@@ -572,7 +572,7 @@ class RotatedRegionSet(RegionSetWrapper):
         for section in chunk_data['Sections']:
             section = dict(section)
             newsections.append(section)
-            for arrayname in ['Blocks', 'Data', 'SkyLight', 'BlockLight']:
+            for arrayname in ['Blocks', 'Data', 'SkyLight', 'BlockLight', 'Add']:
                 array = section[arrayname]
                 # Since the anvil change, arrays are arranged with axes Y,Z,X
                 # numpy.rot90 always rotates the first two axes, so for it to


### PR DESCRIPTION
In Mojang source code, the section is not named 'AddBlocks' but 'Add'.
This change has been tested with map which contain Id > 256.
