### PR TITLE
Fix C extension build warnings the painful way

### DIFF
--- a/overviewer_core/src/Draw.c
+++ b/overviewer_core/src/Draw.c
@@ -55,6 +55,7 @@
 /* FIXME: support clip window (and mask?) */
 
 #include "Imaging.h"
+#include "utils.h"
 
 #include <math.h>
 
@@ -63,13 +64,6 @@
 
 #define INK8(ink) (*(UINT8*)ink)
 #define INK32(ink) (*(INT32*)ink)
-
-/* like (a * b + 127) / 255), but much faster on most platforms */
-#define MULDIV255(a, b, tmp)\
-        (tmp = (a) * (b) + 128, ((((tmp) >> 8) + (tmp)) >> 8))
-
-#define BLEND(mask, in1, in2, tmp1, tmp2)\
-        (MULDIV255(in1, 255 - mask, tmp1) + MULDIV255(in2, mask, tmp2))
 
 /* -------------------------------------------------------------------- */
 /* Primitives                                                           */
@@ -105,9 +99,9 @@ point32rgba(Imaging im, int x, int y, int ink)
     if (x >= 0 && x < im->xsize && y >= 0 && y < im->ysize) {
         UINT8* out = (UINT8*) im->image[y]+x*4;
         UINT8* in = (UINT8*) &ink;
-        out[0] = BLEND(in[3], out[0], in[0], tmp1, tmp2);
-        out[1] = BLEND(in[3], out[1], in[1], tmp1, tmp2);
-        out[2] = BLEND(in[3], out[2], in[2], tmp1, tmp2);
+        out[0] = OV_BLEND(in[3], out[0], in[0], tmp1, tmp2);
+        out[1] = OV_BLEND(in[3], out[1], in[1], tmp1, tmp2);
+        out[2] = OV_BLEND(in[3], out[2], in[2], tmp1, tmp2);
     }
 }
 
@@ -176,9 +170,9 @@ hline32rgba(Imaging im, int x0, int y0, int x1, int ink)
             UINT8* out = (UINT8*) im->image[y0]+x0*4;
             UINT8* in = (UINT8*) &ink;
             while (x0 <= x1) {
-                out[0] = BLEND(in[3], out[0], in[0], tmp1, tmp2);
-                out[1] = BLEND(in[3], out[1], in[1], tmp1, tmp2);
-                out[2] = BLEND(in[3], out[2], in[2], tmp1, tmp2);
+                out[0] = OV_BLEND(in[3], out[0], in[0], tmp1, tmp2);
+                out[1] = OV_BLEND(in[3], out[1], in[1], tmp1, tmp2);
+                out[2] = OV_BLEND(in[3], out[2], in[2], tmp1, tmp2);
                 x0++; out += 4;
             }
         }

--- a/overviewer_core/src/composite.c
+++ b/overviewer_core/src/composite.c
@@ -183,7 +183,7 @@ alpha_over_full(PyObject *dest, PyObject *src, PyObject *mask, float overall_alp
             
             /* apply overall_alpha */
             if (overall_alpha_int != 255 && *inmask != 0) {
-                in_alpha = MULDIV255(*inmask, overall_alpha_int, tmp1);
+                in_alpha = OV_MULDIV255(*inmask, overall_alpha_int, tmp1);
             } else {
                 in_alpha = *inmask;
             }
@@ -204,11 +204,11 @@ alpha_over_full(PyObject *dest, PyObject *src, PyObject *mask, float overall_alp
                 in += 3;
             } else {
                 /* general case */
-                int alpha = in_alpha + MULDIV255(*outmask, 255 - in_alpha, tmp1);
+                int alpha = in_alpha + OV_MULDIV255(*outmask, 255 - in_alpha, tmp1);
                 for (i = 0; i < 3; i++) {
                     /* general case */
-                    *out = MULDIV255(*in, in_alpha, tmp1) +
-                        MULDIV255(MULDIV255(*out, *outmask, tmp2), 255 - in_alpha, tmp3);
+                    *out = OV_MULDIV255(*in, in_alpha, tmp1) +
+                        OV_MULDIV255(OV_MULDIV255(*out, *outmask, tmp2), 255 - in_alpha, tmp3);
                     
                     *out = (*out * 255) / alpha;
                     out++, in++;
@@ -332,13 +332,13 @@ tint_with_mask(PyObject *dest, unsigned char sr, unsigned char sg,
         for (x = 0; x < xsize; x++) {
             /* special cases */
             if (*inmask == 255) {
-                *out = MULDIV255(*out, sr, tmp1);
+                *out = OV_MULDIV255(*out, sr, tmp1);
                 out++;
-                *out = MULDIV255(*out, sg, tmp1);
+                *out = OV_MULDIV255(*out, sg, tmp1);
                 out++;
-                *out = MULDIV255(*out, sb, tmp1);
+                *out = OV_MULDIV255(*out, sb, tmp1);
                 out++;
-                *out = MULDIV255(*out, sa, tmp1);
+                *out = OV_MULDIV255(*out, sa, tmp1);
                 out++;
             } else if (*inmask == 0) {
                 /* do nothing -- source is fully transparent */
@@ -347,13 +347,13 @@ tint_with_mask(PyObject *dest, unsigned char sr, unsigned char sg,
                 /* general case */
                 
                 /* TODO work out general case */
-                *out = MULDIV255(*out, (255 - *inmask) + MULDIV255(sr, *inmask, tmp1), tmp2);
+                *out = OV_MULDIV255(*out, (255 - *inmask) + OV_MULDIV255(sr, *inmask, tmp1), tmp2);
                 out++;
-                *out = MULDIV255(*out, (255 - *inmask) + MULDIV255(sg, *inmask, tmp1), tmp2);
+                *out = OV_MULDIV255(*out, (255 - *inmask) + OV_MULDIV255(sg, *inmask, tmp1), tmp2);
                 out++;
-                *out = MULDIV255(*out, (255 - *inmask) + MULDIV255(sb, *inmask, tmp1), tmp2);
+                *out = OV_MULDIV255(*out, (255 - *inmask) + OV_MULDIV255(sb, *inmask, tmp1), tmp2);
                 out++;
-                *out = MULDIV255(*out, (255 - *inmask) + MULDIV255(sa, *inmask, tmp1), tmp2);
+                *out = OV_MULDIV255(*out, (255 - *inmask) + OV_MULDIV255(sa, *inmask, tmp1), tmp2);
                 out++;
             }
 
@@ -410,15 +410,15 @@ draw_triangle(PyObject *dest, int inclusive,
     }
     
     /* set up draw ranges */
-    xmin = MIN(x0, MIN(x1, x2));
-    ymin = MIN(y0, MIN(y1, y2));
-    xmax = MAX(x0, MAX(x1, x2)) + 1;
-    ymax = MAX(y0, MAX(y1, y2)) + 1;
+    xmin = OV_MIN(x0, OV_MIN(x1, x2));
+    ymin = OV_MIN(y0, OV_MIN(y1, y2));
+    xmax = OV_MAX(x0, OV_MAX(x1, x2)) + 1;
+    ymax = OV_MAX(y0, OV_MAX(y1, y2)) + 1;
     
-    xmin = MAX(xmin, 0);
-    ymin = MAX(ymin, 0);
-    xmax = MIN(xmax, imDest->xsize);
-    ymax = MIN(ymax, imDest->ysize);
+    xmin = OV_MAX(xmin, 0);
+    ymin = OV_MAX(ymin, 0);
+    xmax = OV_MIN(xmax, imDest->xsize);
+    ymax = OV_MIN(ymax, imDest->ysize);
     
     /* setup coefficients */
     a12 = y1 - y2; b12 = x2 - x1; c12 = (x1 * y2) - (x2 * y1);
@@ -446,9 +446,9 @@ draw_triangle(PyObject *dest, int inclusive,
                 unsigned int g = alpha * g0 + beta * g1 + gamma * g2;
                 unsigned int b = alpha * b0 + beta * b1 + gamma * b2;
                 
-                *out = MULDIV255(*out, r, tmp); out++;
-                *out = MULDIV255(*out, g, tmp); out++;
-                *out = MULDIV255(*out, b, tmp); out++;
+                *out = OV_MULDIV255(*out, r, tmp); out++;
+                *out = OV_MULDIV255(*out, g, tmp); out++;
+                *out = OV_MULDIV255(*out, b, tmp); out++;
                 
                 /* keep alpha the same */
                 out++;
@@ -482,9 +482,9 @@ draw_triangle(PyObject *dest, int inclusive,
         g = alpha * g0 + beta * g1 + gamma * g2;
         b = alpha * b0 + beta * b1 + gamma * b2;
                 
-        *out = MULDIV255(*out, r, tmp); out++;
-        *out = MULDIV255(*out, g, tmp); out++;
-        *out = MULDIV255(*out, b, tmp); out++;
+        *out = OV_MULDIV255(*out, r, tmp); out++;
+        *out = OV_MULDIV255(*out, g, tmp); out++;
+        *out = OV_MULDIV255(*out, b, tmp); out++;
     }
     
     return dest;

--- a/overviewer_core/src/overviewer.h
+++ b/overviewer_core/src/overviewer.h
@@ -33,7 +33,7 @@
 
 // increment this value if you've made a change to the c extesion
 // and want to force users to rebuild
-#define OVERVIEWER_EXTENSION_VERSION 54
+#define OVERVIEWER_EXTENSION_VERSION 56
 
 /* Python PIL, and numpy headers */
 #include <Python.h>
@@ -41,11 +41,9 @@
 #include <Imaging.h>
 /* Fix Pillow on mingw-w64 which includes windows.h in Imaging.h */
 #undef TRANSPARENT
+/* Utility macros */
+#include "utils.h"
 
-/* like (a * b + 127) / 255), but much faster on most platforms
-   from PIL's _imaging.c */
-#define MULDIV255(a, b, tmp)								\
-	(tmp = (a) * (b) + 128, ((((tmp) >> 8) + (tmp)) >> 8))
 
 /* macro for getting a value out of various numpy arrays the 3D arrays have
    interesting, swizzled coordinates because minecraft (anvil) stores blocks
@@ -54,11 +52,6 @@
 #define getArrayShort3D(array, x,y,z) (*(unsigned short *)(PyArray_GETPTR3((array), (y), (z), (x))))
 #define getArrayByte2D(array, x,y) (*(unsigned char *)(PyArray_GETPTR2((array), (y), (x))))
 
-
-/* generally useful MAX / MIN macros */
-#define MAX(a, b) ((a) > (b) ? (a) : (b))
-#define MIN(a, b) ((a) < (b) ? (a) : (b))
-#define CLAMP(x, a, b) (MIN(MAX(x, a), b))
 
 /* in composite.c */
 Imaging imaging_python_to_c(PyObject *obj);

--- a/overviewer_core/src/primitives/base.c
+++ b/overviewer_core/src/primitives/base.c
@@ -220,8 +220,8 @@ base_draw(void *data, RenderState *state, PyObject *src, PyObject *mask, PyObjec
             rain *= temp;
             
             /* make sure they're sane */
-            temp = CLAMP(temp, 0.0, 1.0);
-            rain = CLAMP(rain, 0.0, 1.0);
+            temp = OV_CLAMP(temp, 0.0, 1.0);
+            rain = OV_CLAMP(rain, 0.0, 1.0);
             
             /* convert to x/y coordinates in color table */
             tablex = 255 - (255 * temp);
@@ -240,9 +240,9 @@ base_draw(void *data, RenderState *state, PyObject *src, PyObject *mask, PyObjec
             Py_DECREF(color);
             
             /* do the after-coloration */
-            r = MULDIV255(r, multr, tmp);
-            g = MULDIV255(g, multg, tmp);
-            b = MULDIV255(b, multb, tmp);
+            r = OV_MULDIV255(r, multr, tmp);
+            g = OV_MULDIV255(g, multg, tmp);
+            b = OV_MULDIV255(b, multb, tmp);
         }
         
         /* final coloration */

--- a/overviewer_core/src/primitives/lighting.c
+++ b/overviewer_core/src/primitives/lighting.c
@@ -25,7 +25,7 @@ static void
 calculate_light_color(void *data,
                       unsigned char skylight, unsigned char blocklight,
                       unsigned char *r, unsigned char *g, unsigned char *b) {
-    unsigned char v = 255 * powf(0.8f, 15.0 - MAX(blocklight, skylight));
+    unsigned char v = 255 * powf(0.8f, 15.0 - OV_MAX(blocklight, skylight));
     *r = v;
     *g = v;
     *b = v;
@@ -40,7 +40,7 @@ calculate_light_color_fancy(void *data,
     unsigned int index;
     PyObject *color;
     
-    blocklight = MAX(blocklight, skylight);
+    blocklight = OV_MAX(blocklight, skylight);
     
     index = skylight + blocklight * 16;
     color = PySequence_GetItem(mode->lightcolor, index);
@@ -60,7 +60,7 @@ static void
 calculate_light_color_night(void *data,
                             unsigned char skylight, unsigned char blocklight,
                             unsigned char *r, unsigned char *g, unsigned char *b) {
-    unsigned char v = 255 * powf(0.8f, 15.0 - MAX(blocklight, skylight - 11));
+    unsigned char v = 255 * powf(0.8f, 15.0 - OV_MAX(blocklight, skylight - 11));
     *r = v;
     *g = v;
     *b = v;
@@ -194,7 +194,7 @@ get_lighting_color(RenderPrimitiveLighting *self, RenderState *state,
         return;
     }
     
-    self->calculate_light_color(self, MIN(skylevel, 15), MIN(blocklevel, 15), r, g, b);
+    self->calculate_light_color(self, OV_MIN(skylevel, 15), OV_MIN(blocklevel, 15), r, g, b);
 }
 
 /* does per-face occlusion checking for do_shading_with_mask */

--- a/overviewer_core/src/primitives/overlay-mineral.c
+++ b/overviewer_core/src/primitives/overlay-mineral.c
@@ -68,7 +68,7 @@ static void get_color(void *data, RenderState *state,
                 *b = minerals[i].b;
                 
                 tmp = (128 - y_max + y) * 2 - 40;
-                *a = MIN(MAX(0, tmp), 255);
+                *a = OV_MIN(OV_MAX(0, tmp), 255);
                 
                 max_i = i;
                 break;

--- a/overviewer_core/src/primitives/overlay-spawn.c
+++ b/overviewer_core/src/primitives/overlay-spawn.c
@@ -46,10 +46,10 @@ static void get_color(void *data, RenderState *state,
     blocklight = get_data(state, BLOCKLIGHT, x, y_light, z);
     skylight = get_data(state, SKYLIGHT, x, y_light, z);
     
-    if (MAX(blocklight, skylight) <= 7) {
+    if (OV_MAX(blocklight, skylight) <= 7) {
         /* hostile mobs spawn in daylight */
         *a = 240;
-    } else if (MAX(blocklight, skylight - 11) <= 7) {
+    } else if (OV_MAX(blocklight, skylight - 11) <= 7) {
         /* hostile mobs spawn at night */
         *a = 150;
     }

--- a/overviewer_core/src/utils.h
+++ b/overviewer_core/src/utils.h
@@ -1,0 +1,17 @@
+#ifndef __OV_UTILS_H_INCLUDED__
+#define __OV_UTILS_H_INCLUDED__
+
+/* generally useful MAX / MIN macros */
+#define OV_MAX(a, b) ((a) > (b) ? (a) : (b))
+#define OV_MIN(a, b) ((a) < (b) ? (a) : (b))
+#define OV_CLAMP(x, a, b) (OV_MIN(OV_MAX(x, a), b))
+
+/* like (a * b + 127) / 255), but much faster on most platforms
+   from PIL's _imaging.c */
+#define OV_MULDIV255(a, b, tmp)\
+    (tmp = (a) * (b) + 128, ((((tmp) >> 8) + (tmp)) >> 8))
+
+#define OV_BLEND(mask, in1, in2, tmp1, tmp2)\
+        (OV_MULDIV255(in1, 255 - mask, tmp1) + OV_MULDIV255(in2, mask, tmp2))
+
+#endif


### PR DESCRIPTION
Some bad distributions (Debian) apparently are not good enough to have a Pillow version from this decade packaged.

Therefore, we need to do it the painful way of prefixing our symbols and refactoring everything to use them.

A new header file called "utils.h" has been added for this purpose, and it is included in "overviewer.h".

The following macros have been prefixed with "OV_":
- MIN
- MAX
- CLAMP
- BLEND
- MULDIV255

Additionally, the C extension version was bumped to 56 because 55 was reverted back to 54.