### PR TITLE
Add option to skip scanning for POIs in regions

### DIFF
--- a/overviewer.py
+++ b/overviewer.py
@@ -99,6 +99,8 @@ def main():
             "These scripts may accept different arguments than the ones listed above")
     exegroup.add_option("--genpoi", dest="genpoi", action="store_true",
             help="Runs the genPOI script")
+    exegroup.add_option("--skip-scan", dest="skipscan", action="store_true",
+            help="When running GenPOI, don't scan for entities")
 
     parser.add_option_group(exegroup)
 

--- a/overviewer_core/aux_files/genPOI.py
+++ b/overviewer_core/aux_files/genPOI.py
@@ -122,6 +122,7 @@ def main():
     parser = OptionParser(usage=helptext)
     parser.add_option("--config", dest="config", action="store", help="Specify the config file to use.")
     parser.add_option("--quiet", dest="quiet", action="count", help="Reduce logging output")
+    parser.add_option("--skip-scan", dest="skipscan", action="store_true", help="Skip scanning for entities when using GenPOI")
 
     options, args = parser.parse_args()
     if not options.config:
@@ -182,12 +183,14 @@ def main():
                 l.append(to_append)
             except KeyError:
                 markers[rname] = [to_append]
+        
+        if not options.skipscan:
+            handleEntities(rset, os.path.join(destdir, rname), render, rname)
 
-        handleEntities(rset, os.path.join(destdir, rname), render, rname)
         handlePlayers(rset, render, worldpath)
         handleManual(rset, render['manualpois'])
 
-    logging.info("Done scanning regions")
+    logging.info("Done handling POIs")
     logging.info("Writing out javascript files")
     markerSetDict = dict()
     for (flter, rset) in markersets:


### PR DESCRIPTION
Sometimes, people just use --genpoi for manual POIs. This option
allows them to save some time by not handling entities.

This feature was requested on IRC.
