### PR TITLE
Filter out player files not ending in ".dat"

### DIFF
--- a/overviewer_core/aux_files/genPOI.py
+++ b/overviewer_core/aux_files/genPOI.py
@@ -56,11 +56,8 @@ def handlePlayers(rset, render, worldpath):
                  'default': 0}[render['dimension']]
     playerdir = os.path.join(worldpath, "players")
     if os.path.isdir(playerdir):
-        def ignoreTmp(filename):
-            return filename.endswith(".dat")
-
         playerfiles = os.listdir(playerdir)
-        playerfiles = filter(ignoreTmp, playerfiles)
+        playerfiles = [x for x in playerfiles if x.endswith(".dat")]
         isSinglePlayer = False
 
     else:


### PR DESCRIPTION
Ignore anything in the players directory that doesn't end with ".dat"

Addresses issue #806
