### PR TITLE
RFC: Custom block plugin system

### DIFF
--- a/customblocks/wool.py
+++ b/customblocks/wool.py
@@ -1,0 +1,41 @@
+#from overviewer_core import textures
+
+@material(blockid=35, data=range(16), solid=True)
+def wool(self, blockid, data):
+    if data == 0: # white
+        texture = self.terrain_images[64]
+    elif data == 1: # orange
+        texture = self.terrain_images[210]
+    elif data == 2: # magenta
+        texture = self.terrain_images[194]
+    elif data == 3: # light blue
+        texture = self.terrain_images[178]
+    elif data == 4: # yellow
+        texture = self.terrain_images[162]
+    elif data == 5: # light green
+        texture = self.terrain_images[146]
+    elif data == 6: # pink
+        texture = self.terrain_images[130]
+    elif data == 7: # grey
+        texture = self.terrain_images[114]
+    elif data == 8: # light grey
+        texture = self.terrain_images[225]
+    elif data == 9: # cyan
+        texture = self.terrain_images[209]
+    elif data == 10: # purple
+        texture = self.terrain_images[193]
+    elif data == 11: # blue
+        texture = self.terrain_images[177]
+    elif data == 12: # brown
+        texture = self.terrain_images[161]
+    elif data == 13: # dark green
+        texture = self.terrain_images[145]
+        texture = Image.new("RGBA", (16, 16), 0x99FFFFFF)
+    elif data == 14: # red
+        texture = self.terrain_images[129]
+        texture = Image.open("/tmp/wool.png").convert("RGBA").resize((16,16))
+    elif data == 15: # black
+        texture = self.terrain_images[113]
+    
+    return self.build_block(texture, texture)
+

--- a/overviewer.py
+++ b/overviewer.py
@@ -391,8 +391,10 @@ dir but you forgot to put quotes around the directory, since it contains spaces.
             worldcache[render['world']] = w
 
         # find or create the textures object
-        texopts = util.dict_subset(render, ["texturepath", "bgcolor", "northdirection"])
-        texopts_key = tuple(texopts.items())
+        texopts = util.dict_subset(render, ["texturepath", "bgcolor", "northdirection", "customblocks"])
+        texopts_red = util.dict_subset(texopts, ["texturepath", "bgcolor", "northdirection"])
+        texopts_red["customblocks"] = " ".join(texopts.get("customblocks", None))
+        texopts_key = tuple(texopts_red.items())
         if texopts_key not in texcache:
             tex = textures.Textures(**texopts)
             tex.generate()

--- a/overviewer_core/settingsDefinition.py
+++ b/overviewer_core/settingsDefinition.py
@@ -86,6 +86,8 @@ renders = Setting(required=True, default=util.OrderedDict(),
             "poititle": Setting(required=False, validator=validateStr, default="Signs"),
             "customwebassets": Setting(required=False, validator=validateWebAssetsPath, default=None),
             "maxzoom": Setting(required=False, validator=validateInt, default=None),
+            "customblocks": Setting(required=False, validator=validateCustomblocks, default=None),
+
             # Remove this eventually (once people update their configs)
             "worldname": Setting(required=False, default=None,
                 validator=error("The option 'worldname' is now called 'world'. Please update your config files")),

--- a/overviewer_core/settingsValidators.py
+++ b/overviewer_core/settingsValidators.py
@@ -227,6 +227,18 @@ def validatePath(p):
     if not os.path.exists(abs_path):
         raise ValidationException("'%s' does not exist. Path initially given as '%s'" % (abs_path,p))
 
+def validateCustomblocks(p):
+    cb = []
+    for i in p:
+        ocb_path = os.path.join(util.get_program_path(), "customblocks", "%s.py" % i)
+        if os.path.isfile(ocb_path):
+            cb.append(ocb_path)
+        elif os.path.isfile(expand_path(i)):
+            cb.append(expand_path(i))
+        else:
+            raise ValidationException("Unable to find block definition file '%s'" % i)
+    return cb
+
 def make_dictValidator(keyvalidator, valuevalidator):
     """Compose and return a dict validator -- a validator that validates each
     key and value in a dictionary.

--- a/overviewer_core/textures.py
+++ b/overviewer_core/textures.py
@@ -37,11 +37,12 @@ class Textures(object):
     rendering. It accepts a background color, north direction, and
     local textures path.
     """
-    def __init__(self, texturepath=None, bgcolor=(26, 26, 26, 0), northdirection=0):
+    def __init__(self, texturepath=None, bgcolor=(26, 26, 26, 0), northdirection=0, customblocks=None):
         self.bgcolor = bgcolor
         self.rotation = northdirection
         self.find_file_local_path = texturepath
-        
+        self.customblocks = customblocks
+
         # not yet configurable
         self.texture_size = 24
         self.texture_dimensions = (self.texture_size, self.texture_size)
@@ -100,7 +101,11 @@ class Textures(object):
                 block = tex[0]
                 scaled_block = block.resize(self.texture_dimensions, Image.ANTIALIAS)
                 blockmap[i] = self.generate_texture_tuple(scaled_block)
-        
+
+        if not self.customblocks is None:
+            for i in self.customblocks:
+                execfile(i)
+
         self.generated = True
     
     ##
@@ -1303,43 +1308,6 @@ def tall_grass(self, blockid, data):
 
 # dead bush
 billboard(blockid=32, index=55)
-
-@material(blockid=35, data=range(16), solid=True)
-def wool(self, blockid, data):
-    if data == 0: # white
-        texture = self.terrain_images[64]
-    elif data == 1: # orange
-        texture = self.terrain_images[210]
-    elif data == 2: # magenta
-        texture = self.terrain_images[194]
-    elif data == 3: # light blue
-        texture = self.terrain_images[178]
-    elif data == 4: # yellow
-        texture = self.terrain_images[162]
-    elif data == 5: # light green
-        texture = self.terrain_images[146]
-    elif data == 6: # pink
-        texture = self.terrain_images[130]
-    elif data == 7: # grey
-        texture = self.terrain_images[114]
-    elif data == 8: # light grey
-        texture = self.terrain_images[225]
-    elif data == 9: # cyan
-        texture = self.terrain_images[209]
-    elif data == 10: # purple
-        texture = self.terrain_images[193]
-    elif data == 11: # blue
-        texture = self.terrain_images[177]
-    elif data == 12: # brown
-        texture = self.terrain_images[161]
-    elif data == 13: # dark green
-        texture = self.terrain_images[145]
-    elif data == 14: # red
-        texture = self.terrain_images[129]
-    elif data == 15: # black
-        texture = self.terrain_images[113]
-    
-    return self.build_block(texture, texture)
 
 # dandelion
 sprite(blockid=37, index=13)


### PR DESCRIPTION
This is just a proof of concept to try and get the ball rolling. The render definition for wool has been moved out of textures.py into a seperate file, which you can then add back in the config file using customblocks = ['wool']. This tries to render red wool using a custom texture, which I placed in /tmp/wool.png - you can download the file I used from http://sucs.org/~tswsl1989/texture-test.png

If you try this, then the texture will be visible, but very dark and hard to distinguish. I'm not sure if this darkening is the issue with the other wool colours.

Suggestions/comments?
