### PR TITLE
Fix marker icon position properly. Closes #1481.

### DIFF
--- a/overviewer_core/data/js_src/util.js
+++ b/overviewer_core/data/js_src/util.js
@@ -334,8 +334,7 @@ overviewer.util = {
                     for (var mkidx = 0; mkidx < markers[obj.path].length; mkidx++) {
                         var marker_group = new L.layerGroup();
                         var marker_entry = markers[obj.path][mkidx];
-                        var icon =  L.icon({iconUrl: marker_entry.icon,
-                                            className: "ov-marker"});
+                        var icon =  L.divIcon({html: `<img class="ov-marker" src="${marker_entry.icon}">`});
                         console.log("marker group:", marker_entry.displayName, marker_entry.groupName);
 
                         for (var dbidx = 0; dbidx < markersDB[marker_entry.groupName].raw.length; dbidx++) {
@@ -343,8 +342,7 @@ overviewer.util = {
                             var latlng = overviewer.util.fromWorldToLatLng(db.x, db.y, db.z, obj);
                             var m_icon;
                             if (db.icon != undefined) {
-                                m_icon = L.icon({iconUrl: db.icon,
-                                                 className: "ov-marker"});
+                                m_icon = L.divIcon({html: `<img class="ov-marker" src="${db.icon}">`});
                             } else {
                                 m_icon = icon;
                             }


### PR DESCRIPTION
CSS margin is always relative to the containing element. For some
reason, using the browser inspector, this does not get propagated
properly. Adding a containing element with the size of the child element
allows us to use margin to offset the icon.