### PR TITLE
Fix an issue with baked in overlays not having any alpha

### DIFF
--- a/overviewer_core/src/overviewer.h
+++ b/overviewer_core/src/overviewer.h
@@ -26,7 +26,7 @@
 
 // increment this value if you've made a change to the c extesion
 // and want to force users to rebuild
-#define OVERVIEWER_EXTENSION_VERSION 36
+#define OVERVIEWER_EXTENSION_VERSION 37
 
 /* Python PIL, and numpy headers */
 #include <Python.h>

--- a/overviewer_core/src/primitives/overlay.c
+++ b/overviewer_core/src/primitives/overlay.c
@@ -82,8 +82,8 @@ overlay_draw(void *data, RenderState *state, PyObject *src, PyObject *mask, PyOb
     
     /* do the overlay */
     if (a > 0) {
-        alpha_over(state->img, self->white_color, self->facemask_top, state->imgx, state->imgy + increment, 0, 0);
-        tint_with_mask(state->img, r, g, b, a, self->facemask_top, state->imgx, state->imgy + increment, 0, 0);
+        alpha_over_full(state->img, self->white_color, self->facemask_top, a/255.f, state->imgx, state->imgy + increment, 0, 0);
+        tint_with_mask(state->img, r, g, b, 255, self->facemask_top, state->imgx, state->imgy + increment, 0, 0);
     }
 }
 


### PR DESCRIPTION
Tested with ClearBase and Base rendermodes and appears to be working alright.

Can be checked out here. http://contre.us/exmapleOverlays/#/-279/64/38/max/0/1 Left side of the map is with the old style and the right part is with the new code. Look at the tops of the bookcases to see the alpha being applied or not.

When you switch to Day and add the overlay, both sides are still alpha'd properly.
