### PR TITLE
Fixed POI infowindow image scaling for FireFox

### DIFF
--- a/overviewer_core/data/web_assets/overviewer.css
+++ b/overviewer_core/data/web_assets/overviewer.css
@@ -25,7 +25,7 @@ body {
 .infoWindow>img {
     width:80px;
     float: left;
-
+    image-rendering: -moz-crisp-edges;
 }
 
 .infoWindow>p {


### PR DESCRIPTION
This stops FireFox from interpolating the player images and essentially making them a blurry mess.
