### PR TITLE
Added genPOI workaround for MystCraft

### DIFF
--- a/overviewer_core/aux_files/genPOI.py
+++ b/overviewer_core/aux_files/genPOI.py
@@ -18,6 +18,7 @@ import os
 import logging
 import json
 import sys
+import re
 from optparse import OptionParser
 
 from overviewer_core import logger
@@ -57,9 +58,15 @@ def handlePlayers(rset, render, worldpath):
     # only handle this region set once
     if 'Players' in rset._pois:
         return
-    dimension = {None: 0,
-                 'DIM-1': -1,
-                 'DIM1': 1}[rset.get_type()]
+    try:
+        dimension = {None: 0,
+                     'DIM-1': -1,
+                     'DIM1': 1}[rset.get_type()]
+    except KeyError, e:
+        mystdim = re.match(r"^DIM_MYST(\d+)$", str(e))  # Dirty hack. Woo!
+        if mystdim:
+            dimension = int(mystdim.group(1))
+
     playerdir = os.path.join(worldpath, "players")
     if os.path.isdir(playerdir):
         playerfiles = os.listdir(playerdir)


### PR DESCRIPTION
Possibly fixes issue #993.

Uses the number at the end of the dimension name as dimension number. This is most likely going to work with the way Forge keeps track of which numbers are taken; the Mystcraft FAQ says it stores a list of populated dimension numbers. Thus, I assume the number after DIM_MYST would be that dimension number.

In theory, this should work.

_In practice, I didn't test it._
