### PR TITLE
Try to track the capabilities of our outputdir filesystem.

### DIFF
--- a/overviewer_core/assetmanager.py
+++ b/overviewer_core/assetmanager.py
@@ -25,7 +25,7 @@ from PIL import Image
 
 import world
 import util
-from files import FileReplacer, mirror_dir
+from files import FileReplacer, mirror_dir, get_fs_caps
 
 class AssetManager(object):
     """\
@@ -43,6 +43,8 @@ directory.
         self.outputdir = outputdir
         self.custom_assets_dir = custom_assets_dir
         self.renders = dict()
+
+        self.fs_caps = get_fs_caps(self.outputdir)
 
         # look for overviewerConfig in self.outputdir
         try:
@@ -148,7 +150,7 @@ directory.
 
         # write out config
         jsondump = json.dumps(dump, indent=4)
-        with FileReplacer(os.path.join(self.outputdir, "overviewerConfig.js")) as tmpfile:
+        with FileReplacer(os.path.join(self.outputdir, "overviewerConfig.js"), capabilities=self.fs_caps) as tmpfile:
             with codecs.open(tmpfile, 'w', encoding='UTF-8') as f:
                 f.write("var overviewerConfig = " + jsondump + ";\n")
 
@@ -162,12 +164,12 @@ directory.
         global_assets = os.path.join(util.get_program_path(), "overviewer_core", "data", "web_assets")
         if not os.path.isdir(global_assets):
             global_assets = os.path.join(util.get_program_path(), "web_assets")
-        mirror_dir(global_assets, self.outputdir)
+        mirror_dir(global_assets, self.outputdir, capabilities=self.fs_caps)
 
         if self.custom_assets_dir:
             # Could have done something fancy here rather than just overwriting
             # the global files, but apparently this what we used to do pre-rewrite.
-            mirror_dir(self.custom_assets_dir, self.outputdir)
+            mirror_dir(self.custom_assets_dir, self.outputdir, capabilities=self.fs_caps)
 
 	# write a dummy baseMarkers.js if none exists
         if not os.path.exists(os.path.join(self.outputdir, "baseMarkers.js")):
@@ -179,7 +181,7 @@ directory.
         js_src = os.path.join(util.get_program_path(), "overviewer_core", "data", "js_src")
         if not os.path.isdir(js_src):
             js_src = os.path.join(util.get_program_path(), "js_src")
-        with FileReplacer(os.path.join(self.outputdir, "overviewer.js")) as tmpfile:
+        with FileReplacer(os.path.join(self.outputdir, "overviewer.js"), capabilities=self.fs_caps) as tmpfile:
             with open(tmpfile, "w") as fout:
                 # first copy in js_src/overviewer.js
                 with open(os.path.join(js_src, "overviewer.js"), 'r') as f:
@@ -199,6 +201,6 @@ directory.
         versionstr = "%s (%s)" % (util.findGitVersion(), util.findGitHash()[:7])
         index = index.replace("{version}", versionstr)
 
-        with FileReplacer(indexpath) as indexpath:
+        with FileReplacer(indexpath, capabilities=self.fs_caps) as indexpath:
             with codecs.open(indexpath, 'w', encoding='UTF-8') as output:
                 output.write(index)

--- a/overviewer_core/tileset.py
+++ b/overviewer_core/tileset.py
@@ -31,7 +31,7 @@ from PIL import Image
 
 from .util import roundrobin
 from . import nbt
-from .files import FileReplacer
+from .files import FileReplacer, get_fs_caps
 from .optimizeimages import optimize_image
 import rendermodes
 import c_overviewer
@@ -356,6 +356,9 @@ class TileSet(object):
                 "--fullrender for just this run")
                 self.options['renderchecks'] = 2
             os.mkdir(self.outputdir)
+
+        # must wait until outputdir exists
+        self.fs_caps = get_fs_caps(self.outputdir)
 
         if self.options['renderchecks'] == 2:
             # Set forcerendertime so that upon an interruption the next render
@@ -902,7 +905,7 @@ class TileSet(object):
                     logging.error("While attempting to delete corrupt image %s, an error was encountered. You will need to delete it yourself. Error was '%s'", path[1], e)
 
         # Save it
-        with FileReplacer(imgpath) as tmppath:
+        with FileReplacer(imgpath, capabilities=self.fs_caps) as tmppath:
             if imgformat == 'jpg':
                 img.save(tmppath, "jpeg", quality=self.options['imgquality'], subsampling=0)
             else: # png
@@ -1006,7 +1009,7 @@ class TileSet(object):
             #draw.text((96,96), "c,r: %s,%s" % (col, row), fill='red')
 
         # Save them
-        with FileReplacer(imgpath) as tmppath:
+        with FileReplacer(imgpath, capabilities=self.fs_caps) as tmppath:
             if self.imgextension == 'jpg':
                 tileimg.save(tmppath, "jpeg", quality=self.options['imgquality'], subsampling=0)
             else: # png


### PR DESCRIPTION
For example, don't chmod if the filesystem dosen't support chmod, and
don't rename over files if that's not supported (this functionality was
already in place).

Should fix #1061
Related to #1055 (we could add a mtime capability flag)
