### PR TITLE
Fixes mob spawners rendering as coal ore.

### DIFF
--- a/overviewer_core/textures.py
+++ b/overviewer_core/textures.py
@@ -1508,7 +1508,7 @@ def fire(self, blockid, data):
     return img
 
 # monster spawner
-block(blockid=52, top_index=34, transparent=True)
+block(blockid=52, top_index=65, transparent=True)
 
 # wooden, cobblestone, red brick, stone brick, netherbrick, sandstone, spruce, birch and jungle stairs.
 @material(blockid=[53,67,108,109,114,128,134,135,136], data=range(8), transparent=True, solid=True, nospawn=True)


### PR DESCRIPTION
Changes line 1511:
Old:

``` python
block(blockid=52, top_index=34, transparent=True)
```

New:

``` python
block(blockid=52, top_index=65, transparent=True)
```

Can't tell you why it claims I rewrote the whole file though.
