### PR TITLE
Updating linux build docs

### DIFF
--- a/docs/building.rst
+++ b/docs/building.rst
@@ -133,6 +133,8 @@ You will need the following packages (at least):
 Then to build::
 
     python setup.py build
+    
+At this point, you can run ``./overviewer.py`` from the current directory, so to run it you'll have to be in this directory and run ``./overviewer.py`` or provide the the full path to ``overviewer.py``.  Another option would be to add this directory to your ``$PATH``.   Note that there is a ``python setup.py install`` step that you can run which will install things into ``/usr/local/bin``, but this is not recommended as it might conflict with other installs of Overviewer
 
 OSX
 ---


### PR DESCRIPTION
Include some small text that clarifies how to run overviewer after a `build` step

CC @agrif @CounterPillow @rrimc69

Does this help reduce some of the confusion?