### PR TITLE
Use <noscript> to display message when JavaScript is disabled

### DIFF
--- a/overviewer_core/data/js_src/util.js
+++ b/overviewer_core/data/js_src/util.js
@@ -36,8 +36,6 @@ overviewer.util = {
         overviewer.util.initializePolyfills();
         overviewer.util.initializeMarkers();
 
-        document.getElementById('NoJSWarning').remove();
-
         overviewer.coordBoxClass = L.Control.extend({
             options: {
                 position: 'bottomleft',

--- a/overviewer_core/data/web_assets/index.html
+++ b/overviewer_core/data/web_assets/index.html
@@ -22,11 +22,10 @@
 
 <!-- Generated at: {time} -->
 <body onload="overviewer.util.initialize()">
- <div id="mcmap">
-     <div id="NoJSWarning" style="color:white; background-color:black">
-         If you can see this message, there is likely a problem loading the Overviewer javascript components.
-         Check the javascript console for error messages.
-     </div>
- </div>
+    <noscript style="color:white; background-color:black">
+        If you can see this message, there is likely a problem loading the Overviewer JavaScript components.
+        Check the JavaScript console for error messages.
+    </noscript>
+    <div id="mcmap"></div>
 </body>
 </html>


### PR DESCRIPTION
This change switches `div#NoJSWarning` with the [`<noscript>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/noscript) element. Its purpose is to display a message if scripting is disabled in the browser.