### PR TITLE
Fixed regression caused when changing logging.

### DIFF
--- a/overviewer.py
+++ b/overviewer.py
@@ -32,6 +32,7 @@ import subprocess
 import multiprocessing
 import time
 import logging
+logging.basicConfig()
 from optparse import OptionParser, OptionGroup
 
 from overviewer_core import util

--- a/overviewer_core/logger.py
+++ b/overviewer_core/logger.py
@@ -287,6 +287,13 @@ def configure(loglevel=logging.INFO, verbose=False, simple=False):
 
     """
 
+    # Reset the logger. This is necessary, as the other overviewer modules
+    # cause import side-effects, so I had to add a "basicConfig" to the
+    # application entry point. Without resetting, this would cause messages to
+    # be printed more than once (as there would be multiple handlers)!
+    root = logging.getLogger()
+    map(root.removeHandler, root.handlers[:])
+
     logger = logging.getLogger('overviewer_core')
     logger.setLevel(loglevel)
     is_windows = platform.system() == 'Windows'


### PR DESCRIPTION
The regression was cause in the branch of e473314.

As mentioned in the code comments, the issue here is that other overviewer modules have "import side-effects". I did not expect that at first. This commit effectively fixes the regression. It's not the nicest solution, but without refactoring out the mentioned side-effects it's not that easy! I had to introduce "logging.basicConfig" as an additional side-effect to the application entry-point!

Additionally, I had to work "blindly". I don't have Minecraft installed anymore. Furthermore, a lot of the unit-tests fail, none of which have anything to do with the logging changes.

I have done all I can do to verify it works as intended. Without working unit-tests, there's only so much I can do... 
