### PR TITLE
Remove inline for estimate_blocklevel

### DIFF
--- a/overviewer_core/src/primitives/lighting.c
+++ b/overviewer_core/src/primitives/lighting.c
@@ -95,7 +95,7 @@ calculate_light_color_fancy_night(void *data,
  * may (and probably should) pass NULL.
  */
 
-inline unsigned char
+unsigned char
 estimate_blocklevel(RenderPrimitiveLighting *self, RenderState *state,
                          int x, int y, int z, int *authoratative) {
 


### PR DESCRIPTION
Inlining the function allows the compiler to optimize away the
function completely. Clang 3.7.1 does exactly that.

This leads to an error, if the library is used with python:

    % ./overviewer.py
    Traceback (most recent call last):
      File "/tmp/minecraft/Minecraft-Overviewer/overviewer_core/__init__.py", line 20, in check_c_overviewer
        import c_overviewer
    ImportError: /tmp/minecraft/Minecraft-Overviewer/overviewer_core/c_overviewer.so: undefined symbol: estimate_blocklevel

    Something has gone wrong importing the c_overviewer extension.  Please
    make sure it is up-to-date (clean and rebuild)