### PR TITLE
Adding blocks for new flowers and doublePlants

### DIFF
--- a/overviewer_core/src/primitives/base.c
+++ b/overviewer_core/src/primitives/base.c
@@ -74,6 +74,10 @@ static void
 base_draw(void *data, RenderState *state, PyObject *src, PyObject *mask, PyObject *mask_light) {
     PrimitiveBase *self = (PrimitiveBase *)data;
 
+    /* in order to detect top parts of doublePlant grass & ferns */
+    unsigned char below_block = get_data(state, BLOCKS, state->x, state->y-1, state->z);
+    unsigned char below_data = get_data(state, DATA, state->x, state->y-1, state->z);
+
     /* draw the block! */
     alpha_over(state->img, src, mask, state->imgx, state->imgy, 0, 0);
     
@@ -102,7 +106,11 @@ base_draw(void *data, RenderState *state, PyObject *src, PyObject *mask, PyObjec
         /* vines */
         state->block == 106 ||
         /* lily pads */
-        state->block == 111)
+        state->block == 111 ||
+        /* doublePlant grass & ferns */
+        (state->block == 175 && (state->block_data == 2 || state->block_data == 3)) ||
+        /* doublePlant grass & ferns tops */
+        (state->block == 175 && below_block == 175 && (below_data == 2 || below_data == 3)) )
     {
         /* do the biome stuff! */
         PyObject *facemask = mask;
@@ -153,6 +161,10 @@ base_draw(void *data, RenderState *state, PyObject *src, PyObject *mask, PyObjec
             break;
         case 111:
             /* lily pads */
+            color_table = self->grasscolor;
+            break;
+        case 175:
+            /* doublePlant grass & ferns */
             color_table = self->grasscolor;
             break;
         default:

--- a/overviewer_core/textures.py
+++ b/overviewer_core/textures.py
@@ -637,7 +637,7 @@ class Textures(object):
         """
         img = Image.new("RGBA", (24,24), self.bgcolor)
 
-        front = tex.resize((14, 11), Image.ANTIALIAS)
+        front = tex.resize((14, 12), Image.ANTIALIAS)
         alpha_over(img, front, (5,9))
         return img
 
@@ -1368,8 +1368,16 @@ def wool(self, blockid, data):
 
 # dandelion
 sprite(blockid=37, imagename="assets/minecraft/textures/blocks/flower_dandelion.png")
-# rose
-sprite(blockid=38, imagename="assets/minecraft/textures/blocks/flower_rose.png")
+
+# flowers
+@material(blockid=38, data=range(10), transparent=True)
+def flower(self, blockid, data):
+    flower_map = ["rose", "blue_orchid", "allium", "houstonia", "tulip_red", "tulip_orange",
+                  "tulip_white", "tulip_pink", "oxeye_daisy", "dandelion"]
+    texture = self.load_image_texture("assets/minecraft/textures/blocks/flower_%s.png" % flower_map[data])
+
+    return self.build_billboard(texture)
+
 # brown mushroom
 sprite(blockid=39, imagename="assets/minecraft/textures/blocks/mushroom_brown.png")
 # red mushroom
@@ -3774,7 +3782,7 @@ def beacon(self, blockid, data):
     
     return img
 
-# cobbleston and mossy cobblestone walls
+# cobblestone and mossy cobblestone walls
 # one additional bit of data value added for mossy and cobblestone
 @material(blockid=139, data=range(32), transparent=True, nospawn=True)
 def cobblestone_wall(self, blockid, data):
@@ -4109,3 +4117,25 @@ def stained_clay(self, blockid, data):
 
 #coal block
 block(blockid=173, top_image="assets/minecraft/textures/blocks/coal_block.png")
+
+#doublePlant blocks
+@material(blockid=175, data=range(16), transparent=True)
+def flower(self, blockid, data):
+    doublePlant_map = ["sunflower", "syringa", "grass", "fern", "rose", "paeonia", "paeonia", "paeonia"]
+    plant = doublePlant_map[data & 0x7]
+
+    if data & 0x8:
+        part = "top"
+    else:
+        part = "bottom"
+
+    png = "assets/minecraft/textures/blocks/doublePlant_%s_%s.png" % (plant,part)
+    texture = self.load_image_texture(png)
+    img = self.build_billboard(texture)
+
+    #sunflower top
+    if data == 8:
+        bloom_tex = self.load_image_texture("assets/minecraft/textures/blocks/doublePlant_sunflower_front.png")
+        alpha_over(img, bloom_tex.resize((14, 11), Image.ANTIALIAS), (5,5))
+
+    return img


### PR DESCRIPTION
... added in 13w36.

This also makes billboards 1 px taller so that the doublePlants don't have a 1 px gap in the middle.

I had to disable the random positioning (like for tallgrass) for doublePlants because the top and bottom parts usually get moved in different directions.

NOW on the snapshot branch!
