### PR TITLE
Make JSObserver work with Leaflet. Fixes #1451.

### DIFF
--- a/overviewer_core/data/js_src/overviewer.js
+++ b/overviewer_core/data/js_src/overviewer.js
@@ -15,6 +15,7 @@ overviewer.worldCtrl = null;
 overviewer.layerCtrl = null;
 overviewer.compass = null;
 overviewer.coord_box = null;
+overviewer.progress = null;
 overviewer.current_world = null;
 
 /// Records the current layer by name (if any) of each world

--- a/overviewer_core/data/web_assets/overviewer.css
+++ b/overviewer_core/data/web_assets/overviewer.css
@@ -165,7 +165,7 @@ div.worldcontrol select {
     font-size: 1.2em;
 }
 
-.leaflet-container .coordbox {
+.leaflet-container .coordbox, .leaflet-container .progress {
     box-shadow: none;
     font-size: 11px;
     background: rgba(255, 255, 255, 0.7);

--- a/overviewer_core/observer.py
+++ b/overviewer_core/observer.py
@@ -294,7 +294,7 @@ class JSObserver(Observer):
         """
         self._current_value = current_value
         if self._need_update():
-            refresh = max(1500*(time.time() - self.last_update_time), self.minrefresh) // 1
+            refresh = max(1500*(time.time() - max(self.start_time, self.last_update_time)), self.minrefresh) // 1
             self.logfile.seek(0)
             self.logfile.truncate()
             if self.get_current_value():


### PR DESCRIPTION
This retrieves `progress.json` using the new-ish [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API), which [does not work in Internet Explorer](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API#Browser_compatibility). The code detects this, and does not start the update cycle when `window.fetch` is not available.

This PR also fixes a bug where the first status update has an absurd update time—`time.time() + 1`—due to `JSObserver.last_update_time` being set to `-1` initially.