### PR TITLE
Fix transparency check for block IDs > 255

### DIFF
--- a/overviewer_core/src/primitives/base.c
+++ b/overviewer_core/src/primitives/base.c
@@ -61,9 +61,9 @@ base_occluded(void *data, RenderState *state, int x, int y, int z) {
          !render_mode_hidden(state->rendermode, x-1, y, z) &&
          !render_mode_hidden(state->rendermode, x, y, z+1) &&
          !render_mode_hidden(state->rendermode, x, y+1, z) &&
-         !is_transparent(getArrayByte3D(state->blocks, x-1, y, z)) &&
-         !is_transparent(getArrayByte3D(state->blocks, x, y, z+1)) &&
-         !is_transparent(getArrayByte3D(state->blocks, x, y+1, z))) {
+         !is_transparent(getArrayShort3D(state->blocks, x-1, y, z)) &&
+         !is_transparent(getArrayShort3D(state->blocks, x, y, z+1)) &&
+         !is_transparent(getArrayShort3D(state->blocks, x, y+1, z))) {
         return 1;
     }
 

--- a/overviewer_core/src/primitives/clear-base.c
+++ b/overviewer_core/src/primitives/clear-base.c
@@ -23,9 +23,9 @@ clear_base_occluded(void *data, RenderState *state, int x, int y, int z) {
          !render_mode_hidden(state->rendermode, x-1, y, z) &&
          !render_mode_hidden(state->rendermode, x, y, z+1) &&
          !render_mode_hidden(state->rendermode, x, y+1, z) &&
-         !is_transparent(getArrayByte3D(state->blocks, x-1, y, z)) &&
-         !is_transparent(getArrayByte3D(state->blocks, x, y, z+1)) &&
-         !is_transparent(getArrayByte3D(state->blocks, x, y+1, z))) {
+         !is_transparent(getArrayShort3D(state->blocks, x-1, y, z)) &&
+         !is_transparent(getArrayShort3D(state->blocks, x, y, z+1)) &&
+         !is_transparent(getArrayShort3D(state->blocks, x, y+1, z))) {
         return 1;
     }
     


### PR DESCRIPTION
Change the getArrayByte3D() calls into getArrayShort3D(), so that block IDs larger than 255 work properly.
