### PR TITLE
Update text for 1.10

### DIFF
--- a/docs/running.rst
+++ b/docs/running.rst
@@ -275,7 +275,7 @@ If you want or need to provide your own textures, you have several options:
     wget https://s3.amazonaws.com/Minecraft.Download/versions/${VERSION}/${VERSION}.jar -P ~/.minecraft/versions/${VERSION}/
 
   If that's too confusing for you, then just take this single line and paste it into
-  a terminal to get 1.8 textures::
+  a terminal to get 1.10 textures::
 
     wget https://s3.amazonaws.com/Minecraft.Download/versions/1.10/1.10.jar -P ~/.minecraft/versions/1.10/
 


### PR DESCRIPTION
Updated the text for getting the latest minecraft .jar to be for 1.10, used to be 1.8.