### PR TITLE
Add support for sandstone stairs

### DIFF
--- a/overviewer_core/src/primitives/lighting.c
+++ b/overviewer_core/src/primitives/lighting.c
@@ -158,7 +158,7 @@ get_lighting_color(RenderPrimitiveLighting *self, RenderState *state,
     blocklevel = get_data(state, BLOCKLIGHT, x, y, z);
 
     /* special half-step handling, stairs handling */
-    if (block == 44 || block == 53 || block == 67 || block == 108 || block == 109 || block == 114) {
+    if (block == 44 || block == 53 || block == 67 || block == 108 || block == 109 || block == 114 || block == 128) {
         unsigned int upper_block;
         
         /* stairs and half-blocks take the skylevel from the upper block if it's transparent */
@@ -167,7 +167,7 @@ get_lighting_color(RenderPrimitiveLighting *self, RenderState *state,
         do {
             upper_counter++; 
             upper_block = get_data(state, BLOCKS, x, y + upper_counter, z);
-        } while (upper_block == 44 || upper_block == 53 || upper_block == 67 || upper_block == 108 || upper_block == 109 || upper_block == 114);
+        } while (upper_block == 44 || upper_block == 53 || upper_block == 67 || upper_block == 108 || upper_block == 109 || upper_block == 114 || upper_block == 128);
         if (is_transparent(upper_block)) {
             skylevel = get_data(state, SKYLIGHT, x, y + upper_counter, z);
         } else {

--- a/overviewer_core/textures.py
+++ b/overviewer_core/textures.py
@@ -1344,7 +1344,7 @@ def slabs(self, blockid, data):
     if texture== 0: # stone slab
         top = self.terrain_images[6]
         side = self.terrain_images[5]
-    elif texture== 1: # stone slab
+    elif texture== 1: # sandstone slab
         top = self.terrain_images[176]
         side = self.terrain_images[192]
     elif texture== 2: # wooden slab
@@ -1492,7 +1492,7 @@ def fire(self, blockid, data):
 block(blockid=52, top_index=34, transparent=True)
 
 # wooden, cobblestone, red brick, stone brick and netherbrick stairs.
-@material(blockid=[53,67,108,109,114], data=range(8), transparent=True, solid=True, nospawn=True)
+@material(blockid=[53,67,108,109,114,128], data=range(8), transparent=True, solid=True, nospawn=True)
 def stairs(self, blockid, data):
 
     # first, rotations
@@ -1526,12 +1526,18 @@ def stairs(self, blockid, data):
         texture = self.terrain_images[54]
     elif blockid == 114: # netherbrick stairs
         texture = self.terrain_images[224]
+    elif blockid == 128: # sandstone stairs
+        texture = self.terrain_images[192]
     
     side = texture.copy()
     half_block_u = texture.copy() # up, down, left, right
     half_block_d = texture.copy()
     half_block_l = texture.copy()
     half_block_r = texture.copy()
+    
+    if blockid == 128: # sandstone stairs have a distinct top texture
+        half_block_u = self.terrain_images[176].copy()
+        half_block_d = self.terrain_images[176].copy()
 
     # generate needed geometries
     ImageDraw.Draw(side).rectangle((0,0,7,6),outline=(0,0,0,0),fill=(0,0,0,0))


### PR DESCRIPTION
_This is a small fix, but I hope it helps. When I get more familiar with the Overviewer, I'll try to add the other missing 1.3 blocks._

Treat blockID 128 as stairs mapped to sandstone texture. Top texture of
sandstone stairs is different than sides and requires special handling.

_Rendered map with fix (part of the [Transylvania](http://transylvania.forumgratuit.org/) server):
http://cilyan.org/piwigo/picture.php?/218/category/7_
