### PR TITLE
genpoi UUID improvements

### DIFF
--- a/overviewer_core/aux_files/genPOI.py
+++ b/overviewer_core/aux_files/genPOI.py
@@ -33,6 +33,7 @@ from optparse import OptionParser
 from overviewer_core import logger
 from overviewer_core import nbt
 from overviewer_core import configParser, world
+from overviewer_core.files import FileReplacer
 
 UUID_LOOKUP_URL = 'https://sessionserver.mojang.com/session/minecraft/profile/'
 
@@ -233,13 +234,11 @@ class PlayerDict(dict):
     @classmethod
     def save_cache(cls, outputdir):
         cache_file = os.path.join(outputdir, "uuidcache.dat")
-        try:
-            gz = gzip.GzipFile(cache_file + ".tmp", "wb")
+
+        with FileReplacer(cache_file) as cache_file_name:
+            gz = gzip.GzipFile(cache_file_name, "wb")
             json.dump(cls.uuid_cache, gz)
-            os.rename(cache_file + ".tmp", cache_file)
             logging.info("Wrote UUID cache with %d entries", len(cls.uuid_cache.keys()))
-        except (IOError, OSError):
-            logging.warning("Failed to save UUID cache!")
 
     def __getitem__(self, item):
         if item == "EntityId":


### PR DESCRIPTION
* When reading the cache, catch some errors on load, instead of crashing
* When writing to cache, write to tmp file, then move it into place.
  This should be more robust if a ctrl+c is recieved while writing the
  cache

Addresses #1266 

cc @ion1 @agrif 

I'll merge this in a few days, so let me know if you have any comments