### PR TITLE
display region file name in map coordinates view

### DIFF
--- a/overviewer_core/data/js_src/views.js
+++ b/overviewer_core/data/js_src/views.js
@@ -134,11 +134,13 @@ overviewer.views.CoordboxView = Backbone.View.extend({
         latLng.lng(),
         overviewer.mapView.options.currentTileSet);
 
-        var regionfileX = Math.floor(worldcoords.x / 32.0);
-        var regionfileZ = Math.floor(worldcoords.z / 32.0);
+        var regionfileX = Math.floor(Math.floor(worldcoords.x / 16.0) / 32.0);
+        var regionfileZ = Math.floor(Math.floor(worldcoords.z / 16.0) / 32.0);
         var regionfilename = "r." + regionfileX + "." + regionfileZ + ".mca";
 
-        this.el.innerHTML = "X " + Math.round(worldcoords.x) + " Z " + Math.round(worldcoords.z) + "(" + regionfilename + ")";
+        this.el.innerHTML = "<strong>X</strong> " + Math.round(worldcoords.x) +
+                            " <strong>Z</strong> " + Math.round(worldcoords.z) +
+                            " (" + regionfilename + ")";
     }
 });
 


### PR DESCRIPTION
Small patch to easily show which region file the mouse is over along with the coordinates. 

![screen shot 2014-02-14 at 4 12 57 pm](https://f.cloud.github.com/assets/54353/2176517/f294d070-95d5-11e3-9e8d-16cc6a0b52c6.png)
