### PR TITLE
Better error handling of errors when a world fails to open.

### DIFF
--- a/overviewer.py
+++ b/overviewer.py
@@ -613,6 +613,12 @@ def list_worlds():
             playstamp = ""
         path = info['path']
         print(formatString % (name, playstamp, timestamp, path))
+    found_corrupt = any([x.get("IsCorrupt") for x in worlds.values()])
+    if found_corrupt:
+        print("")
+        print("An error has been detected in one or more of your worlds (see the above table).")
+        print("This is usually due to a corrupt level.dat file.  Corrupt worlds need to be")
+        print("repaired before Overviewer can render them.")
 
 if __name__ == "__main__":
     multiprocessing.freeze_support()

--- a/overviewer_core/nbt.py
+++ b/overviewer_core/nbt.py
@@ -189,7 +189,7 @@ class NBTFileReader(object):
             payload = self._read_tag_compound()
             
             return (name, payload)
-        except (struct.error, ValueError), e:
+        except (struct.error, ValueError, TypeError), e:
             raise CorruptNBTError("could not parse nbt: %s" % (str(e),))
 
 # For reference, the MCR format is outlined at

--- a/overviewer_core/world.py
+++ b/overviewer_core/world.py
@@ -792,9 +792,16 @@ def get_worlds():
     for dir in os.listdir("."):
         world_dat = os.path.join(dir, "level.dat")
         if not os.path.exists(world_dat): continue
-        info = nbt.load(world_dat)[1]
-        info['Data']['path'] = os.path.join(".", dir).decode(loc)
-        if 'LevelName' in info['Data'].keys():
-            ret[info['Data']['LevelName']] = info['Data']
+        world_path = os.path.join(".", dir)
+        try:
+            info = nbt.load(world_dat)[1]
+            info['Data']['path'] = world_path.decode(loc)
+            if 'LevelName' in info['Data'].keys():
+                ret[info['Data']['LevelName']] = info['Data']
+        except nbt.CorruptNBTError:
+            ret[os.path.basename(world_path).decode(loc) + " (corrupt)"] = {'path': world_path.decode(loc),
+                    'LastPlayed': 0,
+                    'Time': 0,
+                    'IsCorrupt': True}
 
     return ret

--- a/overviewer_core/world.py
+++ b/overviewer_core/world.py
@@ -781,13 +781,20 @@ def get_worlds():
     # No dirs found - most likely not running from inside minecraft-dir
     if not save_dir is None:
         for dir in os.listdir(save_dir):
-            world_dat = os.path.join(save_dir, dir, "level.dat")
+            world_path = os.path.join(save_dir, dir)
+            world_dat = os.path.join(world_path, "level.dat")
             if not os.path.exists(world_dat): continue
-            info = nbt.load(world_dat)[1]
-            info['Data']['path'] = os.path.join(save_dir, dir).decode(loc)
+            try:
+                info = nbt.load(world_dat)[1]
+                info['Data']['path'] = os.path.join(save_dir, dir).decode(loc)
+                if 'LevelName' in info['Data'].keys():
+                    ret[info['Data']['LevelName']] = info['Data']
+            except nbt.CorruptNBTError:
+                ret[os.path.basename(world_path).decode(loc) + " (corrupt)"] = {'path': world_path.decode(loc),
+                        'LastPlayed': 0,
+                        'Time': 0,
+                        'IsCorrupt': True}
 
-            if 'LevelName' in info['Data'].keys():
-                ret[info['Data']['LevelName']] = info['Data']
     
     for dir in os.listdir("."):
         world_dat = os.path.join(dir, "level.dat")


### PR DESCRIPTION
A common case is a corrupt (or empty) level.dat file.  This condition
wasn't properly caught, yielding a less-than-useful stack trace.  Even
more concerning is that this could happen when a user is just running
"overviewer.py" to get a world listing.

This has been fixed to improve the user experience



Old behavior:

```
2016-12-19 10:52:41 E An error has occurred. This may be a bug. Please let us know!
See http://docs.overviewer.org/en/latest/index.html#help

This is the error that occurred:
Traceback (most recent call last):
  File "overviewer.py", line 608, in <module>
    ret = main()
  File "overviewer.py", line 229, in main
    list_worlds()
  File "overviewer.py", line 577, in list_worlds
    worlds = world.get_worlds()
  File "/storage/home/achin/devel/Minecraft-Overviewer/overviewer_core/world.py", line 795, in get_worlds
    info = nbt.load(world_dat)[1]
  File "/storage/home/achin/devel/Minecraft-Overviewer/overviewer_core/nbt.py", line 29, in wrapper
    return func(fileobj, *args)
  File "/storage/home/achin/devel/Minecraft-Overviewer/overviewer_core/nbt.py", line 37, in load
    return NBTFileReader(fileobj).read_all()
  File "/storage/home/achin/devel/Minecraft-Overviewer/overviewer_core/nbt.py", line 183, in read_all
    tagtype = ord(self._file.read(1))
TypeError: ord() expected a character, but string of length 0 found
```

New behavior:
```
Detected saves:
World                 | Playtime | Modified         | Path 
--------------------- | -------- | ---------------- | ---- 
coords                | 0:01     | 2016-06-25 21:53 | /storage/home/achin/.minecraft/saves/coords 
exmaple               | 4:25     | 2013-08-18 08:33 | ./exmaple 
exmaple_bad (corrupt) |          |                  | ./exmaple_bad 
testing               | 0:01     | 2016-06-11 10:40 | /storage/home/achin/.minecraft/saves/testing 
world.18-pre1         | 72:16    | 2014-08-26 11:18 | ./world.18-pre1 
```