### PR TITLE
Create POI filter identifiers from render name instead of RegionSet

### DIFF
--- a/overviewer_core/aux_files/genPOI.py
+++ b/overviewer_core/aux_files/genPOI.py
@@ -466,7 +466,7 @@ def main():
         # find filters for this render
         for f in render['markers']:
             # internal identifier for this filter
-            name = replaceBads(f['name']) + hex(hash(f['filterFunction']))[-4:] + "_" + hex(hash(rset))[-4:]
+            name = replaceBads(f['name']) + hex(hash(f['filterFunction']))[-4:] + "_" + hex(hash(rname))[-4:]
 
             # add it to the list of filters
             filters.add((name, f['name'], f['filterFunction'], rset, worldpath, rname))


### PR DESCRIPTION
I was seeing a problem with an Overviewer configuration where I had two renders (day and night) that used the same RegionSet (dimension) and the same set of POI filter functions. genPOI generates filter identifiers, like Signsf6c7_25a3 and Players0941_25a3, based on the filter function and the RegionSet, and the markers are grouped in markersDB.js by those identifiers. Since they share the same filter functions and RegionSet, both renders end up using the same marker groups.

The problem was that since genPOI processes the filters once for each render, but the filter identifier and thus the marker group are the same for both renders, the markers are added to each group twice and displayed twice.

The best way to fix this seems to be to generate the filter identifier based on the render name instead of the RegionSet. This creates separate marker groups for each render (which will usually end up containing the same set of markers if the renders use the same RegionSet).

An alternative solution might be to only process the filters once for each RegionSet, rather than once for each render, and keep allowing different renders on the same RegionSet to share marker groups. However, I don't think that plays nicely with the way manualpois are specified per-render.