### PR TITLE
Fix reference to stochastic render command line option

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -472,6 +472,8 @@ values. The valid configuration keys are listed below.
 
     **Default:** ``"upper-left"``
 
+.. _rerenderprob:
+
 ``rerenderprob``
     This is the probability that a tile will be rerendered even though there may
     have been no changes to any blocks within that tile. Its value should be a

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -44,7 +44,7 @@ You've added a new feature or changed textures, but it's not showing up on my ma
 Some new features will only show up in newly-rendered areas. Use the
 :option:`--forcerender` option to update the entire map. If you have a really
 large map and don't want to re-render everything, take a look at
-the :option:`--stochastic-render` option.
+the :ref:`rerenderprob` configuration option.
 
 How do I use this on CentOS 5?
 ------------------------------


### PR DESCRIPTION
Replace with reference to the rerenderprob config entry
