### PR TITLE
Fixed pngnq rename error in Windows

### DIFF
--- a/overviewer_core/optimizeimages.py
+++ b/overviewer_core/optimizeimages.py
@@ -47,6 +47,7 @@ class Optimizer:
 
 class NonAtomicOptimizer(Optimizer):
     def cleanup(self, img):
+        os.remove(img)
         os.rename(img + ".tmp", img)
 
     def fire_and_forget(self, args, img):


### PR DESCRIPTION
Fixed error 183 (File already exists) in Windows when trying to use
pngnq and trying to rename "file.png.tmp" to "file.png".
