### PR TITLE
NBT: Use a replacement strategy to deal with undecodable data.

### DIFF
--- a/overviewer_core/nbt.py
+++ b/overviewer_core/nbt.py
@@ -144,7 +144,7 @@ class NBTFileReader(object):
         # Read the string
         string = self._file.read(length)
         # decode it and return
-        return string.decode("UTF-8")
+        return string.decode("UTF-8", 'replace')
 
     def _read_tag_list(self):
         tagid = self._read_tag_byte()


### PR DESCRIPTION
The NBT spec requires that all strings are UTF-8 encoded.  However in
practice, non-UTF-8 data can get into a level.dat file (generally via
some weird user-supplied characters in signs.  This results in the
following error:

    CorruptNBTError: could not parse nbt: 'utf8' codec can't decode byte
    0xc0 in position 3: invalid start byte

This happens often enough that we should just ignore this error by using
the 'replace' strategy to replace the invalid data

CC @cheeseinthedark who most recently reported this error