### PR TITLE
Possibly fixed crash when HOME is undefined

### DIFF
--- a/overviewer_core/textures.py
+++ b/overviewer_core/textures.py
@@ -217,7 +217,7 @@ class Textures(object):
 
         # Find an installed minecraft client jar and look in it for the texture
         # file we need.
-        versiondir = None
+        versiondir = ""
         if "APPDATA" in os.environ and sys.platform.startswith("win"):
             versiondir = os.path.join(os.environ['APPDATA'], ".minecraft", "versions")
         elif "HOME" in os.environ:


### PR DESCRIPTION
When HOME was undefined on Linux, the code would try calling
os.listdir(None) which will obviously fail.

This is a workaround. A proper fix would be to rewrite the
code to check for each operating system, not a combination
of operating systems, environment variables and the current
air humidity in London.

Closes issue #1025
