### PR TITLE
Remove doctype from index.html

### DIFF
--- a/overviewer_core/data/web_assets/index.html
+++ b/overviewer_core/data/web_assets/index.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html>
 <html>
 <head>
 


### PR DESCRIPTION
index.html renders as blank in some browsers (Chrome for me) because the document height is considered to be auto in standards mode. In quirks mode, 100% means the browser height instead. To use 100% in standards mode, you'd have to set height 100% for all children. I can't figure out how the current setup works for people in general, though.
