### PR TITLE
Convert RGBA to RGB before saving as JPEG

### DIFF
--- a/overviewer_core/assetmanager.py
+++ b/overviewer_core/assetmanager.py
@@ -146,6 +146,8 @@ directory.
 
             # write a blank image
             blank = Image.new("RGBA", (1,1), tileset.options.get('bgcolor'))
+            if tileset.options.get('imgformat') != 'png':
+                blank = blank.convert("RGB")
             blank.save(os.path.join(self.outputdir, tileset.options.get('name'), "blank." + tileset.options.get('imgformat')))
 
         # write out config

--- a/overviewer_core/tileset.py
+++ b/overviewer_core/tileset.py
@@ -978,7 +978,7 @@ class TileSet(object):
         # Save it
         with FileReplacer(imgpath, capabilities=self.fs_caps) as tmppath:
             if imgformat == 'jpg':
-                img.save(tmppath, "jpeg", quality=self.options['imgquality'], subsampling=0)
+                img.convert('RGB').save(tmppath, "jpeg", quality=self.options['imgquality'], subsampling=0)
             else: # png
                 img.save(tmppath, "png")
 
@@ -1089,7 +1089,7 @@ class TileSet(object):
         # Save them
         with FileReplacer(imgpath, capabilities=self.fs_caps) as tmppath:
             if self.imgextension == 'jpg':
-                tileimg.save(tmppath, "jpeg", quality=self.options['imgquality'], subsampling=0)
+                tileimg.convert('RGB').save(tmppath, "jpeg", quality=self.options['imgquality'], subsampling=0)
             else: # png
                 tileimg.save(tmppath, "png")
 


### PR DESCRIPTION
Convert RGBA to RGB before saving as JPEG, since Pillow 4.2.0 no longer allows saving RGBA as a JPEG. Fixes #1428