### PR TITLE
Fix error in the config.rst file

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -625,7 +625,7 @@ Rendering
                 'crop': (-500, -500, 500, 500),
         }
 
-    Example that renders two 500 by 500 squares of land:
+    Example that renders two 500 by 500 squares of land::
 
         renders['myrender'] = {
                 'world': 'myworld',


### PR DESCRIPTION
There is an error in the config.rst file in the [Documentation->Rendering->crop](http://docs.overviewer.org/en/latest/config/#rendering) the missing colon leads to the code to be rendered as normal paragraph.
