### PR TITLE
Negative maxzoom gets added to the total levels

### DIFF
--- a/overviewer_core/tileset.py
+++ b/overviewer_core/tileset.py
@@ -519,7 +519,7 @@ class TileSet(object):
                 zoomLevels = self.treedepth,
                 minZoom = 0,
                 defaultZoom = self.options.get('defaultzoom'),
-                maxZoom = self.options.get('maxzoom', self.treedepth),
+                maxZoom = self.options.get('maxzoom', self.treedepth) if self.options.get('maxzoom', self.treedepth) >= 0 else self.treedepth+self.options.get('maxzoom'),
                 path = self.options.get('name'),
                 base = self.options.get('base'),
                 bgcolor = bgcolorformat(self.options.get('bgcolor')),


### PR DESCRIPTION
->Specifying -1 would result in the most detailed level to be excluded

This is a kinda hacky and temporary solution, should work for now though.
