### PR TITLE
Fix LookupError for unknown encodings.

### DIFF
--- a/overviewer_core/assetmanager.py
+++ b/overviewer_core/assetmanager.py
@@ -55,6 +55,16 @@ directory.
             logging.debug(traceback.format_exc())
             self.overviewerConfig = dict(tilesets=dict())
 
+        # Make sure python knows the preferred encoding. If it does not, set it
+        # to utf-8"
+        self.preferredencoding = locale.getpreferredencoding()
+        try:
+            # We don't care what is returned, just that we can get a codec.
+            codecs.lookup(self.preferredencoding)
+        except LookupError:
+            self.preferredencoding = "utf_8"
+        logging.debug("Preferred enoding set to: %s", self.preferredencoding)
+
     def get_tileset_config(self, name):
         "Return the correct dictionary from the parsed overviewerConfig.js"
         for conf in self.overviewerConfig['tilesets']:
@@ -185,7 +195,7 @@ directory.
 
         index = codecs.open(indexpath, 'r', encoding='UTF-8').read()
         index = index.replace("{title}", "Minecraft Overviewer")
-        index = index.replace("{time}", time.strftime("%a, %d %b %Y %H:%M:%S %Z", time.localtime()).decode(locale.getpreferredencoding()))
+        index = index.replace("{time}", time.strftime("%a, %d %b %Y %H:%M:%S %Z", time.localtime()).decode(self.preferredencoding))
         versionstr = "%s (%s)" % (util.findGitVersion(), util.findGitHash()[:7])
         index = index.replace("{version}", versionstr)
 


### PR DESCRIPTION
Sets the preferred encoding to UTF-8 if python is unable to find a codec
for the value returned by locale.getpreferedencodings() function.

Without this fix, the following traceback occurs when python doesn't know the encoding:

2013-07-19 11:41:26 E An error has occurred. This may be a bug. Please let us know!
See http://docs.overviewer.org/en/latest/index.html#help

This is the error that occurred:
Traceback (most recent call last):
  File "./overviewer.py", line 532, in <module>
    ret = main()
  File "./overviewer.py", line 473, in main
    assetMrg.initialize(tilesets)
  File "/Users/pvarner/Minecraft-Overviewer/overviewer_core/assetmanager.py", line 72, in initialize
    self._output_assets(tilesets, True)
  File "/Users/pvarner/Minecraft-Overviewer/overviewer_core/assetmanager.py", line 146, in _output_assets
    self.output_noconfig()
  File "/Users/pvarner/Minecraft-Overviewer/overviewer_core/assetmanager.py", line 188, in output_noconfig
    index = index.replace("{time}", time.strftime("%a, %d %b %Y %H:%M:%S %Z", time.localtime()).decode(locale.getpreferredencoding()))
LookupError: unknown encoding: 
