### PR TITLE
Missing underscore.js/backbone.js in index.html

### DIFF
--- a/overviewer_core/data/web_assets/index.html
+++ b/overviewer_core/data/web_assets/index.html
@@ -8,6 +8,8 @@
 <meta name="generator" content="Minecraft-Overviewer {version}" />
 <meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
 
+<script type="text/javascript" src="underscore.js"></script>
+<script type="text/javascript" src="backbone.js"></script>
 <script type="text/javascript" src="overviewerConfig.js"></script>
 <script type="text/javascript" src="overviewer.js"></script>
 <script type="text/javascript" src="baseMarkers.js"></script>


### PR DESCRIPTION
Overviewer depends on Backbone framework, but missing to load underscore.js/backbone.js in index.html.