### PR TITLE
OrderedDict removal && setup.py cleanup 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - wget http://hg.effbot.org/pil-117/raw/f356a1f64271/libImaging/ImPlatform.h
 install:
   - pip install -q pillow
-  - pip install -q numpy
+  - python setup.py develop
   - python setup.py build
 before_script:
   - git clone git://github.com/overviewer/Minecraft-Overviewer-Addons.git ~/mcoa/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,16 @@
+sudo: false
 language: python
 python:
   - "2.6"
   - "2.7"
-  # - "3.2"
 env:
   - MC_VERSION=1.8
-before_install:
-  - wget http://hg.effbot.org/pil-117/raw/f356a1f64271/libImaging/Imaging.h
-  - wget http://hg.effbot.org/pil-117/raw/f356a1f64271/libImaging/ImPlatform.h
 install:
-  - pip install -q pillow
-  - python setup.py develop
+  - mkdir -p Imaging/libImaging
+  - curl -L -o Imaging/libImaging/Imaging.h http://hg.effbot.org/pil-117/raw/f356a1f64271/libImaging/Imaging.h
+  - curl -L -o Imaging/libImaging/ImPlatform.h http://hg.effbot.org/pil-117/raw/f356a1f64271/libImaging/ImPlatform.h
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install -r requirements-2.6.txt --download-cache $HOME/.pip-cache; fi
+  - if [[ $TRAVIS_PYTHON_VERSION != '2.6' ]]; then pip install -r requirements.txt --download-cache $HOME/.pip-cache; fi
   - python setup.py build
 before_script:
   - git clone git://github.com/overviewer/Minecraft-Overviewer-Addons.git ~/mcoa/
@@ -26,6 +26,3 @@ notifications:
     skip_join: true
     template:
       - "\x0313Minecraft-Overviewer\x03/\x0306%{branch}\x03 \x0314%{commit}\x03 %{build_url} %{message}"
-# matrix:
-  # allow_failures:
-    # - python: "3.2"

--- a/docs/building.rst
+++ b/docs/building.rst
@@ -43,7 +43,6 @@ Visual Studio will only build 32-bit executables.  We currently don't have a
 recommended way of building Overviewer on 64-bit Windows using free tools.  If you
 have bought a copy of Visual Studio, you can use it for 64-bit builds.
 
-
 Prerequisites
 ~~~~~~~~~~~~~
 
@@ -56,7 +55,11 @@ Building with Visual Studio
 2. From the Start menu, navigate to the 'Microsoft Visual Studio 2010 Express' and open the 'Visual Studio Command Prompt (2010)' shortcut.
 3. cd to the folder containing the Overviewer source code.
 4. Copy Imaging.h and ImPlatform.h from your PIL installation into the current working directory.
-5. First try a build::
+5. Install additional dependencies::
+
+    c:\python26\python setup.py develop
+
+6. Then try a build::
 
     c:\python26\python setup.py build
 
@@ -78,13 +81,17 @@ Building with mingw
 1. Open a MinGW shell.
 2. cd to the Overviewer directory.
 3. Copy Imaging.h and ImPlatform.h from your PIL installation into the current working directory.
-4. Build::
+4. Install dependencies::
+
+    python setup.py develop
+
+5. Build::
 
     python setup.py build --compiler=mingw32
-    
+
 If the build fails with complaints about ``-mno-cygwin``, open the file ``Lib/distutils/cygwincompiler.py``
 in an editor of your choice, and remove all mentions of ``-mno-cygwin``. This is a bug in distutils,
-filed as `Issue 12641 <http://bugs.python.org/issue12641>`_. 
+filed as `Issue 12641 <http://bugs.python.org/issue12641>`_.
 
 
 Linux
@@ -100,7 +107,11 @@ You will need the following packages (at least):
 * python-dev
 * python-numpy
 
-Then to build::
+Install remaining dependencies from the Python Package Index::
+
+    python setup.py develop
+
+Finally build::
 
     python setup.py build
 
@@ -117,6 +128,10 @@ OSX
 2. Compile the PIL code (``python ./setup.py build``)
 3. Install PIL (``sudo python ./setup.py install``)
 4. Find the path to the ``libImaging`` directory in the PIL source tree.
+5. Install the remaining dependencies::
+
+    python setup.py develop
+
 5. Build Minecraft Overviewer with the path from step 4 as the value for PIL_INCLUDE_DIR::
 
     PIL_INCLUDE_DIR="path from step 4" python ./setup.py build
@@ -136,6 +151,9 @@ The following script (copied into your MCO source directory) should handle every
         tar xzf imaging.tgz
         rm imaging.tgz
     fi
+
+    # Install dependencies
+    python setup.py develop
 
     # build MCO
     PIL_INCLUDE_DIR="`pwd`/Imaging-1.1.7/libImaging" python ./setup.py build
@@ -182,8 +200,9 @@ regular user.
 
   1. ``$ git clone git://github.com/overviewer/Minecraft-Overviewer.git``
   2. ``$ cd Minecraft-Overviewer``
-  3. ``$ python26 setup.py build``
-  4. Change the first line of overviewer.py from ``#!/usr/bin/env python`` to ``#!/usr/bin/env python26`` so that the Python 2.6 interpreter is used instead of the default 2.4
+  3. ``$ python26 setup.py develop``
+  4. ``$ python26 setup.py build``
+  5. Change the first line of overviewer.py from ``#!/usr/bin/env python`` to ``#!/usr/bin/env python26`` so that the Python 2.6 interpreter is used instead of the default 2.4
 
 4. Run Overviewer as usual
 

--- a/overviewer.py
+++ b/overviewer.py
@@ -19,10 +19,10 @@ import platform
 import sys
 
 # quick version check
-if not (sys.version_info[0] == 2 and sys.version_info[1] >= 6):
+if sys.version_info < (2, 6, 0):
     print("Sorry, the Overviewer requires at least Python 2.6 to run")
-    if sys.version_info[0] >= 3:
-        print("and will not run on Python 3.0 or later")
+    if sys.version_info >= (3, 0, 0):
+        print("Overviewer does not run on Python 3.0 or later")
     sys.exit(1)
 
 import os
@@ -357,7 +357,7 @@ dir but you forgot to put quotes around the directory, since it contains spaces.
                 logging.warning(checkname + " ignoring render " + repr(name) + " since it's marked as \"don't render\".")
             else:
                 render['renderchecks'] = num
-        
+
     if options.forcerender:
         logging.info("Forcerender mode activated. ALL tiles will be rendered")
         set_renderchecks("forcerender", 2)
@@ -423,7 +423,7 @@ dir but you forgot to put quotes around the directory, since it contains spaces.
     # create our asset manager... ASSMAN
     assetMrg = assetmanager.AssetManager(destdir, config.get('customwebassets', None))
 
-    # If we've been asked to update web assets, do that and then exit 
+    # If we've been asked to update web assets, do that and then exit
     if options.update_web_assets:
         assetMrg.output_noconfig()
         logging.info("Web assets have been updated")
@@ -478,7 +478,7 @@ dir but you forgot to put quotes around the directory, since it contains spaces.
             texcache[texopts_key] = tex
         else:
             tex = texcache[texopts_key]
-    
+
         try:
             logging.debug("Asking for regionset %r" % render['dimension'][1])
             rset = w.get_regionset(render['dimension'][1])
@@ -562,8 +562,8 @@ dir but you forgot to put quotes around the directory, since it contains spaces.
     if options.pid:
         os.remove(options.pid)
 
-    logging.info("Your render has been written to '%s', open index.html to view it" % destdir)    
-        
+    logging.info("Your render has been written to '%s', open index.html to view it" % destdir)
+
     return 0
 
 def list_worlds():

--- a/overviewer_core/util.py
+++ b/overviewer_core/util.py
@@ -25,6 +25,19 @@ from string import hexdigits
 from subprocess import Popen, PIPE
 from itertools import cycle, islice, product
 import errno
+
+# Try and import odict for Python 2.6, falling back to 2.7+ behavior
+try:
+    import odict
+    OrderedDict = odict.odict
+except ImportError:
+    try:
+        import collections
+        OrderedDict = collections.OrderedDict
+    except AttributeError:
+        pass
+
+
 def get_program_path():
     if hasattr(sys, "frozen") or imp.is_frozen("__main__"):
         return os.path.dirname(sys.executable)
@@ -90,7 +103,7 @@ def is_bare_console():
             num = GetConsoleProcessList(ctypes.byref(ctypes.c_int(0)), ctypes.c_int(1))
             if (num == 1):
                 return True
-                
+
         except Exception:
             pass
     return False
@@ -127,271 +140,6 @@ def dict_subset(d, keys):
             n[key] = d[key]
     return n
 
-## (from http://code.activestate.com/recipes/576693/ [r9])
-# Backport of OrderedDict() class that runs on Python 2.4, 2.5, 2.6, 2.7 and pypy.
-# Passes Python2.7's test suite and incorporates all the latest updates.
-
-try:
-    from thread import get_ident as _get_ident
-except ImportError:
-    from dummy_thread import get_ident as _get_ident
-
-try:
-    from _abcoll import KeysView, ValuesView, ItemsView
-except ImportError:
-    pass
-
-class OrderedDict(dict):
-    'Dictionary that remembers insertion order'
-    # An inherited dict maps keys to values.
-    # The inherited dict provides __getitem__, __len__, __contains__, and get.
-    # The remaining methods are order-aware.
-    # Big-O running times for all methods are the same as for regular dictionaries.
-
-    # The internal self.__map dictionary maps keys to links in a doubly linked list.
-    # The circular doubly linked list starts and ends with a sentinel element.
-    # The sentinel element never gets deleted (this simplifies the algorithm).
-    # Each link is stored as a list of length three:  [PREV, NEXT, KEY].
-
-    def __init__(self, *args, **kwds):
-        '''Initialize an ordered dictionary.  Signature is the same as for
-        regular dictionaries, but keyword arguments are not recommended
-        because their insertion order is arbitrary.
-
-        '''
-        if len(args) > 1:
-            raise TypeError('expected at most 1 arguments, got %d' % len(args))
-        try:
-            self.__root
-        except AttributeError:
-            self.__root = root = []                     # sentinel node
-            root[:] = [root, root, None]
-            self.__map = {}
-        self.__update(*args, **kwds)
-
-    def __setitem__(self, key, value, dict_setitem=dict.__setitem__):
-        'od.__setitem__(i, y) <==> od[i]=y'
-        # Setting a new item creates a new link which goes at the end of the linked
-        # list, and the inherited dictionary is updated with the new key/value pair.
-        if key not in self:
-            root = self.__root
-            last = root[0]
-            last[1] = root[0] = self.__map[key] = [last, root, key]
-        dict_setitem(self, key, value)
-
-    def __delitem__(self, key, dict_delitem=dict.__delitem__):
-        'od.__delitem__(y) <==> del od[y]'
-        # Deleting an existing item uses self.__map to find the link which is
-        # then removed by updating the links in the predecessor and successor nodes.
-        dict_delitem(self, key)
-        link_prev, link_next, key = self.__map.pop(key)
-        link_prev[1] = link_next
-        link_next[0] = link_prev
-
-    def __iter__(self):
-        'od.__iter__() <==> iter(od)'
-        root = self.__root
-        curr = root[1]
-        while curr is not root:
-            yield curr[2]
-            curr = curr[1]
-
-    def __reversed__(self):
-        'od.__reversed__() <==> reversed(od)'
-        root = self.__root
-        curr = root[0]
-        while curr is not root:
-            yield curr[2]
-            curr = curr[0]
-
-    def clear(self):
-        'od.clear() -> None.  Remove all items from od.'
-        try:
-            for node in self.__map.itervalues():
-                del node[:]
-            root = self.__root
-            root[:] = [root, root, None]
-            self.__map.clear()
-        except AttributeError:
-            pass
-        dict.clear(self)
-
-    def popitem(self, last=True):
-        '''od.popitem() -> (k, v), return and remove a (key, value) pair.
-        Pairs are returned in LIFO order if last is true or FIFO order if false.
-
-        '''
-        if not self:
-            raise KeyError('dictionary is empty')
-        root = self.__root
-        if last:
-            link = root[0]
-            link_prev = link[0]
-            link_prev[1] = root
-            root[0] = link_prev
-        else:
-            link = root[1]
-            link_next = link[1]
-            root[1] = link_next
-            link_next[0] = root
-        key = link[2]
-        del self.__map[key]
-        value = dict.pop(self, key)
-        return key, value
-
-    # -- the following methods do not depend on the internal structure --
-
-    def keys(self):
-        'od.keys() -> list of keys in od'
-        return list(self)
-
-    def values(self):
-        'od.values() -> list of values in od'
-        return [self[key] for key in self]
-
-    def items(self):
-        'od.items() -> list of (key, value) pairs in od'
-        return [(key, self[key]) for key in self]
-
-    def iterkeys(self):
-        'od.iterkeys() -> an iterator over the keys in od'
-        return iter(self)
-
-    def itervalues(self):
-        'od.itervalues -> an iterator over the values in od'
-        for k in self:
-            yield self[k]
-
-    def iteritems(self):
-        'od.iteritems -> an iterator over the (key, value) items in od'
-        for k in self:
-            yield (k, self[k])
-
-    def update(*args, **kwds):
-        '''od.update(E, **F) -> None.  Update od from dict/iterable E and F.
-
-        If E is a dict instance, does:           for k in E: od[k] = E[k]
-        If E has a .keys() method, does:         for k in E.keys(): od[k] = E[k]
-        Or if E is an iterable of items, does:   for k, v in E: od[k] = v
-        In either case, this is followed by:     for k, v in F.items(): od[k] = v
-
-        '''
-        if len(args) > 2:
-            raise TypeError('update() takes at most 2 positional '
-                            'arguments (%d given)' % (len(args),))
-        elif not args:
-            raise TypeError('update() takes at least 1 argument (0 given)')
-        self = args[0]
-        # Make progressively weaker assumptions about "other"
-        other = ()
-        if len(args) == 2:
-            other = args[1]
-        if isinstance(other, dict):
-            for key in other:
-                self[key] = other[key]
-        elif hasattr(other, 'keys'):
-            for key in other.keys():
-                self[key] = other[key]
-        else:
-            for key, value in other:
-                self[key] = value
-        for key, value in kwds.items():
-            self[key] = value
-
-    __update = update  # let subclasses override update without breaking __init__
-
-    __marker = object()
-
-    def pop(self, key, default=__marker):
-        '''od.pop(k[,d]) -> v, remove specified key and return the corresponding value.
-        If key is not found, d is returned if given, otherwise KeyError is raised.
-
-        '''
-        if key in self:
-            result = self[key]
-            del self[key]
-            return result
-        if default is self.__marker:
-            raise KeyError(key)
-        return default
-
-    def setdefault(self, key, default=None):
-        'od.setdefault(k[,d]) -> od.get(k,d), also set od[k]=d if k not in od'
-        if key in self:
-            return self[key]
-        self[key] = default
-        return default
-
-    def __repr__(self, _repr_running={}):
-        'od.__repr__() <==> repr(od)'
-        call_key = id(self), _get_ident()
-        if call_key in _repr_running:
-            return '...'
-        _repr_running[call_key] = 1
-        try:
-            if not self:
-                return '%s()' % (self.__class__.__name__,)
-            return '%s(%r)' % (self.__class__.__name__, self.items())
-        finally:
-            del _repr_running[call_key]
-
-    def __reduce__(self):
-        'Return state information for pickling'
-        items = [[k, self[k]] for k in self]
-        inst_dict = vars(self).copy()
-        for k in vars(OrderedDict()):
-            inst_dict.pop(k, None)
-        if inst_dict:
-            return (self.__class__, (items,), inst_dict)
-        return self.__class__, (items,)
-
-    def copy(self):
-        'od.copy() -> a shallow copy of od'
-        return self.__class__(self)
-
-    @classmethod
-    def fromkeys(cls, iterable, value=None):
-        '''OD.fromkeys(S[, v]) -> New ordered dictionary with keys from S
-        and values equal to v (which defaults to None).
-
-        '''
-        d = cls()
-        for key in iterable:
-            d[key] = value
-        return d
-
-    def __eq__(self, other):
-        '''od.__eq__(y) <==> od==y.  Comparison to another OD is order-sensitive
-        while comparison to a regular mapping is order-insensitive.
-
-        '''
-        if isinstance(other, OrderedDict):
-            return len(self)==len(other) and self.items() == other.items()
-        return dict.__eq__(self, other)
-
-    def __ne__(self, other):
-        return not self == other
-
-    # -- the following methods are only used in Python 2.7 --
-
-    def viewkeys(self):
-        "od.viewkeys() -> a set-like object providing a view on od's keys"
-        return KeysView(self)
-
-    def viewvalues(self):
-        "od.viewvalues() -> an object providing a view on od's values"
-        return ValuesView(self)
-
-    def viewitems(self):
-        "od.viewitems() -> a set-like object providing a view on od's items"
-        return ItemsView(self)
-
-# now replace all that with the official version, if available
-try:
-    import collections
-    OrderedDict = collections.OrderedDict
-except (ImportError, AttributeError):
-    pass
 
 def pid_exists(pid): # http://stackoverflow.com/a/6940314/1318435
     """Check whether pid exists in the current process table."""

--- a/requirements-2.6.txt
+++ b/requirements-2.6.txt
@@ -1,0 +1,3 @@
+numpy
+odict
+pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+numpy
+pillow


### PR DESCRIPTION
Update ``setup.py`` to use ``setuptools.setup`` and refactor a bit, including pep8 cleanup and dependency installation. ``distutils`` use is now deprecated in favor of ``setuptools`` (again), though I did not refactor it out completely. A lot of the refactoring is done in the hope that I can get it to building wheel files which will allow platform specific binary distribution without the build step via pip.

Use the 3rd party odict module available on pypi instead of having the code in util.py. When ``setup.py develop`` or ``setup.py install`` are invoked for Python 2.6, odict will be installed, so the fall through in failures should not happen. The only reason we pass on AttributeError is because to invoke ``setup.py``, ``overviewer_core.util`` needs to be imported.

Update version checking in overviewer.py to match how setup.py has been updated.

This also updates ``.travis.yml`` to speed up builds adding a requirements.txt and requirements-2.6.txt file that can be used with travis-ci for caching purposes. It also enabled containerized builds in travis. Additionally remove commented out things for 3.2. They're in git history if they need to be added back/uncommented.
