### PR TITLE
Fix wood log rotation in lower-left and lower-right orientations.

### DIFF
--- a/overviewer_core/textures.py
+++ b/overviewer_core/textures.py
@@ -860,7 +860,7 @@ def wood(self, blockid, data):
     if self.rotation == 1:
         if wood_orientation == 4: wood_orientation = 8
         elif wood_orientation == 8: wood_orientation = 4
-    elif self.rotation == 2: 
+    elif self.rotation == 3:
         if wood_orientation == 4: wood_orientation = 8
         elif wood_orientation == 8: wood_orientation = 4
 


### PR DESCRIPTION
Fixes the log rotation in the lower-left and lower-right north directions.
The orientations were adjusted in the upper-right and lower-right cases and not in the upper-right and lower-left cases as they should be (90 degree difference vs. 180 degree).
