### PR TITLE
Fixed cave render for solid unknown blocks.

### DIFF
--- a/overviewer_core/src/overviewer.h
+++ b/overviewer_core/src/overviewer.h
@@ -147,6 +147,7 @@ block_has_property(unsigned short b, BlockProperty prop) {
     return block_properties[b] & (1 << prop);
 }
 #define is_transparent(b) block_has_property((b), TRANSPARENT)
+#define is_known_transparent(b) block_has_property((b), TRANSPARENT) && block_has_property((b), KNOWN)
 
 /* helper for indexing section data possibly across section boundaries */
 typedef enum

--- a/overviewer_core/src/primitives/cave.c
+++ b/overviewer_core/src/primitives/cave.c
@@ -43,9 +43,9 @@ cave_occluded(void *data, RenderState *state, int x, int y, int z) {
     /* check for normal occlusion */
     /* use ajacent chunks, if not you get blocks spreaded in chunk edges */
 
-    if (!is_transparent(get_data(state, BLOCKS, x-1, y, z)) &&
-        !is_transparent(get_data(state, BLOCKS, x, y, z+1)) &&
-        !is_transparent(get_data(state, BLOCKS, x, y+1, z))) {
+    if (!is_known_transparent(get_data(state, BLOCKS, x-1, y, z)) &&
+        !is_known_transparent(get_data(state, BLOCKS, x, y, z+1)) &&
+        !is_known_transparent(get_data(state, BLOCKS, x, y+1, z))) {
         return 1;
     }
     


### PR DESCRIPTION
`is_transparent` returns 1 for every unknown block because that's an easy way to
make them ignore lighting. However, this makes cave render useless with a map
containing unknown ores.

The definition `is_known_transparent` checks whether a block is transparent and is known.

This is a workaround, a proper fix would be to have unknown blocks be neither transparent nor
solid. Or make them both. But don't prefer one of the two.

**NOTE:** This was not tested on a world containing unknown blocks, as I had none handy. But it didn't affect the output of exmaple.

Affects issue #982
