### PR TITLE
Remove broken special case for ancient worlds

### DIFF
--- a/overviewer_core/world.py
+++ b/overviewer_core/world.py
@@ -780,12 +780,7 @@ def get_worlds():
             if not os.path.exists(world_dat): continue
             info = nbt.load(world_dat)[1]
             info['Data']['path'] = os.path.join(save_dir, dir).decode(loc)
-            if dir.startswith("World") and len(dir) == 6:
-                try:
-                    world_n = int(dir[-1])
-                    ret[world_n] = info['Data']
-                except ValueError:
-                    pass
+
             if 'LevelName' in info['Data'].keys():
                 ret[info['Data']['LevelName']] = info['Data']
     


### PR DESCRIPTION
Having a world named "Worldn" where _n_ is any number between 0 and 9 would make Overviewer crash while trying to list worlds. This was due to some old backwards-compatibility thing that nobody needs anymore. (If they did it would've crashed for them anyway.)
