### PR TITLE
Added manual POI option

### DIFF
--- a/overviewer_core/aux_files/genPOI.py
+++ b/overviewer_core/aux_files/genPOI.py
@@ -100,12 +100,14 @@ def handlePlayers(rset, render, worldpath):
                      "z": data['SpawnZ']}
             rset._pois['Players'].append(spawn)
 
-def handleManual(rset, render, manualpois):
+def handleManual(rset, manualpois):
     if not hasattr(rset, "_pois"):
         rset._pois = dict(TileEntities=[], Entities=[])
     
+    rset._pois['Manual'] = []
+
     if manualpois:
-        rset._pois['Manual'] = manualpois
+        rset._pois['Manual'].extend(manualpois)
 
 def main():
 
@@ -184,7 +186,7 @@ def main():
 
         handleEntities(rset, os.path.join(destdir, rname), render, rname)
         handlePlayers(rset, render, worldpath)
-        handleManual(rset, render, config['manualpois'])
+        handleManual(rset, render['manualpois'])
 
     logging.info("Done scanning regions")
     logging.info("Writing out javascript files")

--- a/overviewer_core/settingsDefinition.py
+++ b/overviewer_core/settingsDefinition.py
@@ -86,6 +86,7 @@ renders = Setting(required=True, default=util.OrderedDict(),
             "poititle": Setting(required=False, validator=validateStr, default="Signs"),
             "customwebassets": Setting(required=False, validator=validateWebAssetsPath, default=None),
             "maxzoom": Setting(required=False, validator=validateInt, default=None),
+            "manualpois": Setting(required=False, validator=validateManualPOIs, default=[]),
             # Remove this eventually (once people update their configs)
             "worldname": Setting(required=False, default=None,
                 validator=error("The option 'worldname' is now called 'world'. Please update your config files")),

--- a/overviewer_core/settingsValidators.py
+++ b/overviewer_core/settingsValidators.py
@@ -227,6 +227,12 @@ def validatePath(p):
     if not os.path.exists(abs_path):
         raise ValidationException("'%s' does not exist. Path initially given as '%s'" % (abs_path,p))
 
+def validateManualPOIs(d):
+    for poi in d:
+        if not poi['x'] or not poi['y'] or not poi['z'] or not poi['id']:
+            raise ValidationException("Not all POIs have x/y/z coordinates or an id.")
+    return d
+
 def make_dictValidator(keyvalidator, valuevalidator):
     """Compose and return a dict validator -- a validator that validates each
     key and value in a dictionary.


### PR DESCRIPTION
Here's how to use it:
have a list called "manualpois" in your config filled with objects that contain
the attributes id, x, y and z. Feel free to add more attributes as you need them.
Then, write filter functions to filter for your custom POIs (hint: use the id).

Example config:

``` python
worlds['world'] = "../Minecraft-Overviewer-Addons/exmaple"

def signFilter(poi):
    if poi['id'] == 'Sign':
        return "\n".join([poi['Text1'], poi['Text2'], poi['Text3'], poi['Text4']])

def townFilter(poi):
    if poi['id'] == 'Town':
        return poi['name'] + "\n" 

manualpois = [{'id':'Town', 'x':-259, 'y':64, 'z':150, 'name':'Ponyville'}]

outputdir = "../manualmarkertest"

rendermode = "smooth_lighting"

renders["render1"] = {
    'world': 'world',
    'title': 'exmaple',
    'markers': [dict(name="All signs", filterFunction=signFilter), dict(name="Towns", filterFunction=townFilter)]
}
```
