### PR TITLE
The previous Google Maps URL was 404'ing. New URL added.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,10 +8,10 @@ Documentation:
 
 Github code repository:
     http://github.com/overviewer/Minecraft-Overviewer
-	
+
 Travis-CI:
     http://travis-ci.org/overviewer/Minecraft-Overviewer
-	
+
 Blog:
     http://overviewer.org/blog/
 
@@ -74,7 +74,7 @@ do *not* need a Google Maps API key (as was the case with older versions of the
 API), so just copying the directory to your web server should suffice. You are,
 however, bound by the Google Maps API terms of service.
 
-http://code.google.com/apis/maps/terms.html
+https://developers.google.com/maps/terms
 
 Bugs
 ====


### PR DESCRIPTION
- Determined the previous Google Maps Terms URL was returning a 404
- Updated URL to be the current Google Maps Terms URL
- Trailing whitespaces removed on lines 11 and 14
