### PR TITLE
Rearrange infoWindow contents to shrink icon size

### DIFF
--- a/overviewer_core/data/js_src/util.js
+++ b/overviewer_core/data/js_src/util.js
@@ -454,8 +454,8 @@ overviewer.util = {
      * @param google.maps.Marker marker
      */
     'createMarkerInfoWindow': function(marker) {
-        var windowContent = '<div class="infoWindow"><img src="' + marker.icon +
-            '"/><p>' + marker.content.replace(/\n/g,'<br/>') + '</p></div>';
+        var windowContent = '<div class="infoWindow"><p><img src="' + marker.icon +
+            '"/><br />' + marker.content.replace(/\n/g,'<br/>') + '</p></div>';
         var infowindow = new google.maps.InfoWindow({
             'content': windowContent
         });


### PR DESCRIPTION
Partially addresses issue #1057 by moving icons within the paragraph tag and adding a line break before the text.
Icons are rendered at reduced size after this change. Some signs (typically ones with narrow output) still seem to require scroll bars.
