### PR TITLE
Leaflet polyline support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/usr/bin/python"
+}

--- a/docs/examples/filter_polyline_from_signs.py
+++ b/docs/examples/filter_polyline_from_signs.py
@@ -44,7 +44,7 @@ def bordersFromSigns(poi):
                     'polyline': {}
                 }
 
-            borders['polyline'][order] = {'x': poi['x'], 'y': poi['y'], 'z': poi['z']}
+            borders[name]['polyline'][order] = {'x': poi['x'], 'y': poi['y'], 'z': poi['z']}
             borders[name]['size'] = size
 
             # If color occurs once on any sign it's enough
@@ -52,9 +52,9 @@ def bordersFromSigns(poi):
                 borders[name]['color'] = color
 
             # If last
-            if borders['count'] == borders['size']:
+            if borders[name]['count'] == borders[name]['size']:
                 # Convert dict to ordered list
-                tuples = sorted(borders['polyline'].items())
+                tuples = sorted(borders[name]['polyline'].items())
                 # Make sure the signs close by adding the first sign xyz again at the end
                 tuples.append(tuples[0])
                 return {

--- a/docs/examples/filter_polyline_from_signs.py
+++ b/docs/examples/filter_polyline_from_signs.py
@@ -1,0 +1,64 @@
+borders = {}
+
+def bordersFromSigns(poi):
+    """
+        BORDER
+         2/9
+    Hanoko Village
+        purple
+    """
+    global borders
+    if poi['id'] == 'Sign' or poi['id'] == 'minecraft:sign':
+        if poi['Text1'].lower() == 'border':
+            # Get the order of this point and the total number of points from the 2nd line
+            loc = poi['Text2']  # e.g. 2/9
+            delimiter = loc.index('/')
+            order = loc[:delimiter]
+            size = loc[delimiter:delimiter]
+            try:
+                order = int(order)
+                size = int(size)
+            except ValueError:
+                return  # Skip this marker
+
+            # Name on the 3rd line
+            name = poi['Text3']
+            poi['name'] = name
+
+            # Color on the 4th line
+            color = poi['Text4'].lower()
+
+            first = True
+            for border in borders:
+                if border.name == name:
+                    first = False
+                    borders[name]['count'] += 1
+
+            if first:
+                # Create base dict for that border
+                borders[name] = {
+                    'color': 'red',
+                    'text': name,
+                    'size': -1,
+                    'count': 1,
+                    'polyline': {}
+                }
+
+            borders['polyline'][order] = {'x': poi['x'], 'y': poi['y'], 'z': poi['z']}
+            borders[name]['size'] = size
+
+            # If color occurs once on any sign it's enough
+            if color != '':
+                borders[name]['color'] = color
+
+            # If last
+            if borders['count'] == borders['size']:
+                # Convert dict to ordered list
+                tuples = sorted(borders['polyline'].items())
+                # Make sure the signs close by adding the first sign xyz again at the end
+                tuples.append(tuples[0])
+                return {
+                    'color': borders[name]['color'],
+                    'text': borders[name]['text'],
+                    'polyline': [t[1] for t in tuples]  # Only return the xyz values
+                }

--- a/docs/examples/filter_polyline_from_signs.py
+++ b/docs/examples/filter_polyline_from_signs.py
@@ -14,7 +14,7 @@ def bordersFromSigns(poi):
             loc = poi['Text2']  # e.g. 2/9
             delimiter = loc.index('/')
             order = loc[:delimiter]
-            size = loc[delimiter:]
+            size = loc[delimiter + 1:]
             try:
                 order = int(order)
                 size = int(size)
@@ -29,8 +29,8 @@ def bordersFromSigns(poi):
             color = poi['Text4'].lower()
 
             first = True
-            for border in borders:
-                if border.name == name:
+            for key in borders:
+                if key == name:
                     first = False
                     borders[name]['count'] += 1
 

--- a/docs/examples/filter_polyline_from_signs.py
+++ b/docs/examples/filter_polyline_from_signs.py
@@ -14,7 +14,7 @@ def bordersFromSigns(poi):
             loc = poi['Text2']  # e.g. 2/9
             delimiter = loc.index('/')
             order = loc[:delimiter]
-            size = loc[delimiter:delimiter]
+            size = loc[delimiter:]
             try:
                 order = int(order)
                 size = int(size)
@@ -57,8 +57,4 @@ def bordersFromSigns(poi):
                 tuples = sorted(borders[name]['polyline'].items())
                 # Make sure the signs close by adding the first sign xyz again at the end
                 tuples.append(tuples[0])
-                return {
-                    'color': borders[name]['color'],
-                    'text': borders[name]['text'],
-                    'polyline': [t[1] for t in tuples]  # Only return the xyz values
-                }
+                return dict(color=borders[name]['color'], text=borders[name]['text'], polyline=[t[1] for t in tuples])

--- a/docs/examples/filter_polyline_from_signs.py
+++ b/docs/examples/filter_polyline_from_signs.py
@@ -57,4 +57,4 @@ def bordersFromSigns(poi):
                 tuples = sorted(borders[name]['polyline'].items())
                 # Make sure the signs close by adding the first sign xyz again at the end
                 tuples.append(tuples[0])
-                return dict(color=borders[name]['color'], text=borders[name]['text'], polyline=[t[1] for t in tuples])
+                return dict(color=borders[name]['color'], fill=True, text=borders[name]['text'], polyline=[t[1] for t in tuples])

--- a/overviewer_core/aux_files/genPOI.py
+++ b/overviewer_core/aux_files/genPOI.py
@@ -408,11 +408,11 @@ def create_marker_from_filter_result(poi, result):
     elif isinstance(result, dict):
         d['text'] = result['text']
 
-        # Use custom hovertext if provided...
-        if 'hovertext' in result:
+        try:
             d['hovertext'] = unicode(result['hovertext'])
-        else:   # ...otherwise default to display text.
+        except KeyError:
             d['hovertext'] = result['text']
+            pass
 
         if 'polyline' in result and hasattr(result['polyline'], '__iter__'):
             d['polyline'] = []
@@ -421,6 +421,18 @@ def create_marker_from_filter_result(poi, result):
                 d['polyline'].append(dict(x=point['x'], y=point['y'], z=point['z']))
             if isinstance(result['color'], basestring):
                 d['strokeColor'] = result['color']
+
+            try:
+                d['fill'] = result['fill']
+            except KeyError:
+                d['fill'] = False
+                pass
+
+            try:
+                d['strokeWeight'] = result['weight']
+            except KeyError:
+                d['strokeWeight'] = 2
+                pass
 
             if "icon" in result:
                 d["icon"] = result['icon']

--- a/overviewer_core/aux_files/genPOI.py
+++ b/overviewer_core/aux_files/genPOI.py
@@ -153,6 +153,14 @@ def signWrangler(poi):
     return poi
 
 
+def filterPOI(poi, filters, markers):
+    for name, __, filter_function, __, __, __ in filters:
+        result = filter_function(poi)
+        if result:
+            d = create_marker_from_filter_result(poi, result)
+            markers[name]['raw'].append(d)
+
+
 def handleEntities(rset, config, config_path, filters, markers):
     """
     Add markers for Entities or TileEntities.
@@ -175,11 +183,7 @@ def handleEntities(rset, config, config_path, filters, markers):
                 for poi in itertools.chain(data.get('TileEntities', []), data.get('Entities', [])):
                     if poi['id'] == 'Sign' or poi['id'] == 'minecraft:sign':    # kill me
                         poi = signWrangler(poi)
-                    for name, __, filter_function, __, __, __ in filters:
-                        result = filter_function(poi)
-                        if result:
-                            d = create_marker_from_filter_result(poi, result)
-                            markers[name]['raw'].append(d)
+                    filterPOI(poi, filters, markers)
             except nbt.CorruptChunkError:
                 logging.warning("Ignoring POIs in corrupt chunk %d,%d.", x, z)
             except world.ChunkDoesntExist:
@@ -374,11 +378,7 @@ def handleManual(manualpois, filters, markers):
     `markers`.
     """
     for poi in manualpois:
-        for name, __, filter_function, __, __, __ in filters:
-            result = filter_function(poi)
-            if result:
-                d = create_marker_from_filter_result(poi, result)
-                markers[name]['raw'].append(d)
+        filterPOI(poi, filters, markers)
 
 
 def create_marker_from_filter_result(poi, result):

--- a/overviewer_core/data/js_src/util.js
+++ b/overviewer_core/data/js_src/util.js
@@ -392,10 +392,10 @@ overviewer.util = {
                                 let m_icon = L.divIcon({html: `<img class="ov-marker" src="${db.icon == undefined ? marker_entry.icon : db.icon}">`});
                                 // Create marker
                                 layerObj = new L.marker(latlng, {icon: m_icon, title: db.hovertext});
-                                // Add popup to marker
-                                if (marker_entry.createInfoWindow) {
-                                    layerObj.bindPopup(db.text);
-                                }
+                            }
+                            // Add popup to marker
+                            if (marker_entry.createInfoWindow) {
+                                layerObj.bindPopup(db.text);
                             }
                             // Add the polyline or marker to the layer
                             marker_group.addLayer(layerObj);

--- a/overviewer_core/data/js_src/util.js
+++ b/overviewer_core/data/js_src/util.js
@@ -380,9 +380,9 @@ overviewer.util = {
                             var layerObj = undefined;
                             
                             // Polyline or marker?
-                            if ('polygon' in db) {
+                            if ('polyline' in db) {
                                 // Convert all coords
-                                plLatLng = db['polygon'].map(function(plobj) {return overviewer.util.fromWorldToLatLng(plobj.x, plobj.y, plobj.z, obj);})
+                                plLatLng = db['polyline'].map(function(plobj) {return overviewer.util.fromWorldToLatLng(plobj.x, plobj.y, plobj.z, obj);})
                                 layerObj = L.polyline(plLatLng, {color: db['strokeColor'], fillOpacity: .1});
                                 // TODO: add other config options (fill color, fill opacity, stroke width)
                             } else {

--- a/overviewer_core/data/js_src/util.js
+++ b/overviewer_core/data/js_src/util.js
@@ -383,8 +383,12 @@ overviewer.util = {
                             if ('polyline' in db) {
                                 // Convert all coords
                                 plLatLng = db['polyline'].map(function(plobj) {return overviewer.util.fromWorldToLatLng(plobj.x, plobj.y, plobj.z, obj);})
-                                layerObj = L.polyline(plLatLng, {color: db['strokeColor'], fillOpacity: .1});
-                                // TODO: add other config options (fill color, fill opacity, stroke width)
+                                layerObj = L.polyline(plLatLng, {
+                                    color: db['strokeColor'], 
+                                    weight: db['strokeWeight'], 
+                                    fill: db['fill']
+                                });
+                                // TODO: add other config options (fill color, fill opacity)
                             } else {
                                 // Convert coords
                                 let latlng = overviewer.util.fromWorldToLatLng(db.x, db.y, db.z, obj);

--- a/overviewer_core/data/web_assets/regions.js
+++ b/overviewer_core/data/web_assets/regions.js
@@ -2,16 +2,15 @@
 /*
 var groupName = "Regions";
 var displayName = "Areas";
-var world = "top";
+var world = "World";
 
 markersDB[groupName] = {
 	"raw": [
 		{
-		"fillColor": "#00FF00",
-		"fillOpacity": 0.2,
 		"strokeColor": "#FF0000",
-		"strokeOpacity": 1,
-		"polygon" : [
+		"strokeWeight": 2,
+		"fill": true,
+		"polyline" : [
 			{"x": 347, "y": 67, "z": 95},
 			{"x": 347, "y": 77, "z": 95},
 			{"x": 347, "y": 77, "z": 105},
@@ -19,7 +18,7 @@ markersDB[groupName] = {
 			{"x": 347, "y": 67, "z": 105}
 		]}
 	],
-	"name": "Regions",
+	"name": groupName,
 	"created": false
 }
 

--- a/overviewer_core/textures.py
+++ b/overviewer_core/textures.py
@@ -37,6 +37,8 @@ class TextureException(Exception):
 color_map = ["white", "orange", "magenta", "light_blue", "yellow", "lime", "pink", "gray",
              "light_gray", "cyan", "purple", "blue", "brown", "green", "red", "black"]
 
+blocks_path = '/assets/minecraft/textures/block/'
+
 ##
 ## Textures object
 ##
@@ -92,7 +94,7 @@ class Textures(object):
     def generate(self):
         
         # generate biome grass mask
-        self.biome_grass_texture = self.build_block(self.load_image_texture("assets/minecraft/textures/block/grass_block_top.png"), self.load_image_texture("assets/minecraft/textures/block/grass_block_side_overlay.png"))
+        self.biome_grass_texture = self.build_block(self.load_image_texture(blocks_path + "grass_block_top.png"), self.load_image_texture(blocks_path + "grass_block_side_overlay.png"))
         
         # generate the blocks
         global blockmap_generators
@@ -352,7 +354,7 @@ class Textures(object):
             watertexture = self.load_image("custom_water_still.png")
             watertexture = watertexture.crop((0, 0, watertexture.size[0], watertexture.size[0]))
         except TextureException:
-            watertexture = self.load_image_texture("assets/minecraft/textures/block/water_still.png")
+            watertexture = self.load_image_texture(blocks_path + "water_still.png")
         self.watertexture = watertexture
         return watertexture
 
@@ -367,7 +369,7 @@ class Textures(object):
             lavatexture = self.load_image("custom_lava_still.png")
             lavatexture = lavatexture.crop((0, 0, lavatexture.size[0], lavatexture.size[0]))
         except TextureException:
-            lavatexture = self.load_image_texture("assets/minecraft/textures/block/lava_still.png")
+            lavatexture = self.load_image_texture(blocks_path + "lava_still.png")
         self.lavatexture = lavatexture
         return lavatexture
     
@@ -385,8 +387,8 @@ class Textures(object):
             firetextureEW = firetextureEW.crop((0, 0, firetextureEW.size[0], firetextureEW.size[0]))
             firetexture = (firetextureNS,firetextureEW)
         except TextureException:
-            fireNS = self.load_image_texture("assets/minecraft/textures/block/fire_0.png")
-            fireEW = self.load_image_texture("assets/minecraft/textures/block/fire_1.png")
+            fireNS = self.load_image_texture(blocks_path + "fire_0.png")
+            fireEW = self.load_image_texture(blocks_path + "fire_1.png")
             firetexture = (fireNS, fireEW)
         self.firetexture = firetexture
         return firetexture
@@ -402,7 +404,7 @@ class Textures(object):
             portaltexture = self.load_image("custom_portal.png")
             portaltexture = portaltexture.crop((0, 0, portaltexture.size[0], portaltexture.size[1]))
         except TextureException:
-            portaltexture = self.load_image_texture("assets/minecraft/textures/block/nether_portal.png")
+            portaltexture = self.load_image_texture(blocks_path + "nether_portal.png")
         self.portaltexture = portaltexture
         return portaltexture
     
@@ -927,28 +929,28 @@ def billboard(blockid=[], imagename=None, **kwargs):
 @material(blockid=1, data=range(7), solid=True)
 def stone(self, blockid, data):
     if data == 0: # regular old-school stone
-        img = self.load_image_texture("assets/minecraft/textures/block/stone.png")
+        img = self.load_image_texture(blocks_path + "stone.png")
     elif data == 1: # granite
-        img = self.load_image_texture("assets/minecraft/textures/block/granite.png")
+        img = self.load_image_texture(blocks_path + "granite.png")
     elif data == 2: # polished granite
-        img = self.load_image_texture("assets/minecraft/textures/block/polished_granite.png")
+        img = self.load_image_texture(blocks_path + "polished_granite.png")
     elif data == 3: # diorite
-        img = self.load_image_texture("assets/minecraft/textures/block/diorite.png")
+        img = self.load_image_texture(blocks_path + "diorite.png")
     elif data == 4: # polished diorite
-        img = self.load_image_texture("assets/minecraft/textures/block/polished_diorite.png")
+        img = self.load_image_texture(blocks_path + "polished_diorite.png")
     elif data == 5: # andesite
-        img = self.load_image_texture("assets/minecraft/textures/block/andesite.png")
+        img = self.load_image_texture(blocks_path + "andesite.png")
     elif data == 6: # polished andesite
-        img = self.load_image_texture("assets/minecraft/textures/block/polished_andesite.png")
+        img = self.load_image_texture(blocks_path + "polished_andesite.png")
     return self.build_block(img, img)
 
 @material(blockid=2, data=range(11)+[0x10,], solid=True)
 def grass(self, blockid, data):
     # 0x10 bit means SNOW
-    side_img = self.load_image_texture("assets/minecraft/textures/block/grass_block_side.png")
+    side_img = self.load_image_texture(blocks_path + "grass_block_side.png")
     if data & 0x10:
-        side_img = self.load_image_texture("assets/minecraft/textures/block/grass_block_snow.png")
-    img = self.build_block(self.load_image_texture("assets/minecraft/textures/block/grass_block_top.png"), side_img)
+        side_img = self.load_image_texture(blocks_path + "grass_block_snow.png")
+    img = self.build_block(self.load_image_texture(blocks_path + "grass_block_top.png"), side_img)
     if not data & 0x10:
         alpha_over(img, self.biome_grass_texture, (0, 0), self.biome_grass_texture)
     return img
@@ -956,54 +958,54 @@ def grass(self, blockid, data):
 # dirt
 @material(blockid=3, data=range(3), solid=True)
 def dirt_blocks(self, blockid, data):
-    side_img = self.load_image_texture("assets/minecraft/textures/block/dirt.png")
+    side_img = self.load_image_texture(blocks_path + "dirt.png")
     if data == 0: # normal
-        img =  self.build_block(self.load_image_texture("assets/minecraft/textures/block/dirt.png"), side_img)
+        img =  self.build_block(self.load_image_texture(blocks_path + "dirt.png"), side_img)
     if data == 1: # grassless
-        img = self.build_block(self.load_image_texture("assets/minecraft/textures/block/dirt.png"), side_img)
+        img = self.build_block(self.load_image_texture(blocks_path + "dirt.png"), side_img)
     if data == 2: # podzol
-        side_img = self.load_image_texture("assets/minecraft/textures/block/podzol_side.png")
-        img = self.build_block(self.load_image_texture("assets/minecraft/textures/block/podzol_top.png"), side_img)
+        side_img = self.load_image_texture(blocks_path + "podzol_side.png")
+        img = self.build_block(self.load_image_texture(blocks_path + "podzol_top.png"), side_img)
     return img
 
 # cobblestone
-block(blockid=4, top_image="assets/minecraft/textures/block/cobblestone.png")
+block(blockid=4, top_image=blocks_path + "cobblestone.png")
 
 # wooden planks
 @material(blockid=5, data=range(6), solid=True)
 def wooden_planks(self, blockid, data):
     if data == 0: # normal
-        return self.build_block(self.load_image_texture("assets/minecraft/textures/block/oak_planks.png"), self.load_image_texture("assets/minecraft/textures/block/oak_planks.png"))
+        return self.build_block(self.load_image_texture(blocks_path + "oak_planks.png"), self.load_image_texture(blocks_path + "oak_planks.png"))
     if data == 1: # pine
-        return self.build_block(self.load_image_texture("assets/minecraft/textures/block/spruce_planks.png"),self.load_image_texture("assets/minecraft/textures/block/spruce_planks.png"))
+        return self.build_block(self.load_image_texture(blocks_path + "spruce_planks.png"),self.load_image_texture(blocks_path + "spruce_planks.png"))
     if data == 2: # birch
-        return self.build_block(self.load_image_texture("assets/minecraft/textures/block/birch_planks.png"),self.load_image_texture("assets/minecraft/textures/block/birch_planks.png"))
+        return self.build_block(self.load_image_texture(blocks_path + "birch_planks.png"),self.load_image_texture(blocks_path + "birch_planks.png"))
     if data == 3: # jungle wood
-        return self.build_block(self.load_image_texture("assets/minecraft/textures/block/jungle_planks.png"),self.load_image_texture("assets/minecraft/textures/block/jungle_planks.png"))
+        return self.build_block(self.load_image_texture(blocks_path + "jungle_planks.png"),self.load_image_texture(blocks_path + "jungle_planks.png"))
     if data == 4: # acacia
-        return self.build_block(self.load_image_texture("assets/minecraft/textures/block/acacia_planks.png"),self.load_image_texture("assets/minecraft/textures/block/acacia_planks.png"))
+        return self.build_block(self.load_image_texture(blocks_path + "acacia_planks.png"),self.load_image_texture(blocks_path + "acacia_planks.png"))
     if data == 5: # dark oak
-        return self.build_block(self.load_image_texture("assets/minecraft/textures/block/dark_oak_planks.png"),self.load_image_texture("assets/minecraft/textures/block/dark_oak_planks.png"))
+        return self.build_block(self.load_image_texture(blocks_path + "dark_oak_planks.png"),self.load_image_texture(blocks_path + "dark_oak_planks.png"))
 
 @material(blockid=6, data=range(16), transparent=True)
 def saplings(self, blockid, data):
     # usual saplings
-    tex = self.load_image_texture("assets/minecraft/textures/block/oak_sapling.png")
+    tex = self.load_image_texture(blocks_path + "oak_sapling.png")
     
     if data & 0x3 == 1: # spruce sapling
-        tex = self.load_image_texture("assets/minecraft/textures/block/spruce_sapling.png")
+        tex = self.load_image_texture(blocks_path + "spruce_sapling.png")
     elif data & 0x3 == 2: # birch sapling
-        tex = self.load_image_texture("assets/minecraft/textures/block/birch_sapling.png")
+        tex = self.load_image_texture(blocks_path + "birch_sapling.png")
     elif data & 0x3 == 3: # jungle sapling
-        tex = self.load_image_texture("assets/minecraft/textures/block/jungle_sapling.png")
+        tex = self.load_image_texture(blocks_path + "jungle_sapling.png")
     elif data & 0x3 == 4: # acacia sapling
-        tex = self.load_image_texture("assets/minecraft/textures/block/acacia_sapling.png")
+        tex = self.load_image_texture(blocks_path + "acacia_sapling.png")
     elif data & 0x3 == 5: # dark oak/roofed oak/big oak sapling
-        tex = self.load_image_texture("assets/minecraft/textures/block/dark_oak_sapling.png")
+        tex = self.load_image_texture(blocks_path + "dark_oak_sapling.png")
     return self.build_sprite(tex)
 
 # bedrock
-block(blockid=7, top_image="assets/minecraft/textures/block/bedrock.png")
+block(blockid=7, top_image=blocks_path + "bedrock.png")
 
 # water, glass, and ice (no inner surfaces)
 # uses pseudo-ancildata found in iterate.c
@@ -1012,11 +1014,11 @@ def no_inner_surfaces(self, blockid, data):
     if blockid == 8 or blockid == 9:
         texture = self.load_water()
     elif blockid == 20:
-        texture = self.load_image_texture("assets/minecraft/textures/block/glass.png")
+        texture = self.load_image_texture(blocks_path + "glass.png")
     elif blockid == 95:
-        texture = self.load_image_texture("assets/minecraft/textures/block/%s_stained_glass.png" % color_map[data & 0x0f])
+        texture = self.load_image_texture(blocks_path + "%s_stained_glass.png" % color_map[data & 0x0f])
     else:
-        texture = self.load_image_texture("assets/minecraft/textures/block/ice.png")
+        texture = self.load_image_texture(blocks_path + "ice.png")
 
     # now that we've used the lower 4 bits to get color, shift down to get the 5 bits that encode face hiding
     if not (blockid == 8 or blockid == 9): # water doesn't have a shifted pseudodata
@@ -1063,19 +1065,19 @@ def lava(self, blockid, data):
 @material(blockid=12, data=range(2), solid=True)
 def sand_blocks(self, blockid, data):
     if data == 0: # normal
-        img = self.build_block(self.load_image_texture("assets/minecraft/textures/block/sand.png"), self.load_image_texture("assets/minecraft/textures/block/sand.png"))
+        img = self.build_block(self.load_image_texture(blocks_path + "sand.png"), self.load_image_texture(blocks_path + "sand.png"))
     if data == 1: # red
-        img = self.build_block(self.load_image_texture("assets/minecraft/textures/block/red_sand.png"), self.load_image_texture("assets/minecraft/textures/block/red_sand.png"))
+        img = self.build_block(self.load_image_texture(blocks_path + "red_sand.png"), self.load_image_texture(blocks_path + "red_sand.png"))
     return img
 
 # gravel
-block(blockid=13, top_image="assets/minecraft/textures/block/gravel.png")
+block(blockid=13, top_image=blocks_path + "gravel.png")
 # gold ore
-block(blockid=14, top_image="assets/minecraft/textures/block/gold_ore.png")
+block(blockid=14, top_image=blocks_path + "gold_ore.png")
 # iron ore
-block(blockid=15, top_image="assets/minecraft/textures/block/iron_ore.png")
+block(blockid=15, top_image=blocks_path + "iron_ore.png")
 # coal ore
-block(blockid=16, top_image="assets/minecraft/textures/block/coal_ore.png")
+block(blockid=16, top_image=blocks_path + "coal_ore.png")
 
 @material(blockid=[17,162,11306,11307,11308,11309,11310,11311], data=range(12), solid=True)
 def wood(self, blockid, data):
@@ -1092,95 +1094,95 @@ def wood(self, blockid, data):
     # choose textures
     if blockid == 17: # regular wood:
         if wood_type == 0: # normal
-            top = self.load_image_texture("assets/minecraft/textures/block/oak_log_top.png")
-            side = self.load_image_texture("assets/minecraft/textures/block/oak_log.png")
+            top = self.load_image_texture(blocks_path + "oak_log_top.png")
+            side = self.load_image_texture(blocks_path + "oak_log.png")
         if wood_type == 1: # spruce
-            top = self.load_image_texture("assets/minecraft/textures/block/spruce_log_top.png")
-            side = self.load_image_texture("assets/minecraft/textures/block/spruce_log.png")
+            top = self.load_image_texture(blocks_path + "spruce_log_top.png")
+            side = self.load_image_texture(blocks_path + "spruce_log.png")
         if wood_type == 2: # birch
-            top = self.load_image_texture("assets/minecraft/textures/block/birch_log_top.png")
-            side = self.load_image_texture("assets/minecraft/textures/block/birch_log.png")
+            top = self.load_image_texture(blocks_path + "birch_log_top.png")
+            side = self.load_image_texture(blocks_path + "birch_log.png")
         if wood_type == 3: # jungle wood
-            top = self.load_image_texture("assets/minecraft/textures/block/jungle_log_top.png")
-            side = self.load_image_texture("assets/minecraft/textures/block/jungle_log.png")
+            top = self.load_image_texture(blocks_path + "jungle_log_top.png")
+            side = self.load_image_texture(blocks_path + "jungle_log.png")
     elif blockid == 162: # acacia/dark wood:
         if wood_type == 0: # acacia
-            top = self.load_image_texture("assets/minecraft/textures/block/acacia_log_top.png")
-            side = self.load_image_texture("assets/minecraft/textures/block/acacia_log.png")
+            top = self.load_image_texture(blocks_path + "acacia_log_top.png")
+            side = self.load_image_texture(blocks_path + "acacia_log.png")
         elif wood_type == 1: # dark oak
-            top = self.load_image_texture("assets/minecraft/textures/block/dark_oak_log_top.png")
-            side = self.load_image_texture("assets/minecraft/textures/block/dark_oak_log.png")
+            top = self.load_image_texture(blocks_path + "dark_oak_log_top.png")
+            side = self.load_image_texture(blocks_path + "dark_oak_log.png")
         else:
-            top = self.load_image_texture("assets/minecraft/textures/block/acacia_log_top.png")
-            side = self.load_image_texture("assets/minecraft/textures/block/acacia_log.png")
+            top = self.load_image_texture(blocks_path + "acacia_log_top.png")
+            side = self.load_image_texture(blocks_path + "acacia_log.png")
     if blockid == 11306: # stripped regular wood:
         if wood_type == 0: # normal
-            top = self.load_image_texture("assets/minecraft/textures/block/stripped_oak_log_top.png")
-            side = self.load_image_texture("assets/minecraft/textures/block/stripped_oak_log.png")
+            top = self.load_image_texture(blocks_path + "stripped_oak_log_top.png")
+            side = self.load_image_texture(blocks_path + "stripped_oak_log.png")
         if wood_type == 1: # spruce
-            top = self.load_image_texture("assets/minecraft/textures/block/stripped_spruce_log_top.png")
-            side = self.load_image_texture("assets/minecraft/textures/block/stripped_spruce_log.png")
+            top = self.load_image_texture(blocks_path + "stripped_spruce_log_top.png")
+            side = self.load_image_texture(blocks_path + "stripped_spruce_log.png")
         if wood_type == 2: # birch
-            top = self.load_image_texture("assets/minecraft/textures/block/stripped_birch_log_top.png")
-            side = self.load_image_texture("assets/minecraft/textures/block/stripped_birch_log.png")
+            top = self.load_image_texture(blocks_path + "stripped_birch_log_top.png")
+            side = self.load_image_texture(blocks_path + "stripped_birch_log.png")
         if wood_type == 3: # jungle wood
-            top = self.load_image_texture("assets/minecraft/textures/block/stripped_jungle_log_top.png")
-            side = self.load_image_texture("assets/minecraft/textures/block/stripped_jungle_log.png")
+            top = self.load_image_texture(blocks_path + "stripped_jungle_log_top.png")
+            side = self.load_image_texture(blocks_path + "stripped_jungle_log.png")
     elif blockid == 11307: # stripped acacia/dark wood:
         if wood_type == 0: # acacia
-            top = self.load_image_texture("assets/minecraft/textures/block/stripped_acacia_log_top.png")
-            side = self.load_image_texture("assets/minecraft/textures/block/stripped_acacia_log.png")
+            top = self.load_image_texture(blocks_path + "stripped_acacia_log_top.png")
+            side = self.load_image_texture(blocks_path + "stripped_acacia_log.png")
         elif wood_type == 1: # dark oak
-            top = self.load_image_texture("assets/minecraft/textures/block/stripped_dark_oak_log_top.png")
-            side = self.load_image_texture("assets/minecraft/textures/block/stripped_dark_oak_log.png")
+            top = self.load_image_texture(blocks_path + "stripped_dark_oak_log_top.png")
+            side = self.load_image_texture(blocks_path + "stripped_dark_oak_log.png")
         else:
-            top = self.load_image_texture("assets/minecraft/textures/block/stripped_acacia_log_top.png")
-            side = self.load_image_texture("assets/minecraft/textures/block/stripped_acacia_log.png")
+            top = self.load_image_texture(blocks_path + "stripped_acacia_log_top.png")
+            side = self.load_image_texture(blocks_path + "stripped_acacia_log.png")
     if blockid == 11308: # regular bark:
         if wood_type == 0: # normal
-            top = self.load_image_texture("assets/minecraft/textures/block/oak_log.png")
+            top = self.load_image_texture(blocks_path + "oak_log.png")
             side = top
         if wood_type == 1: # spruce
-            top = self.load_image_texture("assets/minecraft/textures/block/spruce_log.png")
+            top = self.load_image_texture(blocks_path + "spruce_log.png")
             side = top
         if wood_type == 2: # birch
-            top = self.load_image_texture("assets/minecraft/textures/block/birch_log.png")
+            top = self.load_image_texture(blocks_path + "birch_log.png")
             side = top
         if wood_type == 3: # jungle wood
-            top = self.load_image_texture("assets/minecraft/textures/block/jungle_log.png")
+            top = self.load_image_texture(blocks_path + "jungle_log.png")
             side = top
     elif blockid == 11309: # acacia/dark bark:
         if wood_type == 0: # acacia
-            top = self.load_image_texture("assets/minecraft/textures/block/acacia_log.png")
+            top = self.load_image_texture(blocks_path + "acacia_log.png")
             side = top
         elif wood_type == 1: # dark oak
-            top = self.load_image_texture("assets/minecraft/textures/block/dark_oak_log.png")
+            top = self.load_image_texture(blocks_path + "dark_oak_log.png")
             side = top
         else:
-            top = self.load_image_texture("assets/minecraft/textures/block/acacia_log.png")
+            top = self.load_image_texture(blocks_path + "acacia_log.png")
             side = top
     if blockid == 11310: # stripped regular wood:
         if wood_type == 0: # normal
-            top = self.load_image_texture("assets/minecraft/textures/block/stripped_oak_log.png")
+            top = self.load_image_texture(blocks_path + "stripped_oak_log.png")
             side = top
         if wood_type == 1: # spruce
-            top = self.load_image_texture("assets/minecraft/textures/block/stripped_spruce_log.png")
+            top = self.load_image_texture(blocks_path + "stripped_spruce_log.png")
             side = top
         if wood_type == 2: # birch
-            top = self.load_image_texture("assets/minecraft/textures/block/stripped_birch_log.png")
+            top = self.load_image_texture(blocks_path + "stripped_birch_log.png")
             side = top
         if wood_type == 3: # jungle wood
-            top = self.load_image_texture("assets/minecraft/textures/block/stripped_jungle_log.png")
+            top = self.load_image_texture(blocks_path + "stripped_jungle_log.png")
             side = top
     elif blockid == 11311: # stripped acacia/dark wood:
         if wood_type == 0: # acacia
-            top = self.load_image_texture("assets/minecraft/textures/block/stripped_acacia_log.png")
+            top = self.load_image_texture(blocks_path + "stripped_acacia_log.png")
             side = top
         elif wood_type == 1: # dark oak
-            top = self.load_image_texture("assets/minecraft/textures/block/stripped_dark_oak_log.png")
+            top = self.load_image_texture(blocks_path + "stripped_dark_oak_log.png")
             side = top
         else:
-            top = self.load_image_texture("assets/minecraft/textures/block/stripped_acacia_log.png")
+            top = self.load_image_texture(blocks_path + "stripped_acacia_log.png")
             side = top
 
     # choose orientation and paste textures
@@ -1196,25 +1198,25 @@ def leaves(self, blockid, data):
     # mask out the bits 4 and 8
     # they are used for player placed and check-for-decay blocks
     data = data & 0x7
-    t = self.load_image_texture("assets/minecraft/textures/block/oak_leaves.png")
+    t = self.load_image_texture(blocks_path + "oak_leaves.png")
     if (blockid, data) == (18, 1): # pine!
-        t = self.load_image_texture("assets/minecraft/textures/block/spruce_leaves.png")
+        t = self.load_image_texture(blocks_path + "spruce_leaves.png")
     elif (blockid, data) == (18, 2): # birth tree
-        t = self.load_image_texture("assets/minecraft/textures/block/birch_leaves.png")
+        t = self.load_image_texture(blocks_path + "birch_leaves.png")
     elif (blockid, data) == (18, 3): # jungle tree
-        t = self.load_image_texture("assets/minecraft/textures/block/jungle_leaves.png")
+        t = self.load_image_texture(blocks_path + "jungle_leaves.png")
     elif (blockid, data) == (161, 4): # acacia tree
-        t = self.load_image_texture("assets/minecraft/textures/block/acacia_leaves.png")
+        t = self.load_image_texture(blocks_path + "acacia_leaves.png")
     elif (blockid, data) == (161, 5): 
-        t = self.load_image_texture("assets/minecraft/textures/block/dark_oak_leaves.png")
+        t = self.load_image_texture(blocks_path + "dark_oak_leaves.png")
     return self.build_block(t, t)
 
 # sponge
-block(blockid=19, top_image="assets/minecraft/textures/block/sponge.png")
+block(blockid=19, top_image=blocks_path + "sponge.png")
 # lapis lazuli ore
-block(blockid=21, top_image="assets/minecraft/textures/block/lapis_ore.png")
+block(blockid=21, top_image=blocks_path + "lapis_ore.png")
 # lapis lazuli block
-block(blockid=22, top_image="assets/minecraft/textures/block/lapis_block.png")
+block(blockid=22, top_image=blocks_path + "lapis_block.png")
 
 # dispensers, dropper, furnaces, and burning furnaces
 @material(blockid=[23, 61, 62, 158], data=range(6), solid=True)
@@ -1236,26 +1238,26 @@ def furnaces(self, blockid, data):
         elif data == 4: data = 3
         elif data == 5: data = 2
     
-    top = self.load_image_texture("assets/minecraft/textures/block/furnace_top.png")
-    side = self.load_image_texture("assets/minecraft/textures/block/furnace_side.png")
+    top = self.load_image_texture(blocks_path + "furnace_top.png")
+    side = self.load_image_texture(blocks_path + "furnace_side.png")
     
     if blockid == 61:
-        front = self.load_image_texture("assets/minecraft/textures/block/furnace_front.png")
+        front = self.load_image_texture(blocks_path + "furnace_front.png")
     elif blockid == 62:
-        front = self.load_image_texture("assets/minecraft/textures/block/furnace_front_on.png")
+        front = self.load_image_texture(blocks_path + "furnace_front_on.png")
     elif blockid == 23:
-        front = self.load_image_texture("assets/minecraft/textures/block/dispenser_front.png")
+        front = self.load_image_texture(blocks_path + "dispenser_front.png")
         if data == 0: # dispenser pointing down
             return self.build_block(top, top)
         elif data == 1: # dispenser pointing up
-            dispenser_top = self.load_image_texture("assets/minecraft/textures/block/dispenser_front_vertical.png")
+            dispenser_top = self.load_image_texture(blocks_path + "dispenser_front_vertical.png")
             return self.build_block(dispenser_top, top)
     elif blockid == 158:
-        front = self.load_image_texture("assets/minecraft/textures/block/dropper_front.png")
+        front = self.load_image_texture(blocks_path + "dropper_front.png")
         if data == 0: # dropper pointing down
             return self.build_block(top, top)
         elif data == 1: # dispenser pointing up
-            dropper_top = self.load_image_texture("assets/minecraft/textures/block/dropper_front_vertical.png")
+            dropper_top = self.load_image_texture(blocks_path + "dropper_front_vertical.png")
             return self.build_block(dropper_top, top)
     
     if data == 3: # pointing west
@@ -1268,28 +1270,28 @@ def furnaces(self, blockid, data):
 # sandstone
 @material(blockid=24, data=range(3), solid=True)
 def sandstone(self, blockid, data):
-    top = self.load_image_texture("assets/minecraft/textures/block/sandstone_top.png")
+    top = self.load_image_texture(blocks_path + "sandstone_top.png")
     if data == 0: # normal
-        return self.build_block(top, self.load_image_texture("assets/minecraft/textures/block/sandstone.png"))
+        return self.build_block(top, self.load_image_texture(blocks_path + "sandstone.png"))
     if data == 1: # hieroglyphic
-        return self.build_block(top, self.load_image_texture("assets/minecraft/textures/block/chiseled_sandstone.png"))
+        return self.build_block(top, self.load_image_texture(blocks_path + "chiseled_sandstone.png"))
     if data == 2: # soft
-        return self.build_block(top, self.load_image_texture("assets/minecraft/textures/block/cut_sandstone.png"))
+        return self.build_block(top, self.load_image_texture(blocks_path + "cut_sandstone.png"))
         
 # red sandstone
 @material(blockid=179, data=range(3), solid=True)
 def sandstone(self, blockid, data):
-    top = self.load_image_texture("assets/minecraft/textures/block/red_sandstone_top.png")
+    top = self.load_image_texture(blocks_path + "red_sandstone_top.png")
     if data == 0: # normal
-            side = self.load_image_texture("assets/minecraft/textures/block/red_sandstone.png")
-            return self.build_full_block(top, None, None, side, side, self.load_image_texture("assets/minecraft/textures/block/red_sandstone_bottom.png") )
+            side = self.load_image_texture(blocks_path + "red_sandstone.png")
+            return self.build_full_block(top, None, None, side, side, self.load_image_texture(blocks_path + "red_sandstone_bottom.png") )
     if data == 1: # hieroglyphic
-        return self.build_block(top, self.load_image_texture("assets/minecraft/textures/block/chiseled_red_sandstone.png"))
+        return self.build_block(top, self.load_image_texture(blocks_path + "chiseled_red_sandstone.png"))
     if data == 2: # soft
-        return self.build_block(top, self.load_image_texture("assets/minecraft/textures/block/cut_red_sandstone.png"))
+        return self.build_block(top, self.load_image_texture(blocks_path + "cut_red_sandstone.png"))
 
 # note block
-block(blockid=25, top_image="assets/minecraft/textures/block/note_block.png")
+block(blockid=25, top_image=blocks_path + "note_block.png")
 
 @material(blockid=26, data=range(12), transparent=True, nospawn=True)
 def bed(self, blockid, data):
@@ -1426,31 +1428,31 @@ def rails(self, blockid, data):
     
     if blockid == 27: # powered rail
         if data & 0x8 == 0: # unpowered
-            raw_straight = self.load_image_texture("assets/minecraft/textures/block/powered_rail.png")
-            raw_corner = self.load_image_texture("assets/minecraft/textures/block/rail_corner.png")    # they don't exist but make the code
+            raw_straight = self.load_image_texture(blocks_path + "powered_rail.png")
+            raw_corner = self.load_image_texture(blocks_path + "rail_corner.png")    # they don't exist but make the code
                                                 # much simplier
         elif data & 0x8 == 0x8: # powered
-            raw_straight = self.load_image_texture("assets/minecraft/textures/block/powered_rail_on.png")
-            raw_corner = self.load_image_texture("assets/minecraft/textures/block/rail_corner.png")    # leave corners for code simplicity
+            raw_straight = self.load_image_texture(blocks_path + "powered_rail_on.png")
+            raw_corner = self.load_image_texture(blocks_path + "rail_corner.png")    # leave corners for code simplicity
         # filter the 'powered' bit
         data = data & 0x7
             
     elif blockid == 28: # detector rail
-        raw_straight = self.load_image_texture("assets/minecraft/textures/block/detector_rail.png")
-        raw_corner = self.load_image_texture("assets/minecraft/textures/block/rail_corner.png")    # leave corners for code simplicity
+        raw_straight = self.load_image_texture(blocks_path + "detector_rail.png")
+        raw_corner = self.load_image_texture(blocks_path + "rail_corner.png")    # leave corners for code simplicity
         
     elif blockid == 66: # normal rail
-        raw_straight = self.load_image_texture("assets/minecraft/textures/block/rail.png")
-        raw_corner = self.load_image_texture("assets/minecraft/textures/block/rail_corner.png")
+        raw_straight = self.load_image_texture(blocks_path + "rail.png")
+        raw_corner = self.load_image_texture(blocks_path + "rail_corner.png")
 
     elif blockid == 157: # activator rail
         if data & 0x8 == 0: # unpowered
-            raw_straight = self.load_image_texture("assets/minecraft/textures/block/activator_rail.png")
-            raw_corner = self.load_image_texture("assets/minecraft/textures/block/rail_corner.png")    # they don't exist but make the code
+            raw_straight = self.load_image_texture(blocks_path + "activator_rail.png")
+            raw_corner = self.load_image_texture(blocks_path + "rail_corner.png")    # they don't exist but make the code
                                                 # much simplier
         elif data & 0x8 == 0x8: # powered
-            raw_straight = self.load_image_texture("assets/minecraft/textures/block/activator_rail_on.png")
-            raw_corner = self.load_image_texture("assets/minecraft/textures/block/rail_corner.png")    # leave corners for code simplicity
+            raw_straight = self.load_image_texture(blocks_path + "activator_rail_on.png")
+            raw_corner = self.load_image_texture(blocks_path + "rail_corner.png")    # leave corners for code simplicity
         # filter the 'powered' bit
         data = data & 0x7
         
@@ -1520,14 +1522,14 @@ def piston(self, blockid, data):
         elif (data & 0b0111) == 5: data = data & 0b1000 | 2
     
     if blockid == 29: # sticky
-        piston_t = self.load_image_texture("assets/minecraft/textures/block/piston_top_sticky.png").copy()
+        piston_t = self.load_image_texture(blocks_path + "piston_top_sticky.png").copy()
     else: # normal
-        piston_t = self.load_image_texture("assets/minecraft/textures/block/piston_top.png").copy()
+        piston_t = self.load_image_texture(blocks_path + "piston_top.png").copy()
         
     # other textures
-    side_t = self.load_image_texture("assets/minecraft/textures/block/piston_side.png").copy()
-    back_t = self.load_image_texture("assets/minecraft/textures/block/piston_bottom.png").copy()
-    interior_t = self.load_image_texture("assets/minecraft/textures/block/piston_inner.png").copy()
+    side_t = self.load_image_texture(blocks_path + "piston_side.png").copy()
+    back_t = self.load_image_texture(blocks_path + "piston_bottom.png").copy()
+    interior_t = self.load_image_texture(blocks_path + "piston_inner.png").copy()
     
     if data & 0x08 == 0x08: # pushed out, non full blocks, tricky stuff
         # remove piston texture from piston body
@@ -1596,13 +1598,13 @@ def piston_extension(self, blockid, data):
         elif (data & 0b0111) == 5: data = data & 0b1000 | 2
     
     if (data & 0x8) == 0x8: # sticky
-        piston_t = self.load_image_texture("assets/minecraft/textures/block/piston_top_sticky.png").copy()
+        piston_t = self.load_image_texture(blocks_path + "piston_top_sticky.png").copy()
     else: # normal
-        piston_t = self.load_image_texture("assets/minecraft/textures/block/piston_top.png").copy()
+        piston_t = self.load_image_texture(blocks_path + "piston_top.png").copy()
     
     # other textures
-    side_t = self.load_image_texture("assets/minecraft/textures/block/piston_side.png").copy()
-    back_t = self.load_image_texture("assets/minecraft/textures/block/piston_top.png").copy()
+    side_t = self.load_image_texture(blocks_path + "piston_side.png").copy()
+    back_t = self.load_image_texture(blocks_path + "piston_top.png").copy()
     # crop piston body
     ImageDraw.Draw(side_t).rectangle((0, 4,16,16),outline=(0,0,0,0),fill=(0,0,0,0))
     
@@ -1662,48 +1664,48 @@ def piston_extension(self, blockid, data):
     return img
 
 # cobweb
-sprite(blockid=30, imagename="assets/minecraft/textures/block/cobweb.png", nospawn=True)
+sprite(blockid=30, imagename=blocks_path + "cobweb.png", nospawn=True)
 
 @material(blockid=31, data=range(3), transparent=True)
 def tall_grass(self, blockid, data):
     if data == 0: # dead shrub
-        texture = self.load_image_texture("assets/minecraft/textures/block/dead_bush.png")
+        texture = self.load_image_texture(blocks_path + "dead_bush.png")
     elif data == 1: # tall grass
-        texture = self.load_image_texture("assets/minecraft/textures/block/grass.png")
+        texture = self.load_image_texture(blocks_path + "grass.png")
     elif data == 2: # fern
-        texture = self.load_image_texture("assets/minecraft/textures/block/fern.png")
+        texture = self.load_image_texture(blocks_path + "fern.png")
     
     return self.build_billboard(texture)
 
 # dead bush
-billboard(blockid=32, imagename="assets/minecraft/textures/block/dead_bush.png")
+billboard(blockid=32, imagename=blocks_path + "dead_bush.png")
 
 @material(blockid=35, data=range(16), solid=True)
 def wool(self, blockid, data):
-    texture = self.load_image_texture("assets/minecraft/textures/block/%s_wool.png" % color_map[data])
+    texture = self.load_image_texture(blocks_path + "%s_wool.png" % color_map[data])
     
     return self.build_block(texture, texture)
 
 # dandelion
-sprite(blockid=37, imagename="assets/minecraft/textures/block/dandelion.png")
+sprite(blockid=37, imagename=blocks_path + "dandelion.png")
 
 # flowers
 @material(blockid=38, data=range(10), transparent=True)
 def flower(self, blockid, data):
     flower_map = ["poppy", "blue_orchid", "allium", "azure_bluet", "red_tulip", "orange_tulip",
                   "white_tulip", "pink_tulip", "oxeye_daisy", "dandelion"]
-    texture = self.load_image_texture("assets/minecraft/textures/block/%s.png" % flower_map[data])
+    texture = self.load_image_texture(blocks_path + "%s.png" % flower_map[data])
 
     return self.build_billboard(texture)
 
 # brown mushroom
-sprite(blockid=39, imagename="assets/minecraft/textures/block/brown_mushroom.png")
+sprite(blockid=39, imagename=blocks_path + "brown_mushroom.png")
 # red mushroom
-sprite(blockid=40, imagename="assets/minecraft/textures/block/red_mushroom.png")
+sprite(blockid=40, imagename=blocks_path + "red_mushroom.png")
 # block of gold
-block(blockid=41, top_image="assets/minecraft/textures/block/gold_block.png")
+block(blockid=41, top_image=blocks_path + "gold_block.png")
 # block of iron
-block(blockid=42, top_image="assets/minecraft/textures/block/iron_block.png")
+block(blockid=42, top_image=blocks_path + "iron_block.png")
 
 # double slabs and slabs
 # these wooden slabs are unobtainable without cheating, they are still
@@ -1717,47 +1719,47 @@ def slabs(self, blockid, data):
 
     if blockid == 44 or blockid == 43:
         if texture== 0: # stone slab
-            top = self.load_image_texture("assets/minecraft/textures/block/stone_slab_top.png")
-            side = self.load_image_texture("assets/minecraft/textures/block/stone_slab_side.png")
+            top = self.load_image_texture(blocks_path + "stone_slab_top.png")
+            side = self.load_image_texture(blocks_path + "stone_slab_side.png")
         elif texture== 1: # sandstone slab
-            top = self.load_image_texture("assets/minecraft/textures/block/sandstone_top.png")
-            side = self.load_image_texture("assets/minecraft/textures/block/sandstone.png")
+            top = self.load_image_texture(blocks_path + "sandstone_top.png")
+            side = self.load_image_texture(blocks_path + "sandstone.png")
         elif texture== 2: # wooden slab
-            top = side = self.load_image_texture("assets/minecraft/textures/block/oak_planks.png")
+            top = side = self.load_image_texture(blocks_path + "oak_planks.png")
         elif texture== 3: # cobblestone slab
-            top = side = self.load_image_texture("assets/minecraft/textures/block/cobblestone.png")
+            top = side = self.load_image_texture(blocks_path + "cobblestone.png")
         elif texture== 4: # brick
-            top = side = self.load_image_texture("assets/minecraft/textures/block/bricks.png")
+            top = side = self.load_image_texture(blocks_path + "bricks.png")
         elif texture== 5: # stone brick
-            top = side = self.load_image_texture("assets/minecraft/textures/block/stone_bricks.png")
+            top = side = self.load_image_texture(blocks_path + "stone_bricks.png")
         elif texture== 6: # nether brick slab
-            top = side = self.load_image_texture("assets/minecraft/textures/block/nether_bricks.png")
+            top = side = self.load_image_texture(blocks_path + "nether_bricks.png")
         elif texture== 7: #quartz        
-            top = side = self.load_image_texture("assets/minecraft/textures/block/quartz_block_side.png")
+            top = side = self.load_image_texture(blocks_path + "quartz_block_side.png")
         elif texture== 8: # special stone double slab with top texture only
-            top = side = self.load_image_texture("assets/minecraft/textures/block/stone_slab_top.png")
+            top = side = self.load_image_texture(blocks_path + "stone_slab_top.png")
         elif texture== 9: # special sandstone double slab with top texture only
-            top = side = self.load_image_texture("assets/minecraft/textures/block/sandstone_top.png")
+            top = side = self.load_image_texture(blocks_path + "sandstone_top.png")
         else:
             return None
 
     elif blockid == 182: # single red sandstone slab
         if texture == 0:
-            top = self.load_image_texture("assets/minecraft/textures/block/red_sandstone_top.png")
-            side = self.load_image_texture("assets/minecraft/textures/block/red_sandstone.png")
+            top = self.load_image_texture(blocks_path + "red_sandstone_top.png")
+            side = self.load_image_texture(blocks_path + "red_sandstone.png")
         else:
             return None
 
     elif blockid == 181: # double red sandstone slab
         if texture == 0: # red sandstone
-            top = self.load_image_texture("assets/minecraft/textures/block/red_sandstone_top.png")
-            side = self.load_image_texture("assets/minecraft/textures/block/red_sandstone.png")
+            top = self.load_image_texture(blocks_path + "red_sandstone_top.png")
+            side = self.load_image_texture(blocks_path + "red_sandstone.png")
         elif texture == 8: # 'full' red sandstone (smooth)
-            top = side = self.load_image_texture("assets/minecraft/textures/block/red_sandstone_top.png");
+            top = side = self.load_image_texture(blocks_path + "red_sandstone_top.png");
         else:
             return None
     elif blockid == 204 or blockid == 205: # purpur slab (single=205 double=204)
-        top = side = self.load_image_texture("assets/minecraft/textures/block/purpur_block.png");
+        top = side = self.load_image_texture(blocks_path + "purpur_block.png");
 
     
     if blockid == 43 or blockid == 181 or blockid == 204: # double slab
@@ -1766,15 +1768,15 @@ def slabs(self, blockid, data):
     return self.build_slab_block(top, side, data & 8 == 8);
 
 # brick block
-block(blockid=45, top_image="assets/minecraft/textures/block/bricks.png")
+block(blockid=45, top_image=blocks_path + "bricks.png")
 # TNT
-block(blockid=46, top_image="assets/minecraft/textures/block/tnt_top.png", side_image="assets/minecraft/textures/block/tnt_side.png", nospawn=True)
+block(blockid=46, top_image=blocks_path + "tnt_top.png", side_image=blocks_path + "tnt_side.png", nospawn=True)
 # bookshelf
-block(blockid=47, top_image="assets/minecraft/textures/block/oak_planks.png", side_image="assets/minecraft/textures/block/bookshelf.png")
+block(blockid=47, top_image=blocks_path + "oak_planks.png", side_image=blocks_path + "bookshelf.png")
 # moss stone
-block(blockid=48, top_image="assets/minecraft/textures/block/mossy_cobblestone.png")
+block(blockid=48, top_image=blocks_path + "mossy_cobblestone.png")
 # obsidian
-block(blockid=49, top_image="assets/minecraft/textures/block/obsidian.png")
+block(blockid=49, top_image=blocks_path + "obsidian.png")
 
 # torch, redstone torch (off), redstone torch(on)
 @material(blockid=[50, 75, 76], data=[1, 2, 3, 4, 5], transparent=True)
@@ -1798,11 +1800,11 @@ def torches(self, blockid, data):
     
     # choose the proper texture
     if blockid == 50: # torch
-        small = self.load_image_texture("assets/minecraft/textures/block/torch.png")
+        small = self.load_image_texture(blocks_path + "torch.png")
     elif blockid == 75: # off redstone torch
-        small = self.load_image_texture("assets/minecraft/textures/block/redstone_torch_off.png")
+        small = self.load_image_texture(blocks_path + "redstone_torch_off.png")
     else: # on redstone torch
-        small = self.load_image_texture("assets/minecraft/textures/block/redstone_torch.png")
+        small = self.load_image_texture(blocks_path + "redstone_torch.png")
         
     # compose a torch bigger than the normal
     # (better for doing transformations)
@@ -1864,7 +1866,7 @@ def fire(self, blockid, data):
     return img
 
 # monster spawner
-block(blockid=52, top_image="assets/minecraft/textures/block/spawner.png", transparent=True)
+block(blockid=52, top_image=blocks_path + "spawner.png", transparent=True)
 
 # wooden, cobblestone, red brick, stone brick, netherbrick, sandstone, spruce, birch, jungle, quartz, and red sandstone stairs.
 @material(blockid=[53,67,108,109,114,128,134,135,136,156,163,164,180,203], data=range(128), transparent=True, solid=True, nospawn=True)
@@ -1881,33 +1883,33 @@ def stairs(self, blockid, data):
     nw,ne,se,sw = quarters
 
     if blockid == 53: # wooden
-        texture = self.load_image_texture("assets/minecraft/textures/block/oak_planks.png").copy()
+        texture = self.load_image_texture(blocks_path + "oak_planks.png").copy()
     elif blockid == 67: # cobblestone
-        texture = self.load_image_texture("assets/minecraft/textures/block/cobblestone.png").copy()
+        texture = self.load_image_texture(blocks_path + "cobblestone.png").copy()
     elif blockid == 108: # red brick stairs
-        texture = self.load_image_texture("assets/minecraft/textures/block/bricks.png").copy()
+        texture = self.load_image_texture(blocks_path + "bricks.png").copy()
     elif blockid == 109: # stone brick stairs
-        texture = self.load_image_texture("assets/minecraft/textures/block/stone_bricks.png").copy()
+        texture = self.load_image_texture(blocks_path + "stone_bricks.png").copy()
     elif blockid == 114: # netherbrick stairs
-        texture = self.load_image_texture("assets/minecraft/textures/block/nether_bricks.png").copy()
+        texture = self.load_image_texture(blocks_path + "nether_bricks.png").copy()
     elif blockid == 128: # sandstone stairs
-        texture = self.load_image_texture("assets/minecraft/textures/block/sandstone.png").copy()
+        texture = self.load_image_texture(blocks_path + "sandstone.png").copy()
     elif blockid == 134: # spruce wood stairs
-        texture = self.load_image_texture("assets/minecraft/textures/block/spruce_planks.png").copy()
+        texture = self.load_image_texture(blocks_path + "spruce_planks.png").copy()
     elif blockid == 135: # birch wood  stairs
-        texture = self.load_image_texture("assets/minecraft/textures/block/birch_planks.png").copy()
+        texture = self.load_image_texture(blocks_path + "birch_planks.png").copy()
     elif blockid == 136: # jungle good stairs
-        texture = self.load_image_texture("assets/minecraft/textures/block/jungle_planks.png").copy()
+        texture = self.load_image_texture(blocks_path + "jungle_planks.png").copy()
     elif blockid == 156: # quartz block stairs
-        texture = self.load_image_texture("assets/minecraft/textures/block/quartz_block_side.png").copy()
+        texture = self.load_image_texture(blocks_path + "quartz_block_side.png").copy()
     elif blockid == 163: # acacia wood stairs
-        texture = self.load_image_texture("assets/minecraft/textures/block/acacia_planks.png").copy()
+        texture = self.load_image_texture(blocks_path + "acacia_planks.png").copy()
     elif blockid == 164: # dark oak stairs
-        texture = self.load_image_texture("assets/minecraft/textures/block/dark_oak_planks.png").copy()
+        texture = self.load_image_texture(blocks_path + "dark_oak_planks.png").copy()
     elif blockid == 180: # red sandstone stairs
-        texture = self.load_image_texture("assets/minecraft/textures/block/red_sandstone.png").copy()
+        texture = self.load_image_texture(blocks_path + "red_sandstone.png").copy()
     elif blockid == 203: # purpur stairs
-        texture = self.load_image_texture("assets/minecraft/textures/block/purpur_block.png").copy()
+        texture = self.load_image_texture(blocks_path + "purpur_block.png").copy()
 
     outside_l = texture.copy()
     outside_r = texture.copy()
@@ -1916,11 +1918,11 @@ def stairs(self, blockid, data):
 
     # sandstone, red sandstone, and quartz stairs have special top texture
     if blockid == 128:
-        texture = self.load_image_texture("assets/minecraft/textures/block/sandstone_top.png").copy()
+        texture = self.load_image_texture(blocks_path + "sandstone_top.png").copy()
     elif blockid == 156:
-        texture = self.load_image_texture("assets/minecraft/textures/block/quartz_block_top.png").copy()
+        texture = self.load_image_texture(blocks_path + "quartz_block_top.png").copy()
     elif blockid == 180:
-        texture = self.load_image_texture("assets/minecraft/textures/block/red_sandstone_top.png").copy()
+        texture = self.load_image_texture(blocks_path + "red_sandstone_top.png").copy()
 
 
     slab_top = texture.copy()
@@ -2192,18 +2194,18 @@ def chests(self, blockid, data):
 def wire(self, blockid, data):
 
     if data & 0b1000000 == 64: # powered redstone wire
-        redstone_wire_t = self.load_image_texture("assets/minecraft/textures/block/redstone_dust_line0.png").rotate(90)
+        redstone_wire_t = self.load_image_texture(blocks_path + "redstone_dust_line0.png").rotate(90)
         redstone_wire_t = self.tint_texture(redstone_wire_t,(255,0,0))
 
-        redstone_cross_t = self.load_image_texture("assets/minecraft/textures/block/redstone_dust_dot.png")
+        redstone_cross_t = self.load_image_texture(blocks_path + "redstone_dust_dot.png")
         redstone_cross_t = self.tint_texture(redstone_cross_t,(255,0,0))
 
         
     else: # unpowered redstone wire
-        redstone_wire_t = self.load_image_texture("assets/minecraft/textures/block/redstone_dust_line0.png").rotate(90)
+        redstone_wire_t = self.load_image_texture(blocks_path + "redstone_dust_line0.png").rotate(90)
         redstone_wire_t = self.tint_texture(redstone_wire_t,(48,0,0))
         
-        redstone_cross_t = self.load_image_texture("assets/minecraft/textures/block/redstone_dust_dot.png")
+        redstone_cross_t = self.load_image_texture(blocks_path + "redstone_dust_dot.png")
         redstone_cross_t = self.tint_texture(redstone_cross_t,(48,0,0))
 
     # generate an image per redstone direction
@@ -2265,17 +2267,17 @@ def wire(self, blockid, data):
     return img
 
 # diamond ore
-block(blockid=56, top_image="assets/minecraft/textures/block/diamond_ore.png")
+block(blockid=56, top_image=blocks_path + "diamond_ore.png")
 # diamond block
-block(blockid=57, top_image="assets/minecraft/textures/block/diamond_block.png")
+block(blockid=57, top_image=blocks_path + "diamond_block.png")
 
 # crafting table
 # needs two different sides
 @material(blockid=58, solid=True, nodata=True)
 def crafting_table(self, blockid, data):
-    top = self.load_image_texture("assets/minecraft/textures/block/crafting_table_top.png")
-    side3 = self.load_image_texture("assets/minecraft/textures/block/crafting_table_side.png")
-    side4 = self.load_image_texture("assets/minecraft/textures/block/crafting_table_front.png")
+    top = self.load_image_texture(blocks_path + "crafting_table_top.png")
+    side3 = self.load_image_texture(blocks_path + "crafting_table_side.png")
+    side4 = self.load_image_texture(blocks_path + "crafting_table_front.png")
     
     img = self.build_full_block(top, None, None, side3, side4, None)
     return img
@@ -2283,7 +2285,7 @@ def crafting_table(self, blockid, data):
 # crops with 8 data values (like wheat)
 @material(blockid=59, data=range(8), transparent=True, nospawn=True)
 def crops8(self, blockid, data):
-    raw_crop = self.load_image_texture("assets/minecraft/textures/block/wheat_stage%d.png" % data)
+    raw_crop = self.load_image_texture(blocks_path + "wheat_stage%d.png" % data)
     crop1 = self.transform_image_top(raw_crop)
     crop2 = self.transform_image_side(raw_crop)
     crop3 = crop2.transpose(Image.FLIP_LEFT_RIGHT)
@@ -2298,17 +2300,17 @@ def crops8(self, blockid, data):
 @material(blockid=[60,208], data=range(9), solid=True)
 def farmland(self, blockid, data):
     if blockid == 60:
-        side = self.load_image_texture("assets/minecraft/textures/block/dirt.png")
-        top = self.load_image_texture("assets/minecraft/textures/block/farmland_moist.png")
+        side = self.load_image_texture(blocks_path + "dirt.png")
+        top = self.load_image_texture(blocks_path + "farmland_moist.png")
         if data == 0:
-            top = self.load_image_texture("assets/minecraft/textures/block/farmland.png")
+            top = self.load_image_texture(blocks_path + "farmland.png")
         # dirt.png is 16 pixels tall, so we need to crop it before building full block
         side = side.crop((0, 1, 16, 16))
         return self.build_full_block((top, 1), side, side, side, side)
 			
     else:
-        top = self.load_image_texture("assets/minecraft/textures/block/grass_path_top.png")
-        side = self.load_image_texture("assets/minecraft/textures/block/grass_path_side.png")
+        top = self.load_image_texture(blocks_path + "grass_path_top.png")
+        side = self.load_image_texture(blocks_path + "grass_path_side.png")
         # side already has 1 transparent pixel at the top, so it doesn't need to be modified
         # just shift the top image down 1 pixel
         return self.build_full_block((top, 1), side, side, side, side)
@@ -2326,7 +2328,7 @@ def signpost(self, blockid, data):
     elif self.rotation == 3:
         data = (data + 12) % 16
 
-    texture = self.load_image_texture("assets/minecraft/textures/block/oak_planks.png").copy()
+    texture = self.load_image_texture(blocks_path + "oak_planks.png").copy()
     # cut the planks to the size of a signpost
     ImageDraw.Draw(texture).rectangle((0,12,15,15),outline=(0,0,0,0),fill=(0,0,0,0))
 
@@ -2339,7 +2341,7 @@ def signpost(self, blockid, data):
             texture.putpixel((x,y),(0,0,0,255))
 
     # Minecraft uses wood texture for the signpost stick
-    texture_stick = self.load_image_texture("assets/minecraft/textures/block/oak_log.png")
+    texture_stick = self.load_image_texture(blocks_path + "oak_log.png")
     texture_stick = texture_stick.resize((12,12), Image.ANTIALIAS)
     ImageDraw.Draw(texture_stick).rectangle((2,0,12,12),outline=(0,0,0,0),fill=(0,0,0,0))
 
@@ -2390,34 +2392,34 @@ def door(self, blockid, data):
 
     if data & 0x8 == 0x8: # top of the door
         if blockid == 64: # classic wood door
-            raw_door = self.load_image_texture("assets/minecraft/textures/block/oak_door_top.png")
+            raw_door = self.load_image_texture(blocks_path + "oak_door_top.png")
         elif blockid == 71: # iron door
-            raw_door = self.load_image_texture("assets/minecraft/textures/block/iron_door_top.png")
+            raw_door = self.load_image_texture(blocks_path + "iron_door_top.png")
         elif blockid == 193: # spruce door
-            raw_door = self.load_image_texture("assets/minecraft/textures/block/spruce_door_top.png")
+            raw_door = self.load_image_texture(blocks_path + "spruce_door_top.png")
         elif blockid == 194: # birch door
-            raw_door = self.load_image_texture("assets/minecraft/textures/block/birch_door_top.png")
+            raw_door = self.load_image_texture(blocks_path + "birch_door_top.png")
         elif blockid == 195: # jungle door
-            raw_door = self.load_image_texture("assets/minecraft/textures/block/jungle_door_top.png")
+            raw_door = self.load_image_texture(blocks_path + "jungle_door_top.png")
         elif blockid == 196: # acacia door
-            raw_door = self.load_image_texture("assets/minecraft/textures/block/acacia_door_top.png")
+            raw_door = self.load_image_texture(blocks_path + "acacia_door_top.png")
         elif blockid == 197: # dark_oak door
-            raw_door = self.load_image_texture("assets/minecraft/textures/block/dark_oak_door_top.png")
+            raw_door = self.load_image_texture(blocks_path + "dark_oak_door_top.png")
     else: # bottom of the door
         if blockid == 64:
-            raw_door = self.load_image_texture("assets/minecraft/textures/block/oak_door_bottom.png")
+            raw_door = self.load_image_texture(blocks_path + "oak_door_bottom.png")
         elif blockid == 71: # iron door
-            raw_door = self.load_image_texture("assets/minecraft/textures/block/iron_door_bottom.png")
+            raw_door = self.load_image_texture(blocks_path + "iron_door_bottom.png")
         elif blockid == 193: # spruce door
-            raw_door = self.load_image_texture("assets/minecraft/textures/block/spruce_door_bottom.png")
+            raw_door = self.load_image_texture(blocks_path + "spruce_door_bottom.png")
         elif blockid == 194: # birch door
-            raw_door = self.load_image_texture("assets/minecraft/textures/block/birch_door_bottom.png")
+            raw_door = self.load_image_texture(blocks_path + "birch_door_bottom.png")
         elif blockid == 195: # jungle door
-            raw_door = self.load_image_texture("assets/minecraft/textures/block/jungle_door_bottom.png")
+            raw_door = self.load_image_texture(blocks_path + "jungle_door_bottom.png")
         elif blockid == 196: # acacia door
-            raw_door = self.load_image_texture("assets/minecraft/textures/block/acacia_door_bottom.png")
+            raw_door = self.load_image_texture(blocks_path + "acacia_door_bottom.png")
         elif blockid == 197: # dark_oak door
-            raw_door = self.load_image_texture("assets/minecraft/textures/block/dark_oak_door_bottom.png")
+            raw_door = self.load_image_texture(blocks_path + "dark_oak_door_bottom.png")
     
     # if you want to render all doors as closed, then force
     # force closed to be True
@@ -2537,7 +2539,7 @@ def ladder(self, blockid, data):
         elif data == 5: data = 2
 
     img = Image.new("RGBA", (24,24), self.bgcolor)
-    raw_texture = self.load_image_texture("assets/minecraft/textures/block/ladder.png")
+    raw_texture = self.load_image_texture(blocks_path + "ladder.png")
 
     if data == 5:
         # normally this ladder would be obsured by the block it's attached to
@@ -2581,7 +2583,7 @@ def wall_sign(self, blockid, data): # wall sign
         elif data == 4: data = 3
         elif data == 5: data = 2
 
-    texture = self.load_image_texture("assets/minecraft/textures/block/oak_planks.png").copy()
+    texture = self.load_image_texture(blocks_path + "oak_planks.png").copy()
     # cut the planks to the size of a signpost
     ImageDraw.Draw(texture).rectangle((0,12,15,15),outline=(0,0,0,0),fill=(0,0,0,0))
 
@@ -2651,7 +2653,7 @@ def levers(self, blockid, data):
         elif data == 6: data = 5
 
     # generate the texture for the base of the lever
-    t_base = self.load_image_texture("assets/minecraft/textures/block/stone.png").copy()
+    t_base = self.load_image_texture(blocks_path + "stone.png").copy()
 
     ImageDraw.Draw(t_base).rectangle((0,0,15,3),outline=(0,0,0,0),fill=(0,0,0,0))
     ImageDraw.Draw(t_base).rectangle((0,12,15,15),outline=(0,0,0,0),fill=(0,0,0,0))
@@ -2659,7 +2661,7 @@ def levers(self, blockid, data):
     ImageDraw.Draw(t_base).rectangle((11,0,15,15),outline=(0,0,0,0),fill=(0,0,0,0))
 
     # generate the texture for the stick
-    stick = self.load_image_texture("assets/minecraft/textures/block/lever.png").copy()
+    stick = self.load_image_texture(blocks_path + "lever.png").copy()
     c_stick = Image.new("RGBA", (16,16), self.bgcolor)
     
     tmp = ImageEnhance.Brightness(stick).enhance(0.8)
@@ -2763,15 +2765,15 @@ def levers(self, blockid, data):
 # wooden and stone pressure plates, and weighted pressure plates
 @material(blockid=[70, 72,147,148,11301,11302,11303,11304,11305], data=[0,1], transparent=True)
 def pressure_plate(self, blockid, data):
-    texture_name = {70:"assets/minecraft/textures/block/stone.png",              # stone
-                    72:"assets/minecraft/textures/block/oak_planks.png",         # oak
-                    11301:"assets/minecraft/textures/block/spruce_planks.png",   # spruce
-                    11302:"assets/minecraft/textures/block/birch_planks.png",    # birch
-                    11303:"assets/minecraft/textures/block/jungle_planks.png",   # jungle
-                    11304:"assets/minecraft/textures/block/acacia_planks.png",   # acacia
-                    11305:"assets/minecraft/textures/block/dark_oak_planks.png", # dark oak
-                    147:"assets/minecraft/textures/block/gold_block.png",        # light golden
-                    148:"assets/minecraft/textures/block/iron_block.png",        # heavy iron
+    texture_name = {70:blocks_path + "stone.png",              # stone
+                    72:blocks_path + "oak_planks.png",         # oak
+                    11301:blocks_path + "spruce_planks.png",   # spruce
+                    11302:blocks_path + "birch_planks.png",    # birch
+                    11303:blocks_path + "jungle_planks.png",   # jungle
+                    11304:blocks_path + "acacia_planks.png",   # acacia
+                    11305:blocks_path + "dark_oak_planks.png", # dark oak
+                    147:blocks_path + "gold_block.png",        # light golden
+                    148:blocks_path + "iron_block.png",        # heavy iron
                    }[blockid]
     t = self.load_image_texture(texture_name).copy()
     
@@ -2799,7 +2801,7 @@ def pressure_plate(self, blockid, data):
     return img
 
 # normal and glowing redstone ore
-block(blockid=[73, 74], top_image="assets/minecraft/textures/block/redstone_ore.png")
+block(blockid=[73, 74], top_image=blocks_path + "redstone_ore.png")
 
 # stone a wood buttons
 @material(blockid=(77,143,11326,11327,11328,11329,11330), data=range(16), transparent=True)
@@ -2829,13 +2831,13 @@ def buttons(self, blockid, data):
         elif data == 5: data = 6
         elif data == 6: data = 5
 
-    texturepath = {77:"assets/minecraft/textures/block/stone.png",
-                   143:"assets/minecraft/textures/block/oak_planks.png",
-                   11326:"assets/minecraft/textures/block/spruce_planks.png",
-                   11327:"assets/minecraft/textures/block/birch_planks.png",
-                   11328:"assets/minecraft/textures/block/jungle_planks.png",
-                   11329:"assets/minecraft/textures/block/acacia_planks.png",
-                   11330:"assets/minecraft/textures/block/dark_oak_planks.png"
+    texturepath = {77:blocks_path + "stone.png",
+                   143:blocks_path + "oak_planks.png",
+                   11326:blocks_path + "spruce_planks.png",
+                   11327:blocks_path + "birch_planks.png",
+                   11328:blocks_path + "jungle_planks.png",
+                   11329:blocks_path + "acacia_planks.png",
+                   11330:blocks_path + "dark_oak_planks.png"
                   }[blockid]
     t = self.load_image_texture(texturepath).copy()
 
@@ -2903,7 +2905,7 @@ def buttons(self, blockid, data):
 def snow(self, blockid, data):
     # still not rendered correctly: data other than 0
     
-    tex = self.load_image_texture("assets/minecraft/textures/block/snow.png")
+    tex = self.load_image_texture(blocks_path + "snow.png")
     
     # make the side image, top 3/4 transparent
     mask = tex.crop((0,12,16,16))
@@ -2923,13 +2925,13 @@ def snow(self, blockid, data):
     return img
 
 # snow block
-block(blockid=80, top_image="assets/minecraft/textures/block/snow.png")
+block(blockid=80, top_image=blocks_path + "snow.png")
 
 # cactus
 @material(blockid=81, data=range(15), transparent=True, solid=True, nospawn=True)
 def cactus(self, blockid, data):
-    top = self.load_image_texture("assets/minecraft/textures/block/cactus_top.png")
-    side = self.load_image_texture("assets/minecraft/textures/block/cactus_side.png")
+    top = self.load_image_texture(blocks_path + "cactus_top.png")
+    side = self.load_image_texture(blocks_path + "cactus_side.png")
 
     img = Image.new("RGBA", (24,24), self.bgcolor)
     
@@ -2951,18 +2953,18 @@ def cactus(self, blockid, data):
     return img
 
 # clay block
-block(blockid=82, top_image="assets/minecraft/textures/block/clay.png")
+block(blockid=82, top_image=blocks_path + "clay.png")
 
 # sugar cane
 @material(blockid=83, data=range(16), transparent=True)
 def sugar_cane(self, blockid, data):
-    tex = self.load_image_texture("assets/minecraft/textures/block/sugar_cane.png")
+    tex = self.load_image_texture(blocks_path + "sugar_cane.png")
     return self.build_sprite(tex)
 
 # jukebox
 @material(blockid=84, data=range(16), solid=True)
 def jukebox(self, blockid, data):
-    return self.build_block(self.load_image_texture("assets/minecraft/textures/block/jukebox_top.png"), self.load_image_texture("assets/minecraft/textures/block/note_block.png"))
+    return self.build_block(self.load_image_texture(blocks_path + "jukebox_top.png"), self.load_image_texture(blocks_path + "note_block.png"))
 
 # nether and normal fences
 # uses pseudo-ancildata found in iterate.c
@@ -2971,33 +2973,33 @@ def fence(self, blockid, data):
     # no need for rotations, it uses pseudo data.
     # create needed images for Big stick fence
     if blockid == 85: # normal fence
-        fence_top = self.load_image_texture("assets/minecraft/textures/block/oak_planks.png").copy()
-        fence_side = self.load_image_texture("assets/minecraft/textures/block/oak_planks.png").copy()
-        fence_small_side = self.load_image_texture("assets/minecraft/textures/block/oak_planks.png").copy()
+        fence_top = self.load_image_texture(blocks_path + "oak_planks.png").copy()
+        fence_side = self.load_image_texture(blocks_path + "oak_planks.png").copy()
+        fence_small_side = self.load_image_texture(blocks_path + "oak_planks.png").copy()
     elif blockid == 188: # spruce fence
-        fence_top = self.load_image_texture("assets/minecraft/textures/block/spruce_planks.png").copy()
-        fence_side = self.load_image_texture("assets/minecraft/textures/block/spruce_planks.png").copy()
-        fence_small_side = self.load_image_texture("assets/minecraft/textures/block/spruce_planks.png").copy()
+        fence_top = self.load_image_texture(blocks_path + "spruce_planks.png").copy()
+        fence_side = self.load_image_texture(blocks_path + "spruce_planks.png").copy()
+        fence_small_side = self.load_image_texture(blocks_path + "spruce_planks.png").copy()
     elif blockid == 189: # birch fence
-        fence_top = self.load_image_texture("assets/minecraft/textures/block/birch_planks.png").copy()
-        fence_side = self.load_image_texture("assets/minecraft/textures/block/birch_planks.png").copy()
-        fence_small_side = self.load_image_texture("assets/minecraft/textures/block/birch_planks.png").copy()
+        fence_top = self.load_image_texture(blocks_path + "birch_planks.png").copy()
+        fence_side = self.load_image_texture(blocks_path + "birch_planks.png").copy()
+        fence_small_side = self.load_image_texture(blocks_path + "birch_planks.png").copy()
     elif blockid == 190: # jungle fence
-        fence_top = self.load_image_texture("assets/minecraft/textures/block/jungle_planks.png").copy()
-        fence_side = self.load_image_texture("assets/minecraft/textures/block/jungle_planks.png").copy()
-        fence_small_side = self.load_image_texture("assets/minecraft/textures/block/jungle_planks.png").copy()
+        fence_top = self.load_image_texture(blocks_path + "jungle_planks.png").copy()
+        fence_side = self.load_image_texture(blocks_path + "jungle_planks.png").copy()
+        fence_small_side = self.load_image_texture(blocks_path + "jungle_planks.png").copy()
     elif blockid == 191: # big/dark oak fence
-        fence_top = self.load_image_texture("assets/minecraft/textures/block/dark_oak_planks.png").copy()
-        fence_side = self.load_image_texture("assets/minecraft/textures/block/dark_oak_planks.png").copy()
-        fence_small_side = self.load_image_texture("assets/minecraft/textures/block/dark_oak_planks.png").copy()
+        fence_top = self.load_image_texture(blocks_path + "dark_oak_planks.png").copy()
+        fence_side = self.load_image_texture(blocks_path + "dark_oak_planks.png").copy()
+        fence_small_side = self.load_image_texture(blocks_path + "dark_oak_planks.png").copy()
     elif blockid == 192: # acacia oak fence
-        fence_top = self.load_image_texture("assets/minecraft/textures/block/acacia_planks.png").copy()
-        fence_side = self.load_image_texture("assets/minecraft/textures/block/acacia_planks.png").copy()
-        fence_small_side = self.load_image_texture("assets/minecraft/textures/block/acacia_planks.png").copy()
+        fence_top = self.load_image_texture(blocks_path + "acacia_planks.png").copy()
+        fence_side = self.load_image_texture(blocks_path + "acacia_planks.png").copy()
+        fence_small_side = self.load_image_texture(blocks_path + "acacia_planks.png").copy()
     else: # netherbrick fence
-        fence_top = self.load_image_texture("assets/minecraft/textures/block/nether_bricks.png").copy()
-        fence_side = self.load_image_texture("assets/minecraft/textures/block/nether_bricks.png").copy()
-        fence_small_side = self.load_image_texture("assets/minecraft/textures/block/nether_bricks.png").copy()
+        fence_top = self.load_image_texture(blocks_path + "nether_bricks.png").copy()
+        fence_side = self.load_image_texture(blocks_path + "nether_bricks.png").copy()
+        fence_small_side = self.load_image_texture(blocks_path + "nether_bricks.png").copy()
 
     # generate the textures of the fence
     ImageDraw.Draw(fence_top).rectangle((0,0,5,15),outline=(0,0,0,0),fill=(0,0,0,0))
@@ -3102,13 +3104,13 @@ def pumpkin(self, blockid, data): # pumpkins, jack-o-lantern
         elif data == 3: data = 2
     
     # texture generation
-    top = self.load_image_texture("assets/minecraft/textures/block/pumpkin_top.png")
-    frontName = {86: "assets/minecraft/textures/block/pumpkin_side.png",
-                 91: "assets/minecraft/textures/block/jack_o_lantern.png",
-                 11300: "assets/minecraft/textures/block/carved_pumpkin.png"
+    top = self.load_image_texture(blocks_path + "pumpkin_top.png")
+    frontName = {86: blocks_path + "pumpkin_side.png",
+                 91: blocks_path + "jack_o_lantern.png",
+                 11300: blocks_path + "carved_pumpkin.png"
                 }[blockid]
     front = self.load_image_texture(frontName)
-    side = self.load_image_texture("assets/minecraft/textures/block/pumpkin_side.png")
+    side = self.load_image_texture(blocks_path + "pumpkin_side.png")
 
     if data == 0: # pointing west
         img = self.build_full_block(top, None, None, side, front)
@@ -3122,13 +3124,13 @@ def pumpkin(self, blockid, data): # pumpkins, jack-o-lantern
     return img
 
 # netherrack
-block(blockid=87, top_image="assets/minecraft/textures/block/netherrack.png")
+block(blockid=87, top_image=blocks_path + "netherrack.png")
 
 # soul sand
-block(blockid=88, top_image="assets/minecraft/textures/block/soul_sand.png")
+block(blockid=88, top_image=blocks_path + "soul_sand.png")
 
 # glowstone
-block(blockid=89, top_image="assets/minecraft/textures/block/glowstone.png")
+block(blockid=89, top_image=blocks_path + "glowstone.png")
 
 # portal
 @material(blockid=90, data=[1, 2, 4, 5, 8, 10], transparent=True)
@@ -3153,10 +3155,10 @@ def portal(self, blockid, data):
 def cake(self, blockid, data):
     
     # cake textures
-    top = self.load_image_texture("assets/minecraft/textures/block/cake_top.png").copy()
-    side = self.load_image_texture("assets/minecraft/textures/block/cake_side.png").copy()
+    top = self.load_image_texture(blocks_path + "cake_top.png").copy()
+    side = self.load_image_texture(blocks_path + "cake_side.png").copy()
     fullside = side.copy()
-    inside = self.load_image_texture("assets/minecraft/textures/block/cake_inner.png")
+    inside = self.load_image_texture(blocks_path + "cake_inner.png")
     
     img = Image.new("RGBA", (24,24), self.bgcolor)
     if data == 0: # unbitten cake
@@ -3294,8 +3296,8 @@ def repeater(self, blockid, data):
         elif (data & 0b0011) == 3: data = data & 0b1100 | 2
     
     # generate the diode
-    top = self.load_image_texture("assets/minecraft/textures/block/repeater.png") if blockid == 93 else self.load_image_texture("assets/minecraft/textures/block/repeater_on.png")
-    side = self.load_image_texture("assets/minecraft/textures/block/stone_slab_side.png")
+    top = self.load_image_texture(blocks_path + "repeater.png") if blockid == 93 else self.load_image_texture(blocks_path + "repeater_on.png")
+    side = self.load_image_texture(blocks_path + "stone_slab_side.png")
     increment = 13
     
     if (data & 0x3) == 0: # pointing east
@@ -3313,7 +3315,7 @@ def repeater(self, blockid, data):
     img = self.build_full_block( (top, increment), None, None, side, side)
 
     # compose a "3d" redstone torch
-    t = self.load_image_texture("assets/minecraft/textures/block/redstone_torch_off.png").copy() if blockid == 93 else self.load_image_texture("assets/minecraft/textures/block/redstone_torch.png").copy()
+    t = self.load_image_texture(blocks_path + "redstone_torch_off.png").copy() if blockid == 93 else self.load_image_texture(blocks_path + "redstone_torch.png").copy()
     torch = Image.new("RGBA", (24,24), self.bgcolor)
     
     t_crop = t.crop((2,2,14,14))
@@ -3426,8 +3428,8 @@ def comparator(self, blockid, data):
     data = data & 0b1100 | (((data & 0b11) + self.rotation) % 4)
 
 
-    top = self.load_image_texture("assets/minecraft/textures/block/comparator.png") if blockid == 149 else self.load_image_texture("assets/minecraft/textures/block/comparator_on.png")
-    side = self.load_image_texture("assets/minecraft/textures/block/stone_slab_side.png")
+    top = self.load_image_texture(blocks_path + "comparator.png") if blockid == 149 else self.load_image_texture(blocks_path + "comparator_on.png")
+    side = self.load_image_texture(blocks_path + "stone_slab_side.png")
     increment = 13
 
     if (data & 0x3) == 0: # pointing north
@@ -3453,7 +3455,7 @@ def comparator(self, blockid, data):
 
     def build_torch(active):
         # compose a "3d" redstone torch
-        t = self.load_image_texture("assets/minecraft/textures/block/redstone_torch_off.png").copy() if not active else self.load_image_texture("assets/minecraft/textures/block/redstone_torch.png").copy()
+        t = self.load_image_texture(blocks_path + "redstone_torch_off.png").copy() if not active else self.load_image_texture(blocks_path + "redstone_torch.png").copy()
         torch = Image.new("RGBA", (24,24), self.bgcolor)
         
         t_crop = t.crop((2,2,14,14))
@@ -3505,13 +3507,13 @@ def trapdoor(self, blockid, data):
         elif (data & 0b0011) == 3: data = data & 0b1100 | 0
 
     # texture generation
-    texturepath = {96:"assets/minecraft/textures/block/oak_trapdoor.png",
-                   167:"assets/minecraft/textures/block/iron_trapdoor.png",
-                   11332:"assets/minecraft/textures/block/spruce_trapdoor.png",
-                   11333:"assets/minecraft/textures/block/birch_trapdoor.png",
-                   11334:"assets/minecraft/textures/block/jungle_trapdoor.png",
-                   11335:"assets/minecraft/textures/block/acacia_trapdoor.png",
-                   11336:"assets/minecraft/textures/block/dark_oak_trapdoor.png"
+    texturepath = {96:blocks_path + "oak_trapdoor.png",
+                   167:blocks_path + "iron_trapdoor.png",
+                   11332:blocks_path + "spruce_trapdoor.png",
+                   11333:blocks_path + "birch_trapdoor.png",
+                   11334:blocks_path + "jungle_trapdoor.png",
+                   11335:blocks_path + "acacia_trapdoor.png",
+                   11336:blocks_path + "dark_oak_trapdoor.png"
                   }[blockid]
 
     if data & 0x4 == 0x4: # opened trapdoor
@@ -3542,11 +3544,11 @@ def trapdoor(self, blockid, data):
 @material(blockid=97, data=range(3), solid=True)
 def hidden_silverfish(self, blockid, data):
     if data == 0: # stone
-        t = self.load_image_texture("assets/minecraft/textures/block/stone.png")
+        t = self.load_image_texture(blocks_path + "stone.png")
     elif data == 1: # cobblestone
-        t = self.load_image_texture("assets/minecraft/textures/block/cobblestone.png")
+        t = self.load_image_texture(blocks_path + "cobblestone.png")
     elif data == 2: # stone brick
-        t = self.load_image_texture("assets/minecraft/textures/block/stone_bricks.png")
+        t = self.load_image_texture(blocks_path + "stone_bricks.png")
     
     img = self.build_block(t, t)
     
@@ -3556,13 +3558,13 @@ def hidden_silverfish(self, blockid, data):
 @material(blockid=98, data=range(4), solid=True)
 def stone_brick(self, blockid, data):
     if data == 0: # normal
-        t = self.load_image_texture("assets/minecraft/textures/block/stone_bricks.png")
+        t = self.load_image_texture(blocks_path + "stone_bricks.png")
     elif data == 1: # mossy
-        t = self.load_image_texture("assets/minecraft/textures/block/mossy_stone_bricks.png")
+        t = self.load_image_texture(blocks_path + "mossy_stone_bricks.png")
     elif data == 2: # cracked
-        t = self.load_image_texture("assets/minecraft/textures/block/cracked_stone_bricks.png")
+        t = self.load_image_texture(blocks_path + "cracked_stone_bricks.png")
     elif data == 3: # "circle" stone brick
-        t = self.load_image_texture("assets/minecraft/textures/block/chiseled_stone_bricks.png")
+        t = self.load_image_texture(blocks_path + "chiseled_stone_bricks.png")
 
     img = self.build_full_block(t, None, None, t, t)
 
@@ -3602,12 +3604,12 @@ def huge_mushroom(self, blockid, data):
 
     # texture generation
     if blockid == 99: # brown
-        cap = self.load_image_texture("assets/minecraft/textures/block/brown_mushroom_block.png")
+        cap = self.load_image_texture(blocks_path + "brown_mushroom_block.png")
     else: # red
-        cap = self.load_image_texture("assets/minecraft/textures/block/red_mushroom_block.png")
+        cap = self.load_image_texture(blocks_path + "red_mushroom_block.png")
 
-    stem = self.load_image_texture("assets/minecraft/textures/block/mushroom_stem.png")
-    porous = self.load_image_texture("assets/minecraft/textures/block/mushroom_block_inside.png")
+    stem = self.load_image_texture(blocks_path + "mushroom_stem.png")
+    porous = self.load_image_texture(blocks_path + "mushroom_block_inside.png")
     
     if data == 0: # fleshy piece
         img = self.build_full_block(porous, None, None, porous, porous)
@@ -3658,12 +3660,12 @@ def panes(self, blockid, data):
     # no rotation, uses pseudo data
     if blockid == 101:
         # iron bars
-        t = self.load_image_texture("assets/minecraft/textures/block/iron_bars.png")
+        t = self.load_image_texture(blocks_path + "iron_bars.png")
     elif blockid == 160:
-        t = self.load_image_texture("assets/minecraft/textures/block/%s_stained_glass.png" % color_map[data & 0xf])
+        t = self.load_image_texture(blocks_path + "%s_stained_glass.png" % color_map[data & 0xf])
     else:
         # glass panes
-        t = self.load_image_texture("assets/minecraft/textures/block/glass.png")
+        t = self.load_image_texture(blocks_path + "glass.png")
     left = t.copy()
     right = t.copy()
 
@@ -3699,7 +3701,7 @@ def panes(self, blockid, data):
     return img
 
 # melon
-block(blockid=103, top_image="assets/minecraft/textures/block/melon_top.png", side_image="assets/minecraft/textures/block/melon_side.png", solid=True)
+block(blockid=103, top_image=blocks_path + "melon_top.png", side_image=blocks_path + "melon_side.png", solid=True)
 
 # pumpkin and melon stem
 # TODO To render it as in game needs from pseudo data and ancil data:
@@ -3712,7 +3714,7 @@ def stem(self, blockid, data):
 
     # not fully grown stem or no pumpkin/melon touching it,
     # straight up stem
-    t = self.load_image_texture("assets/minecraft/textures/block/melon_stem.png").copy()
+    t = self.load_image_texture(blocks_path + "melon_stem.png").copy()
     img = Image.new("RGBA", (16,16), self.bgcolor)
     alpha_over(img, t, (0, int(16 - 16*((data + 1)/8.))), t)
     img = self.build_sprite(t)
@@ -3748,7 +3750,7 @@ def vines(self, blockid, data):
             data = (data - 16) | 1
 
     # decode data and prepare textures
-    raw_texture = self.load_image_texture("assets/minecraft/textures/block/vine.png")
+    raw_texture = self.load_image_texture(blocks_path + "vine.png")
     s = w = n = e = None
 
     if data & 1: # south
@@ -3794,17 +3796,17 @@ def fence_gate(self, blockid, data):
 
     # create the closed gate side
     if blockid == 107: # Oak
-        gate_side = self.load_image_texture("assets/minecraft/textures/block/oak_planks.png").copy()
+        gate_side = self.load_image_texture(blocks_path + "oak_planks.png").copy()
     elif blockid == 183: # Spruce
-        gate_side = self.load_image_texture("assets/minecraft/textures/block/spruce_planks.png").copy()
+        gate_side = self.load_image_texture(blocks_path + "spruce_planks.png").copy()
     elif blockid == 184: # Birch
-        gate_side = self.load_image_texture("assets/minecraft/textures/block/birch_planks.png").copy()
+        gate_side = self.load_image_texture(blocks_path + "birch_planks.png").copy()
     elif blockid == 185: # Jungle
-        gate_side = self.load_image_texture("assets/minecraft/textures/block/jungle_planks.png").copy()
+        gate_side = self.load_image_texture(blocks_path + "jungle_planks.png").copy()
     elif blockid == 186: # Dark Oak
-        gate_side = self.load_image_texture("assets/minecraft/textures/block/dark_oak_planks.png").copy()
+        gate_side = self.load_image_texture(blocks_path + "dark_oak_planks.png").copy()
     elif blockid == 187: # Acacia
-        gate_side = self.load_image_texture("assets/minecraft/textures/block/acacia_planks.png").copy()
+        gate_side = self.load_image_texture(blocks_path + "acacia_planks.png").copy()
     else:
         return None
 
@@ -3864,7 +3866,7 @@ def fence_gate(self, blockid, data):
     return img
 
 # mycelium
-block(blockid=110, top_image="assets/minecraft/textures/block/mycelium_top.png", side_image="assets/minecraft/textures/block/mycelium_side.png")
+block(blockid=110, top_image=blocks_path + "mycelium_top.png", side_image=blocks_path + "mycelium_side.png")
 
 # lilypad
 # At the moment of writing this lilypads has no ancil data and their
@@ -3872,7 +3874,7 @@ block(blockid=110, top_image="assets/minecraft/textures/block/mycelium_top.png",
 # ancildata.
 @material(blockid=111, data=range(4), transparent=True)
 def lilypad(self, blockid, data):
-    t = self.load_image_texture("assets/minecraft/textures/block/lily_pad.png").copy()
+    t = self.load_image_texture(blocks_path + "lily_pad.png").copy()
     if data == 0:
         t = t.rotate(180)
     elif data == 1:
@@ -3885,17 +3887,17 @@ def lilypad(self, blockid, data):
     return self.build_full_block(None, None, None, None, None, t)
 
 # nether brick
-block(blockid=112, top_image="assets/minecraft/textures/block/nether_bricks.png")
+block(blockid=112, top_image=blocks_path + "nether_bricks.png")
 
 # nether wart
 @material(blockid=115, data=range(4), transparent=True)
 def nether_wart(self, blockid, data):
     if data == 0: # just come up
-        t = self.load_image_texture("assets/minecraft/textures/block/nether_wart_stage0.png")
+        t = self.load_image_texture(blocks_path + "nether_wart_stage0.png")
     elif data in (1, 2):
-        t = self.load_image_texture("assets/minecraft/textures/block/nether_wart_stage1.png")
+        t = self.load_image_texture(blocks_path + "nether_wart_stage1.png")
     else: # fully grown
-        t = self.load_image_texture("assets/minecraft/textures/block/nether_wart_stage2.png")
+        t = self.load_image_texture(blocks_path + "nether_wart_stage2.png")
     
     # use the same technic as tall grass
     img = self.build_billboard(t)
@@ -3907,8 +3909,8 @@ def nether_wart(self, blockid, data):
 @material(blockid=116, transparent=True, nodata=True)
 def enchantment_table(self, blockid, data):
     # no book at the moment
-    top = self.load_image_texture("assets/minecraft/textures/block/enchanting_table_top.png")
-    side = self.load_image_texture("assets/minecraft/textures/block/enchanting_table_side.png")
+    top = self.load_image_texture(blocks_path + "enchanting_table_top.png")
+    side = self.load_image_texture(blocks_path + "enchanting_table_side.png")
     img = self.build_full_block((top, 4), None, None, side, side)
 
     return img
@@ -3917,9 +3919,9 @@ def enchantment_table(self, blockid, data):
 # TODO this is a place holder, is a 2d image pasted
 @material(blockid=117, data=range(5), transparent=True)
 def brewing_stand(self, blockid, data):
-    base = self.load_image_texture("assets/minecraft/textures/block/brewing_stand_base.png")
+    base = self.load_image_texture(blocks_path + "brewing_stand_base.png")
     img = self.build_full_block(None, None, None, None, None, base)
-    t = self.load_image_texture("assets/minecraft/textures/block/brewing_stand.png")
+    t = self.load_image_texture(blocks_path + "brewing_stand.png")
     stand = self.build_billboard(t)
     alpha_over(img,stand,(0,-2))
     return img
@@ -3927,9 +3929,9 @@ def brewing_stand(self, blockid, data):
 # cauldron
 @material(blockid=118, data=range(4), transparent=True)
 def cauldron(self, blockid, data):
-    side = self.load_image_texture("assets/minecraft/textures/block/cauldron_side.png")
-    top = self.load_image_texture("assets/minecraft/textures/block/cauldron_top.png")
-    bottom = self.load_image_texture("assets/minecraft/textures/block/cauldron_inner.png")
+    side = self.load_image_texture(blocks_path + "cauldron_side.png")
+    top = self.load_image_texture(blocks_path + "cauldron_top.png")
+    bottom = self.load_image_texture(blocks_path + "cauldron_inner.png")
     water = self.transform_image_top(self.load_water())
     if data == 0: # empty
         img = self.build_full_block(top, side, side, side, side)
@@ -3975,14 +3977,14 @@ def end_portal(self, blockid, data):
 def end_portal_frame(self, blockid, data):
     # The bottom 2 bits are oritation info but seems there is no
     # graphical difference between orientations
-    top = self.load_image_texture("assets/minecraft/textures/block/end_portal_frame_top.png")
-    eye_t = self.load_image_texture("assets/minecraft/textures/block/end_portal_frame_eye.png")
-    side = self.load_image_texture("assets/minecraft/textures/block/end_portal_frame_side.png")
+    top = self.load_image_texture(blocks_path + "end_portal_frame_top.png")
+    eye_t = self.load_image_texture(blocks_path + "end_portal_frame_eye.png")
+    side = self.load_image_texture(blocks_path + "end_portal_frame_side.png")
     img = self.build_full_block((top, 4), None, None, side, side)
     if data & 0x4 == 0x4: # ender eye on it
         # generate the eye
-        eye_t = self.load_image_texture("assets/minecraft/textures/block/end_portal_frame_eye.png").copy()
-        eye_t_s = self.load_image_texture("assets/minecraft/textures/block/end_portal_frame_eye.png").copy()
+        eye_t = self.load_image_texture(blocks_path + "end_portal_frame_eye.png").copy()
+        eye_t_s = self.load_image_texture(blocks_path + "end_portal_frame_eye.png").copy()
         # cut out from the texture the side and the top of the eye
         ImageDraw.Draw(eye_t).rectangle((0,0,15,4),outline=(0,0,0,0),fill=(0,0,0,0))
         ImageDraw.Draw(eye_t_s).rectangle((0,4,15,15),outline=(0,0,0,0),fill=(0,0,0,0))
@@ -3997,26 +3999,26 @@ def end_portal_frame(self, blockid, data):
     return img
 
 # end stone
-block(blockid=121, top_image="assets/minecraft/textures/block/end_stone.png")
+block(blockid=121, top_image=blocks_path + "end_stone.png")
 
 # dragon egg
 # NOTE: this isn't a block, but I think it's better than nothing
-block(blockid=122, top_image="assets/minecraft/textures/block/dragon_egg.png")
+block(blockid=122, top_image=blocks_path + "dragon_egg.png")
 
 # inactive redstone lamp
-block(blockid=123, top_image="assets/minecraft/textures/block/redstone_lamp.png")
+block(blockid=123, top_image=blocks_path + "redstone_lamp.png")
 
 # active redstone lamp
-block(blockid=124, top_image="assets/minecraft/textures/block/redstone_lamp_on.png")
+block(blockid=124, top_image=blocks_path + "redstone_lamp_on.png")
 
 # daylight sensor.  
 @material(blockid=[151,178], transparent=True)
 def daylight_sensor(self, blockid, data):
     if blockid == 151: # daylight sensor
-        top = self.load_image_texture("assets/minecraft/textures/block/daylight_detector_top.png")
+        top = self.load_image_texture(blocks_path + "daylight_detector_top.png")
     else: # inverted daylight sensor
-        top = self.load_image_texture("assets/minecraft/textures/block/daylight_detector_inverted_top.png")
-    side = self.load_image_texture("assets/minecraft/textures/block/daylight_detector_side.png")
+        top = self.load_image_texture(blocks_path + "daylight_detector_inverted_top.png")
+    side = self.load_image_texture(blocks_path + "daylight_detector_side.png")
 
     # cut the side texture in half
     mask = side.crop((0,8,16,16))
@@ -4050,17 +4052,17 @@ def daylight_sensor(self, blockid, data):
 def wooden_slabs(self, blockid, data):
     texture = data & 7
     if texture== 0: # oak 
-        top = side = self.load_image_texture("assets/minecraft/textures/block/oak_planks.png")
+        top = side = self.load_image_texture(blocks_path + "oak_planks.png")
     elif texture== 1: # spruce
-        top = side = self.load_image_texture("assets/minecraft/textures/block/spruce_planks.png")
+        top = side = self.load_image_texture(blocks_path + "spruce_planks.png")
     elif texture== 2: # birch
-        top = side = self.load_image_texture("assets/minecraft/textures/block/birch_planks.png")
+        top = side = self.load_image_texture(blocks_path + "birch_planks.png")
     elif texture== 3: # jungle
-        top = side = self.load_image_texture("assets/minecraft/textures/block/jungle_planks.png")
+        top = side = self.load_image_texture(blocks_path + "jungle_planks.png")
     elif texture== 4: # acacia
-        top = side = self.load_image_texture("assets/minecraft/textures/block/acacia_planks.png")
+        top = side = self.load_image_texture(blocks_path + "acacia_planks.png")
     elif texture== 5: # dark wood
-        top = side = self.load_image_texture("assets/minecraft/textures/block/dark_oak_planks.png")
+        top = side = self.load_image_texture(blocks_path + "dark_oak_planks.png")
     else:
         return None
     
@@ -4070,10 +4072,10 @@ def wooden_slabs(self, blockid, data):
     return self.build_slab_block(top, side, data & 8 == 8);
 
 # emerald ore
-block(blockid=129, top_image="assets/minecraft/textures/block/emerald_ore.png")
+block(blockid=129, top_image=blocks_path + "emerald_ore.png")
 
 # emerald block
-block(blockid=133, top_image="assets/minecraft/textures/block/emerald_block.png")
+block(blockid=133, top_image=blocks_path + "emerald_block.png")
 
 # cocoa plant
 @material(blockid=127, data=range(12), transparent=True)
@@ -4098,17 +4100,17 @@ def cocoa_plant(self, blockid, data):
 
     size = data & 12
     if size == 8: # big
-        t = self.load_image_texture("assets/minecraft/textures/block/cocoa_stage2.png")
+        t = self.load_image_texture(blocks_path + "cocoa_stage2.png")
         c_left = (0,3)
         c_right = (8,3)
         c_top = (5,2)
     elif size == 4: # normal
-        t = self.load_image_texture("assets/minecraft/textures/block/cocoa_stage1.png")
+        t = self.load_image_texture(blocks_path + "cocoa_stage1.png")
         c_left = (-2,2)
         c_right = (8,2)
         c_top = (5,2)
     elif size == 0: # small
-        t = self.load_image_texture("assets/minecraft/textures/block/cocoa_stage0.png")
+        t = self.load_image_texture(blocks_path + "cocoa_stage0.png")
         c_left = (-3,2)
         c_right = (6,2)
         c_top = (5,2)
@@ -4160,17 +4162,17 @@ def cocoa_plant(self, blockid, data):
 @material(blockid=[137,210,211], solid=True, nodata=True)
 def command_block(self, blockid, data):
     if blockid == 210:
-        front = self.load_image_texture("assets/minecraft/textures/block/repeating_command_block_front.png")
-        side = self.load_image_texture("assets/minecraft/textures/block/repeating_command_block_side.png")
-        back = self.load_image_texture("assets/minecraft/textures/block/repeating_command_block_back.png")
+        front = self.load_image_texture(blocks_path + "repeating_command_block_front.png")
+        side = self.load_image_texture(blocks_path + "repeating_command_block_side.png")
+        back = self.load_image_texture(blocks_path + "repeating_command_block_back.png")
     elif blockid == 211:
-        front = self.load_image_texture("assets/minecraft/textures/block/chain_command_block_front.png")
-        side = self.load_image_texture("assets/minecraft/textures/block/chain_command_block_side.png")
-        back = self.load_image_texture("assets/minecraft/textures/block/chain_command_block_back.png")
+        front = self.load_image_texture(blocks_path + "chain_command_block_front.png")
+        side = self.load_image_texture(blocks_path + "chain_command_block_side.png")
+        back = self.load_image_texture(blocks_path + "chain_command_block_back.png")
     else:
-        front = self.load_image_texture("assets/minecraft/textures/block/command_block_front.png")
-        side = self.load_image_texture("assets/minecraft/textures/block/command_block_side.png")
-        back = self.load_image_texture("assets/minecraft/textures/block/command_block_back.png")
+        front = self.load_image_texture(blocks_path + "command_block_front.png")
+        side = self.load_image_texture(blocks_path + "command_block_side.png")
+        back = self.load_image_texture(blocks_path + "command_block_back.png")
     return self.build_full_block(side, side, back, front, side)
 
 # beacon block
@@ -4179,12 +4181,12 @@ def command_block(self, blockid, data):
 @material(blockid=138, transparent=True, nodata = True)
 def beacon(self, blockid, data):
     # generate the three pieces of the block
-    t = self.load_image_texture("assets/minecraft/textures/block/glass.png")
+    t = self.load_image_texture(blocks_path + "glass.png")
     glass = self.build_block(t,t)
-    t = self.load_image_texture("assets/minecraft/textures/block/obsidian.png")
+    t = self.load_image_texture(blocks_path + "obsidian.png")
     obsidian = self.build_full_block((t,12),None, None, t, t)
     obsidian = obsidian.resize((20,20), Image.ANTIALIAS)
-    t = self.load_image_texture("assets/minecraft/textures/block/beacon.png")
+    t = self.load_image_texture(blocks_path + "beacon.png")
     crystal = self.build_block(t,t)
     crystal = crystal.resize((16,16),Image.ANTIALIAS)
     
@@ -4202,14 +4204,14 @@ def beacon(self, blockid, data):
 def cobblestone_wall(self, blockid, data):
     # chorus plants
     if blockid == 199:
-        t = self.load_image_texture("assets/minecraft/textures/block/chorus_plant.png").copy()
+        t = self.load_image_texture(blocks_path + "chorus_plant.png").copy()
     # no rotation, uses pseudo data
     elif data & 0b10000 == 0:
         # cobblestone
-        t = self.load_image_texture("assets/minecraft/textures/block/cobblestone.png").copy()
+        t = self.load_image_texture(blocks_path + "cobblestone.png").copy()
     else:
         # mossy cobblestone
-        t = self.load_image_texture("assets/minecraft/textures/block/mossy_cobblestone.png").copy()
+        t = self.load_image_texture(blocks_path + "mossy_cobblestone.png").copy()
 
     wall_pole_top = t.copy()
     wall_pole_side = t.copy()
@@ -4341,9 +4343,9 @@ def crops4(self, blockid, data):
              6:2,
              7:3}[data]
     if blockid == 141: # carrots
-        raw_crop = self.load_image_texture("assets/minecraft/textures/block/carrots_stage%d.png" % stage)
+        raw_crop = self.load_image_texture(blocks_path + "carrots_stage%d.png" % stage)
     else: # potatoes
-        raw_crop = self.load_image_texture("assets/minecraft/textures/block/potatoes_stage%d.png" % stage)
+        raw_crop = self.load_image_texture(blocks_path + "potatoes_stage%d.png" % stage)
     crop1 = self.transform_image_top(raw_crop)
     crop2 = self.transform_image_side(raw_crop)
     crop3 = crop2.transpose(Image.FLIP_LEFT_RIGHT)
@@ -4369,16 +4371,16 @@ def anvil(self, blockid, data):
     # get the correct textures
     # the bits 0x4 and 0x8 determine how damaged is the anvil
     if (data & 0xc) == 0: # non damaged anvil
-        top = self.load_image_texture("assets/minecraft/textures/block/anvil_top.png")
+        top = self.load_image_texture(blocks_path + "anvil_top.png")
     elif (data & 0xc) == 0x4: # slightly damaged
-        top = self.load_image_texture("assets/minecraft/textures/block/chipped_anvil_top.png")
+        top = self.load_image_texture(blocks_path + "chipped_anvil_top.png")
     elif (data & 0xc) == 0x8: # very damaged
-        top = self.load_image_texture("assets/minecraft/textures/block/damaged_anvil_top.png")
+        top = self.load_image_texture(blocks_path + "damaged_anvil_top.png")
     # everything else use this texture
-    big_side = self.load_image_texture("assets/minecraft/textures/block/anvil.png").copy()
-    small_side = self.load_image_texture("assets/minecraft/textures/block/anvil.png").copy()
-    base = self.load_image_texture("assets/minecraft/textures/block/anvil.png").copy()
-    small_base = self.load_image_texture("assets/minecraft/textures/block/anvil.png").copy()
+    big_side = self.load_image_texture(blocks_path + "anvil.png").copy()
+    small_side = self.load_image_texture(blocks_path + "anvil.png").copy()
+    base = self.load_image_texture(blocks_path + "anvil.png").copy()
+    small_base = self.load_image_texture(blocks_path + "anvil.png").copy()
     
     # cut needed patterns
     ImageDraw.Draw(big_side).rectangle((0,8,15,15),outline=(0,0,0,0),fill=(0,0,0,0))
@@ -4441,10 +4443,10 @@ def anvil(self, blockid, data):
 
 
 # block of redstone
-block(blockid=152, top_image="assets/minecraft/textures/block/redstone_block.png")
+block(blockid=152, top_image=blocks_path + "redstone_block.png")
 
 # nether quartz ore
-block(blockid=153, top_image="assets/minecraft/textures/block/nether_quartz_ore.png")
+block(blockid=153, top_image=blocks_path + "nether_quartz_ore.png")
 
 # block of quartz
 @material(blockid=155, data=range(5), solid=True)
@@ -4452,16 +4454,16 @@ def quartz_block(self, blockid, data):
     
     if data in (0,1): # normal and chiseled quartz block
         if data == 0:
-            top = self.load_image_texture("assets/minecraft/textures/block/quartz_block_top.png")
-            side = self.load_image_texture("assets/minecraft/textures/block/quartz_block_side.png")
+            top = self.load_image_texture(blocks_path + "quartz_block_top.png")
+            side = self.load_image_texture(blocks_path + "quartz_block_side.png")
         else:
-            top = self.load_image_texture("assets/minecraft/textures/block/chiseled_quartz_block_top.png")
-            side = self.load_image_texture("assets/minecraft/textures/block/chiseled_quartz_block.png")
+            top = self.load_image_texture(blocks_path + "chiseled_quartz_block_top.png")
+            side = self.load_image_texture(blocks_path + "chiseled_quartz_block.png")
         return self.build_block(top, side)
     
     # pillar quartz block with orientation
-    top = self.load_image_texture("assets/minecraft/textures/block/quartz_pillar_top.png")
-    side = self.load_image_texture("assets/minecraft/textures/block/quartz_pillar.png").copy()
+    top = self.load_image_texture(blocks_path + "quartz_pillar_top.png")
+    side = self.load_image_texture(blocks_path + "quartz_pillar.png").copy()
     if data == 2: # vertical
         return self.build_block(top, side)
     elif data == 3: # north-south oriented
@@ -4478,9 +4480,9 @@ def quartz_block(self, blockid, data):
 @material(blockid=154, data=range(4), transparent=True)
 def hopper(self, blockid, data):
     #build the top
-    side = self.load_image_texture("assets/minecraft/textures/block/hopper_outside.png")
-    top = self.load_image_texture("assets/minecraft/textures/block/hopper_top.png")
-    bottom = self.load_image_texture("assets/minecraft/textures/block/hopper_inside.png")
+    side = self.load_image_texture(blocks_path + "hopper_outside.png")
+    top = self.load_image_texture(blocks_path + "hopper_top.png")
+    bottom = self.load_image_texture(blocks_path + "hopper_inside.png")
     hop_top = self.build_full_block((top,10), side, side, side, side, side)
 
     #build a solid block for mid/top
@@ -4499,31 +4501,31 @@ def hopper(self, blockid, data):
     return img
 
 # slime block
-block(blockid=165, top_image="assets/minecraft/textures/block/slime_block.png")
+block(blockid=165, top_image=blocks_path + "slime_block.png")
 
 # prismarine block
 @material(blockid=168, data=range(3), solid=True)
 def prismarine_block(self, blockid, data):
 
    if data == 0: # prismarine
-       t = self.load_image_texture("assets/minecraft/textures/block/prismarine.png")
+       t = self.load_image_texture(blocks_path + "prismarine.png")
    elif data == 1: # prismarine bricks
-       t = self.load_image_texture("assets/minecraft/textures/block/prismarine_bricks.png")
+       t = self.load_image_texture(blocks_path + "prismarine_bricks.png")
    elif data == 2: # dark prismarine
-       t = self.load_image_texture("assets/minecraft/textures/block/dark_prismarine.png")
+       t = self.load_image_texture(blocks_path + "dark_prismarine.png")
 
    img = self.build_block(t, t)
 
    return img
 
 # sea lantern 
-block(blockid=169, top_image="assets/minecraft/textures/block/sea_lantern.png")
+block(blockid=169, top_image=blocks_path + "sea_lantern.png")
 
 # hay block
 @material(blockid=170, data=range(9), solid=True)
 def hayblock(self, blockid, data):
-    top = self.load_image_texture("assets/minecraft/textures/block/hay_block_top.png")
-    side = self.load_image_texture("assets/minecraft/textures/block/hay_block_side.png")
+    top = self.load_image_texture(blocks_path + "hay_block_top.png")
+    side = self.load_image_texture(blocks_path + "hay_block_side.png")
 
     if self.rotation == 1:
         if data == 4: data = 8
@@ -4544,47 +4546,47 @@ def hayblock(self, blockid, data):
 # carpet - wool block that's small?
 @material(blockid=171, data=range(16), transparent=True)
 def carpet(self, blockid, data):
-    texture = self.load_image_texture("assets/minecraft/textures/block/%s_wool.png" % color_map[data])
+    texture = self.load_image_texture(blocks_path + "%s_wool.png" % color_map[data])
 
     return self.build_full_block((texture,15),texture,texture,texture,texture)
 
 #clay block
-block(blockid=172, top_image="assets/minecraft/textures/block/terracotta.png")
+block(blockid=172, top_image=blocks_path + "terracotta.png")
 
 #stained hardened clay
 @material(blockid=159, data=range(16), solid=True)
 def stained_clay(self, blockid, data):
-    texture = self.load_image_texture("assets/minecraft/textures/block/%s_terracotta.png" % color_map[data])
+    texture = self.load_image_texture(blocks_path + "%s_terracotta.png" % color_map[data])
 
     return self.build_block(texture,texture)
 
 #coal block
-block(blockid=173, top_image="assets/minecraft/textures/block/coal_block.png")
+block(blockid=173, top_image=blocks_path + "coal_block.png")
 
 # packed ice block
-block(blockid=174, top_image="assets/minecraft/textures/block/packed_ice.png")
+block(blockid=174, top_image=blocks_path + "packed_ice.png")
 
 #blue ice
-block(blockid=11312, top_image="assets/minecraft/textures/block/blue_ice.png")
+block(blockid=11312, top_image=blocks_path + "blue_ice.png")
 
 #smooth stones
-block(blockid=11313, top_image="assets/minecraft/textures/block/stone_slab_top.png") # stone
-block(blockid=11314, top_image="assets/minecraft/textures/block/sandstone_top.png") # sandstone
-block(blockid=11315, top_image="assets/minecraft/textures/block/red_sandstone_top.png") # red sandstone
+block(blockid=11313, top_image=blocks_path + "stone_slab_top.png") # stone
+block(blockid=11314, top_image=blocks_path + "sandstone_top.png") # sandstone
+block(blockid=11315, top_image=blocks_path + "red_sandstone_top.png") # red sandstone
 
 #coral blocks
-block(blockid=11316, top_image="assets/minecraft/textures/block/brain_coral_block.png")
-block(blockid=11317, top_image="assets/minecraft/textures/block/bubble_coral_block.png")
-block(blockid=11318, top_image="assets/minecraft/textures/block/fire_coral_block.png")
-block(blockid=11319, top_image="assets/minecraft/textures/block/horn_coral_block.png")
-block(blockid=11320, top_image="assets/minecraft/textures/block/tube_coral_block.png")
+block(blockid=11316, top_image=blocks_path + "brain_coral_block.png")
+block(blockid=11317, top_image=blocks_path + "bubble_coral_block.png")
+block(blockid=11318, top_image=blocks_path + "fire_coral_block.png")
+block(blockid=11319, top_image=blocks_path + "horn_coral_block.png")
+block(blockid=11320, top_image=blocks_path + "tube_coral_block.png")
 
 #dead coral blocks
-block(blockid=11321, top_image="assets/minecraft/textures/block/dead_brain_coral_block.png")
-block(blockid=11322, top_image="assets/minecraft/textures/block/dead_bubble_coral_block.png")
-block(blockid=11323, top_image="assets/minecraft/textures/block/dead_fire_coral_block.png")
-block(blockid=11324, top_image="assets/minecraft/textures/block/dead_horn_coral_block.png")
-block(blockid=11325, top_image="assets/minecraft/textures/block/dead_tube_coral_block.png")
+block(blockid=11321, top_image=blocks_path + "dead_brain_coral_block.png")
+block(blockid=11322, top_image=blocks_path + "dead_bubble_coral_block.png")
+block(blockid=11323, top_image=blocks_path + "dead_fire_coral_block.png")
+block(blockid=11324, top_image=blocks_path + "dead_horn_coral_block.png")
+block(blockid=11325, top_image=blocks_path + "dead_tube_coral_block.png")
 
 @material(blockid=175, data=range(16), transparent=True)
 def flower(self, blockid, data):
@@ -4596,13 +4598,13 @@ def flower(self, blockid, data):
     else:
         part = "bottom"
 
-    png = "assets/minecraft/textures/block/%s_%s.png" % (plant,part)
+    png = blocks_path + "%s_%s.png" % (plant,part)
     texture = self.load_image_texture(png)
     img = self.build_billboard(texture)
 
     #sunflower top
     if data == 8:
-        bloom_tex = self.load_image_texture("assets/minecraft/textures/block/sunflower_front.png")
+        bloom_tex = self.load_image_texture(blocks_path + "sunflower_front.png")
         alpha_over(img, bloom_tex.resize((14, 11), Image.ANTIALIAS), (5,5))
 
     return img
@@ -4612,21 +4614,21 @@ def flower(self, blockid, data):
 def chorus_flower(self, blockid, data):
     # aged 5, dead
     if data == 5:
-        texture = self.load_image_texture("assets/minecraft/textures/block/chorus_flower_dead.png")
+        texture = self.load_image_texture(blocks_path + "chorus_flower_dead.png")
     else:
-        texture = self.load_image_texture("assets/minecraft/textures/block/chorus_flower.png")
+        texture = self.load_image_texture(blocks_path + "chorus_flower.png")
 
     return self.build_block(texture,texture)
 
 # purpur block
-block(blockid=201, top_image="assets/minecraft/textures/block/purpur_block.png")
+block(blockid=201, top_image=blocks_path + "purpur_block.png")
 
 # purpur pilar
 @material(blockid=202, data=range(12) , solid=True)
 def purpur_pillar(self, blockid, data):
     pillar_orientation = data & 12
-    top=self.load_image_texture("assets/minecraft/textures/block/purpur_pillar_top.png")
-    side=self.load_image_texture("assets/minecraft/textures/block/purpur_pillar.png")
+    top=self.load_image_texture(blocks_path + "purpur_pillar_top.png")
+    side=self.load_image_texture(blocks_path + "purpur_pillar.png")
     if pillar_orientation == 0: # east-west orientation
         return self.build_block(top, side)
     elif pillar_orientation == 4: # east-west orientation
@@ -4636,22 +4638,22 @@ def purpur_pillar(self, blockid, data):
         return self.build_full_block(side, None, None, side.rotate(270), top)
 
 # end brick
-block(blockid=206, top_image="assets/minecraft/textures/block/end_stone_bricks.png")
+block(blockid=206, top_image=blocks_path + "end_stone_bricks.png")
 
 # frosted ice
 @material(blockid=212, data=range(4), solid=True)
 def frosted_ice(self, blockid, data):
-    img = self.load_image_texture("assets/minecraft/textures/block/frosted_ice_%d.png" % data)
+    img = self.load_image_texture(blocks_path + "frosted_ice_%d.png" % data)
     return self.build_block(img, img)
 
 # magma block
-block(blockid=213, top_image="assets/minecraft/textures/block/magma.png")
+block(blockid=213, top_image=blocks_path + "magma.png")
 
 # nether wart block
-block(blockid=214, top_image="assets/minecraft/textures/block/nether_wart_block.png")
+block(blockid=214, top_image=blocks_path + "nether_wart_block.png")
 
 # red nether brick
-block(blockid=215, top_image="assets/minecraft/textures/block/red_nether_bricks.png")
+block(blockid=215, top_image=blocks_path + "red_nether_bricks.png")
 
 @material(blockid=216, data=range(12), solid=True)
 def boneblock(self, blockid, data):
@@ -4664,8 +4666,8 @@ def boneblock(self, blockid, data):
         if boneblock_orientation == 4: boneblock_orientation = 8
         elif boneblock_orientation == 8: boneblock_orientation = 4
 
-    top = self.load_image_texture("assets/minecraft/textures/block/bone_block_top.png")
-    side = self.load_image_texture("assets/minecraft/textures/block/bone_block_side.png")
+    top = self.load_image_texture(blocks_path + "bone_block_top.png")
+    side = self.load_image_texture(blocks_path + "bone_block_side.png")
 
     # choose orientation and paste textures
     if boneblock_orientation == 0:
@@ -4695,10 +4697,10 @@ def observer(self, blockid, data):
         elif data == 4: data = 3
         elif data == 5: data = 2
 
-    front = self.load_image_texture("assets/minecraft/textures/block/observer_front.png").copy()
-    side = self.load_image_texture("assets/minecraft/textures/block/observer_side.png").copy()
-    back = self.load_image_texture("assets/minecraft/textures/block/observer_back.png").copy()
-    top = self.load_image_texture("assets/minecraft/textures/block/observer_top.png").copy()
+    front = self.load_image_texture(blocks_path + "observer_front.png").copy()
+    side = self.load_image_texture(blocks_path + "observer_side.png").copy()
+    back = self.load_image_texture(blocks_path + "observer_back.png").copy()
+    top = self.load_image_texture(blocks_path + "observer_top.png").copy()
 
     if data == 0: # down
         side = side.rotate(90)
@@ -4771,19 +4773,19 @@ def shulker_box(self, blockid, data):
 @material(blockid=255, data=range(4), solid=True)
 def structure_block(self, blockid, data):
     if data == 0:
-        img = self.load_image_texture("assets/minecraft/textures/block/structure_block_save.png")
+        img = self.load_image_texture(blocks_path + "structure_block_save.png")
     elif data == 1:
-        img = self.load_image_texture("assets/minecraft/textures/block/structure_block_load.png")
+        img = self.load_image_texture(blocks_path + "structure_block_load.png")
     elif data == 2:
-        img = self.load_image_texture("assets/minecraft/textures/block/structure_block_corner.png")
+        img = self.load_image_texture(blocks_path + "structure_block_corner.png")
     elif data == 3:
-        img = self.load_image_texture("assets/minecraft/textures/block/structure_block_data.png")
+        img = self.load_image_texture(blocks_path + "structure_block_data.png")
     return self.build_block(img, img)
 
 # beetroots
 @material(blockid=207, data=range(4), transparent=True, nospawn=True)
 def crops(self, blockid, data):
-    raw_crop = self.load_image_texture("assets/minecraft/textures/block/beetroots_stage%d.png" % data)
+    raw_crop = self.load_image_texture(blocks_path + "beetroots_stage%d.png" % data)
     crop1 = self.transform_image_top(raw_crop)
     crop2 = self.transform_image_side(raw_crop)
     crop3 = crop2.transpose(Image.FLIP_LEFT_RIGHT)
@@ -4797,19 +4799,19 @@ def crops(self, blockid, data):
 # Concrete
 @material(blockid=251, data=range(16), solid=True)
 def concrete(self, blockid, data):
-    texture = self.load_image_texture("assets/minecraft/textures/block/%s_concrete.png" % color_map[data])
+    texture = self.load_image_texture(blocks_path + "%s_concrete.png" % color_map[data])
     return self.build_block(texture, texture)
 
 # Concrete Powder
 @material(blockid=252, data=range(16), solid=True)
 def concrete(self, blockid, data):
-    texture = self.load_image_texture("assets/minecraft/textures/block/%s_concrete_powder.png" % color_map[data])
+    texture = self.load_image_texture(blocks_path + "%s_concrete_powder.png" % color_map[data])
     return self.build_block(texture, texture)
 
 # Glazed Terracotta
 @material(blockid=range(235,251), data=range(8), solid=True)
 def glazed_terracotta(self, blockid, data):
-    texture = self.load_image_texture("assets/minecraft/textures/block/%s_glazed_terracotta.png" % color_map[blockid - 235])
+    texture = self.load_image_texture(blocks_path + "%s_glazed_terracotta.png" % color_map[blockid - 235])
     glazed_terracotta_orientation = data & 3
     
     # Glazed Terracotta rotations are need seperate handling for each render direction
@@ -4862,5 +4864,5 @@ def glazed_terracotta(self, blockid, data):
 # dried kelp block
 @material(blockid=11331, data=[0], solid=True)
 def sandstone(self, blockid, data):
-    top = self.load_image_texture("assets/minecraft/textures/block/dried_kelp_top.png")
-    return self.build_block(top, self.load_image_texture("assets/minecraft/textures/block/dried_kelp_side.png"))
+    top = self.load_image_texture(blocks_path + "dried_kelp_top.png")
+    return self.build_block(top, self.load_image_texture(blocks_path + "dried_kelp_side.png"))

--- a/overviewer_core/textures.py
+++ b/overviewer_core/textures.py
@@ -37,7 +37,7 @@ class TextureException(Exception):
 color_map = ["white", "orange", "magenta", "light_blue", "yellow", "lime", "pink", "gray",
              "light_gray", "cyan", "purple", "blue", "brown", "green", "red", "black"]
 
-blocks_path = '/assets/minecraft/textures/block/'
+blocks_path = 'assets/minecraft/textures/block/'
 
 ##
 ## Textures object


### PR DESCRIPTION
Noticed polylines were not working and only saw remnants of Google Maps support in `util.js`. Using the provided `region.js` as example polyline object, I implemented the creation of polylines in `util.js`.

- Added support for drawing the polyline in Leaflet;
  - Tested using the provided `region.js` example polyline.
- Removed duplicate code in genPOI.py;
- Added some comments to `util.js`;
- Added `blocks_path` variable to replace overly hardcoded texture path.