### PR TITLE
Add option to only load entities from chunk and use it for genPOI, resulting in roughly 1/3 runtime reduction.

### DIFF
--- a/overviewer_core/aux_files/genPOI.py
+++ b/overviewer_core/aux_files/genPOI.py
@@ -161,7 +161,7 @@ def handleEntities(rset, config, config_path, filters, markers):
     if numbuckets == 1:
         for (x, z, mtime) in rset.iterate_chunks():
             try:
-                data = rset.get_chunk(x, z)
+                data = rset.get_chunk(x, z, entities_only=True)
                 for poi in itertools.chain(data['TileEntities'], data['Entities']):
                     if poi['id'] == 'Sign': # kill me
                         poi = signWrangler(poi)


### PR DESCRIPTION
This addresses #1224 (my suggestion for some optimization to genPOI).

As well as adding the kwarg to only load entities, I pulled some of the data-processing out into helper methods when I was profiling, and left them factored out; I think that helps readability of the long method and keeps it from getting too far indented as I put some of the work behind a conditional.

I did not bother to put reading the biomes in the conditional since reading them is trivial in terms of processing time as compared to reading blocks/skylight/blocklight.