### PR TITLE
Fixes for locale issues

### DIFF
--- a/overviewer.py
+++ b/overviewer.py
@@ -525,7 +525,7 @@ def list_worlds():
     print("Detected saves:")
 
     # get max length of world name
-    worldNameLen = max([len(str(x)) for x in worlds] + [len("World")])
+    worldNameLen = max([len(x) for x in worlds] + [len("World")])
 
     formatString = "%-" + str(worldNameLen) + "s | %-8s | %-8s | %-16s | %s "
     print(formatString % ("World", "Size", "Playtime", "Modified", "Path"))

--- a/overviewer_core/world.py
+++ b/overviewer_core/world.py
@@ -21,6 +21,7 @@ import hashlib
 import time
 import random
 import re
+import locale
 
 import numpy
 
@@ -734,6 +735,7 @@ def get_worlds():
     "Returns {world # or name : level.dat information}"
     ret = {}
     save_dir = get_save_dir()
+    loc = locale.getpreferredencoding()
 
     # No dirs found - most likely not running from inside minecraft-dir
     if not save_dir is None:
@@ -741,7 +743,7 @@ def get_worlds():
             world_dat = os.path.join(save_dir, dir, "level.dat")
             if not os.path.exists(world_dat): continue
             info = nbt.load(world_dat)[1]
-            info['Data']['path'] = os.path.join(save_dir, dir)
+            info['Data']['path'] = os.path.join(save_dir, dir).decode(loc)
             if dir.startswith("World") and len(dir) == 6:
                 try:
                     world_n = int(dir[-1])
@@ -755,7 +757,7 @@ def get_worlds():
         world_dat = os.path.join(dir, "level.dat")
         if not os.path.exists(world_dat): continue
         info = nbt.load(world_dat)[1]
-        info['Data']['path'] = os.path.join(".", dir)
+        info['Data']['path'] = os.path.join(".", dir).decode(loc)
         if 'LevelName' in info['Data'].keys():
             ret[info['Data']['LevelName']] = info['Data']
 


### PR DESCRIPTION
There were some problems when a level.dat contained a non-ascii name, or
when a level.dat lived in a directory with a non-ascii name.

Paths returned by os.listdir are encoded, so we need to decode them
before printing them.  When calculating the max length of the enumerated
world names, were we for some reason calling str() before taking the
len().  The had the effect of converting unicode strings into
non-unicode strings, which is not the correct thing to do.
