### PR TITLE
add support for advpng to optimizeimages.py

### DIFF
--- a/overviewer_core/optimizeimages.py
+++ b/overviewer_core/optimizeimages.py
@@ -121,6 +121,19 @@ class optipng(Optimizer, PNGOptimizer):
     def is_crusher(self):
         return True
 
+class advpng(Optimizer, PNGOptimizer):
+    binaryname = "advpng"
+    crusher = True
+
+    def __init__(self, olevel=3)
+        self.olevel = olevel
+
+    def optimize(self, img):
+        Optimizer.fire_and_forget(self, [self.binaryname, "-z" + str(self.olevel), "-q", img])
+
+    def is_crusher(self):
+        return True
+
 class jpegoptim(Optimizer, JPEGOptimizer):
     binaryname = "jpegoptim"
     crusher = True


### PR DESCRIPTION
Signed-off-by: Horst Burkhardt <mc@680x0.com>

Use of advpng in conjunction with optipng can frequently provide better compression than either tool alone, this commit permits use of advpng by the overviewer. 