### PR TITLE
Throw an error if the overviewer is running on a world saved on verisons of Minecraft newer than snapshot 17w47a

### DIFF
--- a/overviewer_core/world.py
+++ b/overviewer_core/world.py
@@ -111,6 +111,17 @@ class World(object):
                 logging.critical("Sorry, This version of Minecraft-Overviewer only works with the 'Anvil' chunk format")
                 raise ValueError("World at %s is not compatible with Overviewer" % self.worlddir)
 
+
+        # Check for versions of minecraft after the 17w47a changes
+        if 'Version' in data:
+            version = int(data['Version']["Id"])
+            # version Id of 17w47a 
+            if version >= 1452: 
+                logging.critical("Sorry, This version of Minecraft-Overviewer only works with versions of Minecraft 1.12 and under")
+                logging.critical("This is due to a change in the map chunk format that happened in snapshot 17w47a")
+                raise ValueError("World at %s is not compatible with Overviewer" % self.worlddir)
+
+
         # This isn't much data, around 15 keys and values for vanilla worlds.
         self.leveldat = data
 

--- a/overviewer_core/world.py
+++ b/overviewer_core/world.py
@@ -21,6 +21,7 @@ import time
 import random
 import re
 import locale
+import sys
 
 import numpy
 
@@ -115,11 +116,10 @@ class World(object):
         # Check for versions of minecraft after the 17w47a changes
         if 'Version' in data:
             version = int(data['Version']["Id"])
-            # version Id of 17w47a 
             if version >= 1452: 
                 logging.critical("Sorry, This version of Minecraft-Overviewer only works with versions of Minecraft 1.12 and under")
                 logging.critical("This is due to a change in the map chunk format that happened in snapshot 17w47a")
-                raise ValueError("World at %s is not compatible with Overviewer" % self.worlddir)
+                sys.exit(1)
 
 
         # This isn't much data, around 15 keys and values for vanilla worlds.


### PR DESCRIPTION
When running the Overviewer on newer snapshots and eventually 1.13, the user gets errors about world corruption due to the Overviewer being unable to parse chunks due to the changes in [17w47a](https://minecraft.gamepedia.com/17w47a)

This uses the version id in level.dat to check the version is 17w47a or above and ends the process if so