### PR TITLE
Region trimmer

### DIFF
--- a/contrib/regionTrimmer.py
+++ b/contrib/regionTrimmer.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-"""Deletes outlying unconnected regions"""
+"""Deletes outlying and unconnected regions"""
 
 import logging
 import os


### PR DESCRIPTION
Adds a contrib script to trim disconnected regions, has options to make the trimming more configurable. Usage:

```
$ python contrib/regionTrimmer.py -h
Usage: regionTrimmer.py [options] <path/to/region/directory>

Options:
  -h, --help            show this help message and exit
  -D, --trim-disconnected
                        Trim all disconnected regions
  -M, --trim-outside-main
                        Trim disconnected regions outside main section bounds
  -B [center_X,center_Y,]bound_X,bound_Y, --trim-outside-bounds=[center_X,center_Y,]bound_X,bound_Y
                        Trim outside given bounds (given as
                        [center_X,center_Y,]bound_X,bound_Y)
  -n, --dry-run         Don't actually delete anything
```

Example run:

```
$ python contrib/regionTrimmer.py -M -n ~/tmp/caketown/region/
INFO:__main__:Using regionset path: /home/aheadley/tmp/caketown/region/
INFO:__main__:Found 65 nodes
INFO:__main__:Generating graphing nodes...
INFO:__main__:Found 5 discrete region sections
INFO:__main__:Region section #01: 0043 nodes
INFO:__main__:Bounds: 3 <-> -3 x 2 <-> -7
INFO:__main__:Center: 0 x -3
INFO:__main__:Region section #02: 0012 nodes
INFO:__main__:Bounds: -45 <-> -48 x 36 <-> 34
INFO:__main__:Center: -47 x 35
INFO:__main__:Region section #03: 0007 nodes
INFO:__main__:Bounds: 10 <-> 8 x 0 <-> -2
INFO:__main__:Center: 9 x -1
INFO:__main__:Region section #04: 0002 nodes
INFO:__main__:Bounds: -20 <-> -20 x 39 <-> 38
INFO:__main__:Center: -20 x 38
INFO:__main__:Region section #05: 0001 nodes
INFO:__main__:Bounds: 4579 <-> 4579 x -42 <-> -42
INFO:__main__:Center: 4579 x -42
INFO:__main__:Using 43 node graph as main section,
INFO:__main__:Checking satellite section with 12 nodes, -45 <-> -48 x 36 <-> 34 bounds and -47 x 35 center
INFO:__main__:Section is outside main section bounds
INFO:__main__:Trimming regions: /home/aheadley/tmp/caketown/region/r.-46.35.mca, /home/aheadley/tmp/caketown/region/r.-46.34.mca, /home/aheadley/tmp/caketown/region/r.-48.35.mca, /home/aheadley/tmp/caketown/region/r.-48.36.mca, /home/aheadley/tmp/caketown/region/r.-45.36.mca, /home/aheadley/tmp/caketown/region/r.-46.36.mca, /home/aheadley/tmp/caketown/region/r.-48.34.mca, /home/aheadley/tmp/caketown/region/r.-47.34.mca, /home/aheadley/tmp/caketown/region/r.-45.34.mca, /home/aheadley/tmp/caketown/region/r.-47.35.mca, /home/aheadley/tmp/caketown/region/r.-45.35.mca, /home/aheadley/tmp/caketown/region/r.-47.36.mca
INFO:__main__:Checking satellite section with 7 nodes, 10 <-> 8 x 0 <-> -2 bounds and 9 x -1 center
INFO:__main__:Section is outside main section bounds
INFO:__main__:Trimming regions: /home/aheadley/tmp/caketown/region/r.9.0.mca, /home/aheadley/tmp/caketown/region/r.10.-1.mca, /home/aheadley/tmp/caketown/region/r.8.0.mca, /home/aheadley/tmp/caketown/region/r.8.-1.mca, /home/aheadley/tmp/caketown/region/r.10.-2.mca, /home/aheadley/tmp/caketown/region/r.9.-1.mca, /home/aheadley/tmp/caketown/region/r.10.0.mca
INFO:__main__:Checking satellite section with 2 nodes, -20 <-> -20 x 39 <-> 38 bounds and -20 x 38 center
INFO:__main__:Section is outside main section bounds
INFO:__main__:Trimming regions: /home/aheadley/tmp/caketown/region/r.-20.39.mca, /home/aheadley/tmp/caketown/region/r.-20.38.mca
INFO:__main__:Checking satellite section with 1 nodes, 4579 <-> 4579 x -42 <-> -42 bounds and 4579 x -42 center
INFO:__main__:Section is outside main section bounds
INFO:__main__:Trimming regions: /home/aheadley/tmp/caketown/region/r.4579.-42.mca
```
