### PR TITLE
It helps if we print the error message

### DIFF
--- a/contrib/png-it.py
+++ b/contrib/png-it.py
@@ -68,7 +68,7 @@ def main():
     
     all_images = glob(path)
     if not all_images:
-        "Error! No images found in this zoom level. Is this really an overviewer tile set directory?"
+        print "Error! No images found in this zoom level. Is this really an overviewer tile set directory?"
         sys.exit(1)
 
     # autocrop will calculate the center and crop values automagically


### PR DESCRIPTION
We're already checking to see if the path holds tiles, but were failing to print the error message.
