### PR TITLE
Showlocationmarker option + default poititle set to "Markers"

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -529,6 +529,12 @@ values. The valid configuration keys are listed below.
 
     **Default:** Automatically set to most detailed zoom level
 
+``showlocationmarker``
+    Allows you to specify whether to show the location marker when accessing a URL
+    with coordinates specified.
+
+    **Default:** ``True``
+
 ``base``
     Allows you to specify a remote location for the tile folder, useful if you
     rsync your map's images to a remote server. Leave a trailing slash and point

--- a/overviewer.py
+++ b/overviewer.py
@@ -460,7 +460,7 @@ dir but you forgot to put quotes around the directory, since it contains spaces.
 
         # only pass to the TileSet the options it really cares about
         render['name'] = render_name # perhaps a hack. This is stored here for the asset manager
-        tileSetOpts = util.dict_subset(render, ["name", "imgformat", "renderchecks", "rerenderprob", "bgcolor", "defaultzoom", "imgquality", "optimizeimg", "rendermode", "worldname_orig", "title", "dimension", "changelist", "showspawn", "overlay", "base", "poititle", "maxzoom"])
+        tileSetOpts = util.dict_subset(render, ["name", "imgformat", "renderchecks", "rerenderprob", "bgcolor", "defaultzoom", "imgquality", "optimizeimg", "rendermode", "worldname_orig", "title", "dimension", "changelist", "showspawn", "overlay", "base", "poititle", "maxzoom", "showlocationmarker"])
         tileSetOpts.update({"spawn": w.find_true_spawn()}) # TODO find a better way to do this
         tset = tileset.TileSet(w, rset, assetMrg, tex, tileSetOpts, tileset_dir)
         tilesets.append(tset)

--- a/overviewer_core/assetmanager.py
+++ b/overviewer_core/assetmanager.py
@@ -95,7 +95,7 @@ directory.
                 'queryMarker':      'http://google-maps-icons.googlecode.com/files/regroup.png'
                 }
         dump['CONST']['mapDivId'] = 'mcmap'
-        dump['CONST']['regionStrokeWeight'] = 2
+        dump['CONST']['regionStrokeWeight'] = 2 # Obselete
         dump['CONST']['UPPERLEFT']  = world.UPPER_LEFT;
         dump['CONST']['UPPERRIGHT'] = world.UPPER_RIGHT;
         dump['CONST']['LOWERLEFT']  = world.LOWER_LEFT;
@@ -122,7 +122,7 @@ directory.
             'mapType': True,
             'overlays': True,
             'coordsBox': True,
-            'searchBox': True
+            'searchBox': True   # Lolwat. Obselete
             }
 
 

--- a/overviewer_core/data/js_src/views.js
+++ b/overviewer_core/data/js_src/views.js
@@ -571,7 +571,7 @@ overviewer.views.LocationIconView = Backbone.View.extend({
         'icon':     overviewerConfig.CONST.image.queryMarker,
         'visible':  false
     }); 
-    overviewer.collections.locationMarker.setVisible(true);
+    overviewer.collections.locationMarker.setVisible(overviewer.mapView.options.currentTileSet.get("showlocationmarker"));
 
     }
 });

--- a/overviewer_core/settingsDefinition.py
+++ b/overviewer_core/settingsDefinition.py
@@ -87,6 +87,7 @@ renders = Setting(required=True, default=util.OrderedDict(),
             "customwebassets": Setting(required=False, validator=validateWebAssetsPath, default=None),
             "maxzoom": Setting(required=False, validator=validateInt, default=None),
             "manualpois": Setting(required=False, validator=validateManualPOIs, default=[]),
+            "showlocationmarker": Setting(required=False, validator=validateBool, default=True),
             # Remove this eventually (once people update their configs)
             "worldname": Setting(required=False, default=None,
                 validator=error("The option 'worldname' is now called 'world'. Please update your config files")),

--- a/overviewer_core/tileset.py
+++ b/overviewer_core/tileset.py
@@ -528,7 +528,8 @@ class TileSet(object):
                 last_rendertime = self.max_chunk_mtime,
                 imgextension = self.imgextension,
                 isOverlay = isOverlay,
-                poititle = self.options.get("poititle")
+                poititle = self.options.get("poititle"),
+                showlocationmarker = self.options.get("showlocationmarker")
                 )
 
         if isOverlay:


### PR DESCRIPTION
The `showlocationmarker` option lets you choose whether to show the brown "location" marker when visiting specific coordinates.
The default is `True`, which means that the behaviour will stay the same.

Additionally, the default poititle was changed from "Signs" to "Markers"
