### PR TITLE
Handle UUID player files semi-nicely in POIgen (14w10a+, 1.7.6+)

### DIFF
--- a/overviewer_core/aux_files/genPOI.py
+++ b/overviewer_core/aux_files/genPOI.py
@@ -19,6 +19,7 @@ import logging
 import json
 import sys
 import re
+import urllib2
 import Queue
 import multiprocessing
 
@@ -29,6 +30,8 @@ from optparse import OptionParser
 from overviewer_core import logger
 from overviewer_core import nbt
 from overviewer_core import configParser, world
+
+UUID_LOOKUP_URL = 'https://sessionserver.mojang.com/session/minecraft/profile/'
 
 def replaceBads(s):
     "Replaces bad characters with good characters!"
@@ -132,10 +135,11 @@ def handlePlayers(rset, render, worldpath):
             dimension = int(mystdim.group(1))
         else:
             raise
-    # TODO: get player names from UUIDs once Mojang makes available an API to do it
     playerdir = os.path.join(worldpath, "playerdata")
+    useUUIDs = True
     if not os.path.isdir(playerdir):
         playerdir = os.path.join(worldpath, "players")
+        useUUIDs = False
 
     if os.path.isdir(playerdir):
         playerfiles = os.listdir(playerdir)
@@ -156,6 +160,13 @@ def handlePlayers(rset, render, worldpath):
             logging.warning("Skipping bad player dat file %r", playerfile)
             continue
         playername = playerfile.split(".")[0]
+        if useUUIDs:
+            try:
+                profile = json.loads(urllib2.urlopen(UUID_LOOKUP_URL + playername.replace('-','')).read())
+                if 'name' in profile:
+                    playername = profile['name']
+            except ValueError:
+                logging.warning("Unable to get player name for UUID %s", playername)
         if isSinglePlayer:
             playername = 'Player'
         if data['Dimension'] == dimension:


### PR DESCRIPTION
This pull request is a clone of #1079 opened against the snapshot branch instead of the master branch.

Currently, POIgen crashes trying to handle player POIs on 14w10a worlds, since the `world/players` folder has been moved to `world/playerdata`. This commit patches POIgen to check both folders. Unfortunately, there is currently no way to get the player name from the UUID and it doesn't appear to be stored anywhere, so we're stuck displaying the UUID until Mojang implements a UUID -> name API. This is definitely not ideal, but it's better than a crash.

This patch is fully backwards-compatible; that is, it has no effect on behaviour when handling a 14w08a-/1.7.5- world.
