### PR TITLE
Add block_class to accelerate block-conditionals

### DIFF
--- a/overviewer_core/src/block_class.c
+++ b/overviewer_core/src/block_class.c
@@ -1,0 +1,136 @@
+/* 
+ * This file is part of the Minecraft Overviewer.
+ *
+ * Minecraft Overviewer is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Minecraft Overviewer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with the Overviewer.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "block_class.h"
+#include "utils.h"
+
+
+bool block_class_is_subset(
+	mc_block_t block,
+	const mc_block_t block_class[],
+	size_t     block_class_len
+)
+{
+	size_t i;
+	for( i = 0; i < block_class_len; ++i )
+	{
+		if( block == block_class[i] )
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
+
+const mc_block_t block_class_stair[] = {
+	block_oak_stairs,
+	block_stone_stairs,
+	block_brick_stairs,
+	block_stone_brick_stairs,
+	block_nether_brick_stairs,
+	block_sandstone_stairs,
+	block_spruce_stairs,
+	block_birch_stairs,
+	block_jungle_stairs,
+	block_quartz_stairs,
+	block_acacia_stairs,
+	block_dark_oak_stairs,
+	block_red_sandstone_stairs,
+	block_purpur_stairs
+};
+const size_t block_class_stair_len = count_of(block_class_stair);
+
+const mc_block_t block_class_door[] = {
+	block_wooden_door,
+	block_iron_door,
+	block_spruce_door,
+	block_birch_door,
+	block_jungle_door,
+	block_acacia_door,
+	block_dark_oak_door
+};
+const size_t block_class_door_len = count_of(block_class_door);
+
+const mc_block_t block_class_fence[] = {
+	block_fence,
+	block_nether_brick_fence,
+	block_spruce_fence,
+	block_birch_fence,
+	block_jungle_fence,
+	block_dark_oak_fence,
+	block_acacia_fence
+};
+const size_t block_class_fence_len = count_of(block_class_fence);
+
+const mc_block_t block_class_fence_gate[] = {
+	block_fence_gate,
+	block_spruce_fence_gate,
+	block_birch_fence_gate,
+	block_jungle_fence_gate,
+	block_dark_oak_fence_gate,
+	block_acacia_fence_gate
+};
+const size_t block_class_fence_gate_len = count_of(block_class_fence_gate);
+
+const mc_block_t block_class_ancil[] = {
+	block_wooden_door,
+	block_iron_door,
+	block_spruce_door,
+	block_birch_door,
+	block_jungle_door,
+	block_acacia_door,
+	block_dark_oak_door,
+	block_oak_stairs,
+	block_stone_stairs,
+	block_brick_stairs,
+	block_stone_brick_stairs,
+	block_nether_brick_stairs,
+	block_sandstone_stairs,
+	block_spruce_stairs,
+	block_birch_stairs,
+	block_jungle_stairs,
+	block_quartz_stairs,
+	block_acacia_stairs,
+	block_dark_oak_stairs,
+	block_red_sandstone_stairs,
+	block_purpur_stairs,
+	block_grass,
+	block_flowing_water,
+	block_water,
+	block_glass,
+	block_chest,
+	block_redstone_wire,
+	block_ice,
+	block_fence,
+	block_portal,
+	block_iron_bars,
+	block_glass_pane,
+	block_waterlily,
+	block_nether_brick_fence,
+	block_cobblestone_wall,
+	block_double_plant,
+	block_stained_glass_pane,
+	block_stained_glass,
+	block_trapped_chest,
+	block_spruce_fence,
+	block_birch_fence,
+	block_jungle_fence,
+	block_dark_oak_fence,
+	block_acacia_fence
+};
+const size_t block_class_ancil_len = count_of(block_class_ancil);

--- a/overviewer_core/src/block_class.c
+++ b/overviewer_core/src/block_class.c
@@ -26,42 +26,35 @@ bool block_class_is_subset(
 	mc_block_t block,
 	const mc_block_t block_class[],
 	size_t block_class_len
-)
-{
+) {
 	size_t i = 0;
 
 #ifdef __SSE2__
-	for( ; i / 8 < block_class_len / 8; i += 8 )
-	{
+	for (; i / 8 < block_class_len / 8; i += 8) {
 		const __m128i block_class_vec = _mm_loadu_si128(
 			(__m128i*)&block_class[i]
 		);
 		const __m128i block_vec = _mm_set1_epi16(block);
 		const __m128i block_cmp = _mm_cmpeq_epi16(block_vec,block_class_vec);
-		if( _mm_movemask_epi8(block_cmp) )
-		{
+		if (_mm_movemask_epi8(block_cmp)) {
 			return true;
 		}
 	}
 #endif
 #ifdef __MMX__
-	for( ; i / 4 < block_class_len / 4; i += 4 )
-	{
+	for (; i / 4 < block_class_len / 4; i += 4) {
 		const __m64 block_class_vec = _mm_cvtsi64_m64(
 			*(uint64_t*)&block_class[i]
 		);
 		const __m64 block_vec = _mm_set1_pi16(block);
 		const __m64 block_cmp = _mm_cmpeq_pi16(block_vec,block_class_vec);
-		if( _mm_cvtm64_si64(block_cmp) )
-		{
+		if (_mm_cvtm64_si64(block_cmp)) {
 			return true;
 		}
 	}
 #endif
-	for( ; i < block_class_len; ++i )
-	{
-		if( block == block_class[i] )
-		{
+	for (; i < block_class_len; ++i) {
+		if (block == block_class[i]) {
 			return true;
 		}
 	}
@@ -85,7 +78,7 @@ const mc_block_t block_class_stair[] = {
 	block_red_sandstone_stairs,
 	block_purpur_stairs
 };
-const size_t block_class_stair_len = count_of(block_class_stair);
+const size_t block_class_stair_len = COUNT_OF(block_class_stair);
 
 const mc_block_t block_class_door[] = {
 	block_wooden_door,
@@ -96,7 +89,7 @@ const mc_block_t block_class_door[] = {
 	block_acacia_door,
 	block_dark_oak_door
 };
-const size_t block_class_door_len = count_of(block_class_door);
+const size_t block_class_door_len = COUNT_OF(block_class_door);
 
 const mc_block_t block_class_fence[] = {
 	block_fence,
@@ -107,7 +100,7 @@ const mc_block_t block_class_fence[] = {
 	block_dark_oak_fence,
 	block_acacia_fence
 };
-const size_t block_class_fence_len = count_of(block_class_fence);
+const size_t block_class_fence_len = COUNT_OF(block_class_fence);
 
 const mc_block_t block_class_fence_gate[] = {
 	block_fence_gate,
@@ -117,7 +110,7 @@ const mc_block_t block_class_fence_gate[] = {
 	block_dark_oak_fence_gate,
 	block_acacia_fence_gate
 };
-const size_t block_class_fence_gate_len = count_of(block_class_fence_gate);
+const size_t block_class_fence_gate_len = COUNT_OF(block_class_fence_gate);
 
 const mc_block_t block_class_ancil[] = {
 	block_wooden_door,
@@ -165,7 +158,7 @@ const mc_block_t block_class_ancil[] = {
 	block_dark_oak_fence,
 	block_acacia_fence
 };
-const size_t block_class_ancil_len = count_of(block_class_ancil);
+const size_t block_class_ancil_len = COUNT_OF(block_class_ancil);
 
 const mc_block_t block_class_alt_height[] = {
 	block_stone_slab,
@@ -187,4 +180,5 @@ const mc_block_t block_class_alt_height[] = {
 	block_purpur_slab,
 	block_wooden_slab
 };
-const size_t block_class_alt_height_len = count_of(block_class_alt_height);
+const size_t block_class_alt_height_len = COUNT_OF(block_class_alt_height);
+

--- a/overviewer_core/src/block_class.c
+++ b/overviewer_core/src/block_class.c
@@ -22,7 +22,7 @@
 #include <immintrin.h>
 #endif
 
-bool block_class_is_subset(
+extern inline bool block_class_is_subset(
 	mc_block_t block,
 	const mc_block_t block_class[],
 	size_t block_class_len

--- a/overviewer_core/src/block_class.c
+++ b/overviewer_core/src/block_class.c
@@ -22,7 +22,7 @@
 #include <immintrin.h>
 #endif
 
-extern inline bool block_class_is_subset(
+bool block_class_is_subset(
 	mc_block_t block,
 	const mc_block_t block_class[],
 	size_t block_class_len

--- a/overviewer_core/src/block_class.h
+++ b/overviewer_core/src/block_class.h
@@ -1,0 +1,47 @@
+/* 
+ * This file is part of the Minecraft Overviewer.
+ *
+ * Minecraft Overviewer is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Minecraft Overviewer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with the Overviewer.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __BLOCK_CLASS_H_INCLUDED__
+#define __BLOCK_CLASS_H_INCLUDED__
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#include "mc_id.h"
+
+bool block_class_is_subset(
+	mc_block_t block,
+	const mc_block_t block_class[],
+	size_t     block_class_len
+);
+
+extern const mc_block_t block_class_stair[];
+extern const size_t     block_class_stair_len;
+
+extern const mc_block_t block_class_door[];
+extern const size_t     block_class_door_len;
+
+extern const mc_block_t block_class_fence[];
+extern const size_t     block_class_fence_len;
+
+extern const mc_block_t block_class_fence_gate[];
+extern const size_t     block_class_fence_gate_len;
+
+extern const mc_block_t block_class_ancil[];
+extern const size_t     block_class_ancil_len;
+
+#endif

--- a/overviewer_core/src/block_class.h
+++ b/overviewer_core/src/block_class.h
@@ -48,3 +48,4 @@ extern const mc_block_t block_class_alt_height[];
 extern const size_t     block_class_alt_height_len;
 
 #endif
+

--- a/overviewer_core/src/block_class.h
+++ b/overviewer_core/src/block_class.h
@@ -26,7 +26,7 @@
 bool block_class_is_subset(
 	mc_block_t block,
 	const mc_block_t block_class[],
-	size_t     block_class_len
+	size_t block_class_len
 );
 
 extern const mc_block_t block_class_stair[];

--- a/overviewer_core/src/block_class.h
+++ b/overviewer_core/src/block_class.h
@@ -44,4 +44,7 @@ extern const size_t     block_class_fence_gate_len;
 extern const mc_block_t block_class_ancil[];
 extern const size_t     block_class_ancil_len;
 
+extern const mc_block_t block_class_alt_height[];
+extern const size_t     block_class_alt_height_len;
+
 #endif

--- a/overviewer_core/src/iterate.c
+++ b/overviewer_core/src/iterate.c
@@ -259,13 +259,13 @@ generate_pseudo_data(RenderState *state, unsigned short ancilData) {
         if (get_data(state, BLOCKS, x, y+1, z) == 78)
             return 0x10;
         return ancilData;
-    } else if (state->block == block_flowing_water || state->block == block_water) { /* water */
+    } else if (block_class_is_subset(state->block,(mc_block_t[]){block_flowing_water,block_water},2)) { /* water */
         data = check_adjacent_blocks(state, x, y, z, state->block) ^ 0x0f;
         /* an aditional bit for top is added to the 4 bits of check_adjacent_blocks */
         if (get_data(state, BLOCKS, x, y+1, z) != state->block)
             data |= 0x10;
         return data;
-    } else if ((state->block == block_glass) || (state->block == block_ice) || (state->block == block_stained_glass)) { /* glass and ice and stained glass*/
+    } else if (block_class_is_subset(state->block,(mc_block_t[]){block_glass,block_ice,block_stained_glass},3)) { /* glass and ice and stained glass*/
         /* an aditional bit for top is added to the 4 bits of check_adjacent_blocks
          * Note that stained glass encodes 16 colors using 4 bits.  this pushes us over the 8-bits of an unsigned char, 
          * forcing us to use an unsigned short to hold 16 bits of pseudo ancil data
@@ -317,7 +317,7 @@ generate_pseudo_data(RenderState *state, unsigned short ancilData) {
         }
         return final_data;
 
-    } else if (state->block == block_chest || state->block == block_trapped_chest) {
+    } else if (block_class_is_subset(state->block,(mc_block_t[]){block_chest,block_trapped_chest},2)) {
         /* Orientation is given by ancilData, pseudo data needed to 
          * choose from single or double chest and the correct half of
          * the chest. */
@@ -354,7 +354,7 @@ generate_pseudo_data(RenderState *state, unsigned short ancilData) {
         }
         return final_data;
 
-    } else if ((state->block == block_iron_bars) || (state->block == block_glass_pane) || (state->block == block_stained_glass_pane)) {
+    } else if (block_class_is_subset(state->block,(mc_block_t[]){block_iron_bars,block_glass_pane,block_stained_glass_pane},3)) {
         /* iron bars and glass panes:
          * they seem to stick to almost everything but air,
          * not sure yet! Still a TODO! */
@@ -363,7 +363,7 @@ generate_pseudo_data(RenderState *state, unsigned short ancilData) {
         data = (check_adjacent_blocks(state, x, y, z, 0) ^ 0x0f);
         return (data << 4) | (ancilData & 0xf);
 
-    } else if ((state->block == block_portal) || (state->block == block_nether_brick_fence)) {
+    } else if (block_class_is_subset(state->block,(mc_block_t[]){block_portal,block_nether_brick_fence},2)) {
         /* portal and nether brick fences */
         return check_adjacent_blocks(state, x, y, z, state->block);
 

--- a/overviewer_core/src/iterate.c
+++ b/overviewer_core/src/iterate.c
@@ -259,13 +259,13 @@ generate_pseudo_data(RenderState *state, unsigned short ancilData) {
         if (get_data(state, BLOCKS, x, y+1, z) == 78)
             return 0x10;
         return ancilData;
-    } else if (block_class_is_subset(state->block,(mc_block_t[]){block_flowing_water,block_water},2)) { /* water */
+    } else if (block_class_is_subset(state->block, (mc_block_t[]){block_flowing_water,block_water}, 2)) { /* water */
         data = check_adjacent_blocks(state, x, y, z, state->block) ^ 0x0f;
         /* an aditional bit for top is added to the 4 bits of check_adjacent_blocks */
         if (get_data(state, BLOCKS, x, y+1, z) != state->block)
             data |= 0x10;
         return data;
-    } else if (block_class_is_subset(state->block,(mc_block_t[]){block_glass,block_ice,block_stained_glass},3)) { /* glass and ice and stained glass*/
+    } else if (block_class_is_subset(state->block, (mc_block_t[]){block_glass,block_ice,block_stained_glass}, 3)) { /* glass and ice and stained glass*/
         /* an aditional bit for top is added to the 4 bits of check_adjacent_blocks
          * Note that stained glass encodes 16 colors using 4 bits.  this pushes us over the 8-bits of an unsigned char, 
          * forcing us to use an unsigned short to hold 16 bits of pseudo ancil data
@@ -277,7 +277,7 @@ generate_pseudo_data(RenderState *state, unsigned short ancilData) {
         }
         data = (check_adjacent_blocks(state, x, y, z, state->block) ^ 0x0f) | data;
         return (data << 4) | (ancilData & 0x0f);
-    } else if (block_class_is_subset(state->block,block_class_fence,block_class_fence_len)) { /* fences */
+    } else if (block_class_is_subset(state->block, block_class_fence, block_class_fence_len)) { /* fences */
         /* check for fences AND fence gates */
         return check_adjacent_blocks(state, x, y, z, state->block) | check_adjacent_blocks(state, x, y, z, block_fence_gate) |
                 check_adjacent_blocks(state, x, y, z, block_fence_gate) | check_adjacent_blocks(state, x, y, z, block_birch_fence_gate) | check_adjacent_blocks(state, x, y, z, block_jungle_fence_gate) |
@@ -317,7 +317,7 @@ generate_pseudo_data(RenderState *state, unsigned short ancilData) {
         }
         return final_data;
 
-    } else if (block_class_is_subset(state->block,(mc_block_t[]){block_chest,block_trapped_chest},2)) {
+    } else if (block_class_is_subset(state->block, (mc_block_t[]){block_chest,block_trapped_chest}, 2)) {
         /* Orientation is given by ancilData, pseudo data needed to 
          * choose from single or double chest and the correct half of
          * the chest. */
@@ -354,7 +354,7 @@ generate_pseudo_data(RenderState *state, unsigned short ancilData) {
         }
         return final_data;
 
-    } else if (block_class_is_subset(state->block,(mc_block_t[]){block_iron_bars,block_glass_pane,block_stained_glass_pane},3)) {
+    } else if (block_class_is_subset(state->block, (mc_block_t[]){block_iron_bars,block_glass_pane, block_stained_glass_pane},3)) {
         /* iron bars and glass panes:
          * they seem to stick to almost everything but air,
          * not sure yet! Still a TODO! */
@@ -363,11 +363,11 @@ generate_pseudo_data(RenderState *state, unsigned short ancilData) {
         data = (check_adjacent_blocks(state, x, y, z, 0) ^ 0x0f);
         return (data << 4) | (ancilData & 0xf);
 
-    } else if (block_class_is_subset(state->block,(mc_block_t[]){block_portal,block_nether_brick_fence},2)) {
+    } else if (block_class_is_subset(state->block, (mc_block_t[]){block_portal,block_nether_brick_fence}, 2)) {
         /* portal and nether brick fences */
         return check_adjacent_blocks(state, x, y, z, state->block);
 
-    } else if (block_class_is_subset(state->block,block_class_door,block_class_door_len)) {
+    } else if (block_class_is_subset(state->block, block_class_door, block_class_door_len)) {
         /* use bottom block data format plus one bit for top/down
          * block (0x8) and one bit for hinge position (0x10)
          */
@@ -414,7 +414,7 @@ generate_pseudo_data(RenderState *state, unsigned short ancilData) {
         pr = pr * pr * 42317861 + pr * 11;
         rotation = 3 & (pr >> 16);
         return rotation;
-    } else if (block_class_is_subset(state->block,block_class_stair,block_class_stair_len)) { /* stairs */
+    } else if (block_class_is_subset(state->block, block_class_stair, block_class_stair_len)) { /* stairs */
         /* 4 ancillary bits will be added to indicate which quarters of the block contain the 
          * upper step. Regular stairs will have 2 bits set & corner stairs will have 1 or 3.
          *     Southwest quarter is part of the upper step - 0x40
@@ -471,10 +471,10 @@ generate_pseudo_data(RenderState *state, unsigned short ancilData) {
 
         /* get block & data for neighbors in this order: east, north, west, south */
         /* so we can rotate things easily */
-        stairs[0] = stairs[4] = block_class_is_subset(get_data(state, BLOCKS, x+1, y, z),block_class_stair,block_class_stair_len);
-        stairs[1] = stairs[5] = block_class_is_subset(get_data(state, BLOCKS, x, y, z-1),block_class_stair,block_class_stair_len);
-        stairs[2] = stairs[6] = block_class_is_subset(get_data(state, BLOCKS, x-1, y, z),block_class_stair,block_class_stair_len);
-        stairs[3] = stairs[7] = block_class_is_subset(get_data(state, BLOCKS, x, y, z+1),block_class_stair,block_class_stair_len);
+        stairs[0] = stairs[4] = block_class_is_subset(get_data(state, BLOCKS, x+1, y, z), block_class_stair, block_class_stair_len);
+        stairs[1] = stairs[5] = block_class_is_subset(get_data(state, BLOCKS, x, y, z-1), block_class_stair, block_class_stair_len);
+        stairs[2] = stairs[6] = block_class_is_subset(get_data(state, BLOCKS, x-1, y, z), block_class_stair, block_class_stair_len);
+        stairs[3] = stairs[7] = block_class_is_subset(get_data(state, BLOCKS, x, y, z+1), block_class_stair, block_class_stair_len);
         neigh[0] = neigh[4] = FIX_ROT(get_data(state, DATA, x+1, y, z));
         neigh[1] = neigh[5] = FIX_ROT(get_data(state, DATA, x, y, z-1));
         neigh[2] = neigh[6] = FIX_ROT(get_data(state, DATA, x-1, y, z));
@@ -670,7 +670,7 @@ chunk_render(PyObject *self, PyObject *args) {
                      * grass, water, glass, chest, restone wire,
                      * ice, fence, portal, iron bars, glass panes,
                      * trapped chests, stairs */
-                    if (block_class_is_subset(state.block,block_class_ancil,block_class_ancil_len)) {
+                    if (block_class_is_subset(state.block, block_class_ancil, block_class_ancil_len)) {
                         ancilData = generate_pseudo_data(&state, ancilData);
                         state.block_pdata = ancilData;
                     } else {

--- a/overviewer_core/src/overviewer.h
+++ b/overviewer_core/src/overviewer.h
@@ -33,7 +33,7 @@
 
 // increment this value if you've made a change to the c extesion
 // and want to force users to rebuild
-#define OVERVIEWER_EXTENSION_VERSION 57
+#define OVERVIEWER_EXTENSION_VERSION 58
 
 /* Python PIL, and numpy headers */
 #include <Python.h>

--- a/overviewer_core/src/primitives/base.c
+++ b/overviewer_core/src/primitives/base.c
@@ -125,23 +125,25 @@ base_draw(void *data, RenderState *state, PyObject *src, PyObject *mask, PyObjec
             /* grass needs a special facemask */
             facemask = self->grass_texture;
         }
-
-        switch (state->block) {
-        case block_grass:
-        case block_tallgrass:
-        case block_pumpkin_stem:
-        case block_melon_stem:
-        case block_vine:
-        case block_waterlily:
-        case block_double_plant:
+        if(block_class_is_subset(state->block,(mc_block_t[]){
+            block_grass,
+            block_tallgrass,
+            block_pumpkin_stem,
+            block_melon_stem,
+            block_vine,
+            block_waterlily,
+            block_double_plant
+        },7)) {
             color_table = self->grasscolor;
-            break;
-        case block_flowing_water:
-        case block_water:
+        }
+        else if(block_class_is_subset(state->block,(mc_block_t[]){
+            block_flowing_water,block_water
+        },2)) {
             color_table = self->watercolor;
-            break;
-        case block_leaves:
-        case block_leaves2:
+        }
+        else if(block_class_is_subset(state->block,(mc_block_t[]){
+            block_leaves,block_leaves2
+        },2)) {
             color_table = self->foliagecolor;
             if (state->block_data == 2)
             {
@@ -149,10 +151,7 @@ base_draw(void *data, RenderState *state, PyObject *src, PyObject *mask, PyObjec
                    birch foliage color is flipped XY-ways */
                 flip_xy = 1;
             }
-            break;
-        default:
-            break;
-        };
+        }
             
         if (color_table) {
             unsigned char biome;

--- a/overviewer_core/src/primitives/base.c
+++ b/overviewer_core/src/primitives/base.c
@@ -17,6 +17,7 @@
 
 #include "../overviewer.h"
 #include "../mc_id.h"
+#include "../block_class.h"
 #include "biomes.h"
 
 typedef struct {
@@ -95,19 +96,20 @@ base_draw(void *data, RenderState *state, PyObject *src, PyObject *mask, PyObjec
      */
     if (/* grass, but not snowgrass */
         (state->block == block_grass && get_data(state, BLOCKS, state->x, state->y+1, state->z) != 78) ||
-        /* water */
-        state->block == block_flowing_water || state->block == block_water ||
-        /* leaves */
-        state->block == block_leaves || state->block == block_leaves2 ||
+        block_class_is_subset(state->block,(mc_block_t[]){
+                block_vine,
+                block_waterlily,
+                block_flowing_water,
+                block_water,
+                block_leaves,
+                block_leaves2
+            },
+        6) ||
         /* tallgrass, but not dead shrubs */
         (state->block == block_tallgrass && state->block_data != 0) ||
         /* pumpkin/melon stem, not fully grown. Fully grown stems
          * get constant brown color (see textures.py) */
         (((state->block == block_pumpkin_stem) || (state->block == block_melon_stem)) && (state->block_data != 7)) ||
-        /* vines */
-        state->block == block_vine ||
-        /* lily pads */
-        state->block == block_waterlily ||
         /* doublePlant grass & ferns */
         (state->block == block_double_plant && (state->block_data == 2 || state->block_data == 3)) ||
         /* doublePlant grass & ferns tops */
@@ -125,18 +127,21 @@ base_draw(void *data, RenderState *state, PyObject *src, PyObject *mask, PyObjec
         }
 
         switch (state->block) {
-        case 2:
-            /* grass */
+        case block_grass:
+        case block_tallgrass:
+        case block_pumpkin_stem:
+        case block_melon_stem:
+        case block_vine:
+        case block_waterlily:
+        case block_double_plant:
             color_table = self->grasscolor;
             break;
-        case 8:
-        case 9:
-            /* water */
+        case block_flowing_water:
+        case block_water:
             color_table = self->watercolor;
             break;
-        case 18:
-        case 161:
-            /* leaves */
+        case block_leaves:
+        case block_leaves2:
             color_table = self->foliagecolor;
             if (state->block_data == 2)
             {
@@ -144,30 +149,6 @@ base_draw(void *data, RenderState *state, PyObject *src, PyObject *mask, PyObjec
                    birch foliage color is flipped XY-ways */
                 flip_xy = 1;
             }
-            break;
-        case 31:
-            /* tall grass */
-            color_table = self->grasscolor;
-            break;
-        case 104:
-            /* pumpkin stem */
-            color_table = self->grasscolor;
-            break;
-        case 105:
-            /* melon stem */
-            color_table = self->grasscolor;
-            break;
-        case 106:
-            /* vines */
-            color_table = self->grasscolor;
-            break;
-        case 111:
-            /* lily pads */
-            color_table = self->grasscolor;
-            break;
-        case 175:
-            /* doublePlant grass & ferns */
-            color_table = self->grasscolor;
             break;
         default:
             break;

--- a/overviewer_core/src/primitives/base.c
+++ b/overviewer_core/src/primitives/base.c
@@ -96,7 +96,7 @@ base_draw(void *data, RenderState *state, PyObject *src, PyObject *mask, PyObjec
      */
     if (/* grass, but not snowgrass */
         (state->block == block_grass && get_data(state, BLOCKS, state->x, state->y+1, state->z) != 78) ||
-        block_class_is_subset(state->block,(mc_block_t[]){
+        block_class_is_subset(state->block, (mc_block_t[]){
                 block_vine,
                 block_waterlily,
                 block_flowing_water,
@@ -125,7 +125,7 @@ base_draw(void *data, RenderState *state, PyObject *src, PyObject *mask, PyObjec
             /* grass needs a special facemask */
             facemask = self->grass_texture;
         }
-        if(block_class_is_subset(state->block,(mc_block_t[]){
+        if(block_class_is_subset(state->block, (mc_block_t[]){
             block_grass,
             block_tallgrass,
             block_pumpkin_stem,
@@ -136,12 +136,12 @@ base_draw(void *data, RenderState *state, PyObject *src, PyObject *mask, PyObjec
         },7)) {
             color_table = self->grasscolor;
         }
-        else if(block_class_is_subset(state->block,(mc_block_t[]){
+        else if(block_class_is_subset(state->block, (mc_block_t[]){
             block_flowing_water,block_water
         },2)) {
             color_table = self->watercolor;
         }
-        else if(block_class_is_subset(state->block,(mc_block_t[]){
+        else if(block_class_is_subset(state->block, (mc_block_t[]){
             block_leaves,block_leaves2
         },2)) {
             color_table = self->foliagecolor;

--- a/overviewer_core/src/primitives/edge-lines.c
+++ b/overviewer_core/src/primitives/edge-lines.c
@@ -17,6 +17,7 @@
 
 #include "../overviewer.h"
 #include "../mc_id.h"
+#include "../block_class.h"
 
 typedef struct {
     float opacity;
@@ -35,16 +36,17 @@ edge_lines_draw(void *data, RenderState *state, PyObject *src, PyObject *mask, P
     PrimitiveEdgeLines *self = (PrimitiveEdgeLines *)data;
 
     /* Draw some edge lines! */
-    if (state->block == block_stone_slab || state->block == block_snow_layer || !is_transparent(state->block)) {
+    if (block_class_is_subset(state->block,(mc_block_t[]){block_stone_slab,block_snow_layer},2)
+        || !is_transparent(state->block)) {
         Imaging img_i = imaging_python_to_c(state->img);
         unsigned char ink[] = {0, 0, 0, 255 * self->opacity};
         unsigned short side_block;
         int x = state->x, y = state->y, z = state->z;
 
         int increment=0;
-        if ((state->block == block_stone_slab || state->block == block_wooden_slab) && ((state->block_data & 0x8) == 0 ))  // half-steps BUT no upsidown half-steps
+        if (block_class_is_subset(state->block,(mc_block_t[]){block_wooden_slab,block_stone_slab},2) && ((state->block_data & 0x8) == 0 ))  // half-steps BUT no upsidown half-steps
             increment=6;
-        else if ((state->block == block_snow_layer) || (state->block == block_unpowered_repeater) || (state->block == block_powered_repeater)) // snow, redstone repeaters (on and off)
+        else if (block_class_is_subset(state->block,(mc_block_t[]){block_snow_layer,block_unpowered_repeater,block_powered_repeater},3)) // snow, redstone repeaters (on and off)
             increment=9;
         
         /* +X side */
@@ -52,9 +54,9 @@ edge_lines_draw(void *data, RenderState *state, PyObject *src, PyObject *mask, P
         if (side_block != state->block && (is_transparent(side_block) || render_mode_hidden(state->rendermode, x+1, y, z)) && 
             /* WARNING: ugly special case approaching */
             /* if the block is a slab and the side block is a stair don't draw anything, it can give very ugly results */
-            !((state->block == block_stone_slab || state->block == block_wooden_slab) && ((side_block == block_oak_stairs) || (side_block == block_stone_stairs) || (side_block == block_brick_stairs) ||
-            (side_block == block_stone_brick_stairs) || (side_block == block_nether_brick_stairs) || (side_block == block_sandstone_stairs) || (side_block == block_spruce_stairs) || (side_block == block_birch_stairs) ||
-            (side_block == block_jungle_stairs)))) {
+            !(block_class_is_subset(state->block,(mc_block_t[]){block_wooden_slab,block_stone_slab},2)
+                && (block_class_is_subset(side_block,block_class_stair,block_class_stair_len))
+            )) {
             ImagingDrawLine(img_i, state->imgx+12, state->imgy+1+increment, state->imgx+22+1, state->imgy+5+1+increment, &ink, 1);
             ImagingDrawLine(img_i, state->imgx+12, state->imgy+increment, state->imgx+22+1, state->imgy+5+increment, &ink, 1);
         }
@@ -64,9 +66,10 @@ edge_lines_draw(void *data, RenderState *state, PyObject *src, PyObject *mask, P
         if (side_block != state->block && (is_transparent(side_block) || render_mode_hidden(state->rendermode, x, y, z-1)) &&
             /* WARNING: ugly special case approaching */
             /* if the block is a slab and the side block is a stair don't draw anything, it can give very ugly results */
-            !((state->block == block_stone_slab || state->block == block_wooden_slab) && ((side_block == block_oak_stairs) || (side_block == block_stone_stairs) || (side_block == block_brick_stairs) ||
-            (side_block == block_stone_brick_stairs) || (side_block == block_nether_brick_stairs) || (side_block == block_sandstone_stairs) || (side_block == block_spruce_stairs) || (side_block == block_birch_stairs) ||
-            (side_block == block_jungle_stairs)))) {
+            !(
+                block_class_is_subset(state->block,(mc_block_t[]){block_stone_slab,block_wooden_slab},2)
+                && (block_class_is_subset(side_block,block_class_stair,block_class_stair_len))
+            )) {
             ImagingDrawLine(img_i, state->imgx, state->imgy+6+1+increment, state->imgx+12+1, state->imgy+1+increment, &ink, 1);
             ImagingDrawLine(img_i, state->imgx, state->imgy+6+increment, state->imgx+12+1, state->imgy+increment, &ink, 1);
         }

--- a/overviewer_core/src/primitives/edge-lines.c
+++ b/overviewer_core/src/primitives/edge-lines.c
@@ -36,7 +36,7 @@ edge_lines_draw(void *data, RenderState *state, PyObject *src, PyObject *mask, P
     PrimitiveEdgeLines *self = (PrimitiveEdgeLines *)data;
 
     /* Draw some edge lines! */
-    if (block_class_is_subset(state->block,(mc_block_t[]){block_stone_slab,block_snow_layer},2)
+    if (block_class_is_subset(state->block, (mc_block_t[]){block_stone_slab,block_snow_layer}, 2)
         || !is_transparent(state->block)) {
         Imaging img_i = imaging_python_to_c(state->img);
         unsigned char ink[] = {0, 0, 0, 255 * self->opacity};
@@ -44,9 +44,9 @@ edge_lines_draw(void *data, RenderState *state, PyObject *src, PyObject *mask, P
         int x = state->x, y = state->y, z = state->z;
 
         int increment=0;
-        if (block_class_is_subset(state->block,(mc_block_t[]){block_wooden_slab,block_stone_slab},2) && ((state->block_data & 0x8) == 0 ))  // half-steps BUT no upsidown half-steps
+        if (block_class_is_subset(state->block, (mc_block_t[]){block_wooden_slab,block_stone_slab}, 2) && ((state->block_data & 0x8) == 0 ))  // half-steps BUT no upsidown half-steps
             increment=6;
-        else if (block_class_is_subset(state->block,(mc_block_t[]){block_snow_layer,block_unpowered_repeater,block_powered_repeater},3)) // snow, redstone repeaters (on and off)
+        else if (block_class_is_subset(state->block, (mc_block_t[]){block_snow_layer,block_unpowered_repeater,block_powered_repeater}, 3)) // snow, redstone repeaters (on and off)
             increment=9;
         
         /* +X side */
@@ -54,8 +54,8 @@ edge_lines_draw(void *data, RenderState *state, PyObject *src, PyObject *mask, P
         if (side_block != state->block && (is_transparent(side_block) || render_mode_hidden(state->rendermode, x+1, y, z)) && 
             /* WARNING: ugly special case approaching */
             /* if the block is a slab and the side block is a stair don't draw anything, it can give very ugly results */
-            !(block_class_is_subset(state->block,(mc_block_t[]){block_wooden_slab,block_stone_slab},2)
-                && (block_class_is_subset(side_block,block_class_stair,block_class_stair_len))
+            !(block_class_is_subset(state->block, (mc_block_t[]){block_wooden_slab, block_stone_slab}, 2)
+                && (block_class_is_subset(side_block, block_class_stair, block_class_stair_len))
             )) {
             ImagingDrawLine(img_i, state->imgx+12, state->imgy+1+increment, state->imgx+22+1, state->imgy+5+1+increment, &ink, 1);
             ImagingDrawLine(img_i, state->imgx+12, state->imgy+increment, state->imgx+22+1, state->imgy+5+increment, &ink, 1);
@@ -67,8 +67,8 @@ edge_lines_draw(void *data, RenderState *state, PyObject *src, PyObject *mask, P
             /* WARNING: ugly special case approaching */
             /* if the block is a slab and the side block is a stair don't draw anything, it can give very ugly results */
             !(
-                block_class_is_subset(state->block,(mc_block_t[]){block_stone_slab,block_wooden_slab},2)
-                && (block_class_is_subset(side_block,block_class_stair,block_class_stair_len))
+                block_class_is_subset(state->block, (mc_block_t[]){block_stone_slab,block_wooden_slab}, 2)
+                && (block_class_is_subset(side_block, block_class_stair, block_class_stair_len))
             )) {
             ImagingDrawLine(img_i, state->imgx, state->imgy+6+1+increment, state->imgx+12+1, state->imgy+1+increment, &ink, 1);
             ImagingDrawLine(img_i, state->imgx, state->imgy+6+increment, state->imgx+12+1, state->imgy+increment, &ink, 1);

--- a/overviewer_core/src/primitives/lighting.c
+++ b/overviewer_core/src/primitives/lighting.c
@@ -140,7 +140,7 @@ estimate_blocklevel(RenderPrimitiveLighting *self, RenderState *state,
     blocklevel = get_data(state, BLOCKLIGHT, x, y, z);
     
     /* no longer a guess */
-    if (!block_class_is_subset(block,block_class_alt_height,block_class_alt_height_len) && authoratative) {
+    if (!block_class_is_subset(block, block_class_alt_height, block_class_alt_height_len) && authoratative) {
         *authoratative = 1;
     }
     
@@ -161,7 +161,7 @@ get_lighting_color(RenderPrimitiveLighting *self, RenderState *state,
 
     /* special half-step handling, stairs handling */
     /* Anvil also needs to be here, blockid 145 */
-    if ( block_class_is_subset(block,block_class_alt_height,block_class_alt_height_len) || block == block_anvil) {
+    if ( block_class_is_subset(block, block_class_alt_height, block_class_alt_height_len) || block == block_anvil) {
         unsigned int upper_block;
         
         /* stairs and half-blocks take the skylevel from the upper block if it's transparent */
@@ -170,7 +170,7 @@ get_lighting_color(RenderPrimitiveLighting *self, RenderState *state,
         do {
             upper_counter++; 
             upper_block = get_data(state, BLOCKS, x, y + upper_counter, z);
-        } while (block_class_is_subset(upper_block,block_class_alt_height,block_class_alt_height_len));
+        } while (block_class_is_subset(upper_block, block_class_alt_height, block_class_alt_height_len));
         if (is_transparent(upper_block)) {
             skylevel = get_data(state, SKYLIGHT, x, y + upper_counter, z);
         } else {
@@ -183,7 +183,7 @@ get_lighting_color(RenderPrimitiveLighting *self, RenderState *state,
 
     }
     
-    if (block_class_is_subset(block,(mc_block_t[]){block_flowing_lava,block_lava},2)) {
+    if (block_class_is_subset(block, (mc_block_t[]){block_flowing_lava,block_lava}, 2)) {
         /* lava blocks should always be lit! */
         *r = 255;
         *g = 255;
@@ -302,7 +302,7 @@ lighting_draw(void *data, RenderState *state, PyObject *src, PyObject *mask, PyO
     self = (RenderPrimitiveLighting *)data;
     x = state->x, y = state->y, z = state->z;
     
-    if (block_class_is_subset(state->block,(mc_block_t[]){block_flowing_water,block_water},2)) { /* special case for water */
+    if (block_class_is_subset(state->block, (mc_block_t[]){block_flowing_water,block_water}, 2)) { /* special case for water */
         /* looks like we need a new case for lighting, there are
          * blocks that are transparent for occlusion calculations and
          * need per-face shading if the face is drawn. */

--- a/overviewer_core/src/primitives/lighting.c
+++ b/overviewer_core/src/primitives/lighting.c
@@ -17,6 +17,7 @@
 
 #include "../overviewer.h"
 #include "../mc_id.h"
+#include "../block_class.h"
 #include "lighting.h"
 #include <math.h>
 
@@ -139,7 +140,7 @@ estimate_blocklevel(RenderPrimitiveLighting *self, RenderState *state,
     blocklevel = get_data(state, BLOCKLIGHT, x, y, z);
     
     /* no longer a guess */
-    if (!(block == block_stone_slab || block == block_oak_stairs || block == block_stone_stairs || block == block_brick_stairs || block == block_stone_brick_stairs || block == block_red_sandstone_stairs || block == block_stone_slab2 || block == block_purpur_slab ) && authoratative) {
+    if (!block_class_is_subset(block,block_class_alt_height,block_class_alt_height_len) && authoratative) {
         *authoratative = 1;
     }
     
@@ -160,9 +161,7 @@ get_lighting_color(RenderPrimitiveLighting *self, RenderState *state,
 
     /* special half-step handling, stairs handling */
     /* Anvil also needs to be here, blockid 145 */
-    if (block == block_stone_slab || block == block_oak_stairs || block == block_stone_stairs || block == block_brick_stairs || block == block_stone_brick_stairs || block == block_nether_brick_stairs ||
-        block == block_sandstone_stairs || block == block_spruce_stairs || block == block_birch_stairs || block == block_jungle_stairs || block == block_anvil || block == block_quartz_stairs ||
-        block == block_acacia_stairs || block == block_dark_oak_stairs || block == block_red_sandstone_stairs || block == block_stone_slab2 || block == block_purpur_stairs || block == block_purpur_slab ) {
+    if ( block_class_is_subset(block,block_class_alt_height,block_class_alt_height_len) || block == block_anvil) {
         unsigned int upper_block;
         
         /* stairs and half-blocks take the skylevel from the upper block if it's transparent */
@@ -171,10 +170,7 @@ get_lighting_color(RenderPrimitiveLighting *self, RenderState *state,
         do {
             upper_counter++; 
             upper_block = get_data(state, BLOCKS, x, y + upper_counter, z);
-        } while (upper_block == block_stone_slab || upper_block == block_oak_stairs || upper_block == block_stone_stairs || upper_block == block_brick_stairs ||
-                 upper_block == block_stone_brick_stairs || upper_block == block_nether_brick_stairs || upper_block == block_sandstone_stairs || upper_block == block_spruce_stairs ||
-                 upper_block == block_birch_stairs || upper_block == block_jungle_stairs || upper_block == block_quartz_stairs || upper_block == block_acacia_stairs ||
-                 upper_block == block_dark_oak_stairs || upper_block == block_red_sandstone_stairs || upper_block == block_stone_slab2 || upper_block == block_purpur_stairs || upper_block == block_purpur_slab );
+        } while (block_class_is_subset(upper_block,block_class_alt_height,block_class_alt_height_len));
         if (is_transparent(upper_block)) {
             skylevel = get_data(state, SKYLIGHT, x, y + upper_counter, z);
         } else {
@@ -187,7 +183,7 @@ get_lighting_color(RenderPrimitiveLighting *self, RenderState *state,
 
     }
     
-    if (block == block_flowing_lava || block == block_lava) {
+    if (block_class_is_subset(block,(mc_block_t[]){block_flowing_lava,block_lava},2)) {
         /* lava blocks should always be lit! */
         *r = 255;
         *g = 255;
@@ -306,7 +302,7 @@ lighting_draw(void *data, RenderState *state, PyObject *src, PyObject *mask, PyO
     self = (RenderPrimitiveLighting *)data;
     x = state->x, y = state->y, z = state->z;
     
-    if ((state->block == block_flowing_water) || (state->block == block_water)) { /* special case for water */
+    if (block_class_is_subset(state->block,(mc_block_t[]){block_flowing_water,block_water},2)) { /* special case for water */
         /* looks like we need a new case for lighting, there are
          * blocks that are transparent for occlusion calculations and
          * need per-face shading if the face is drawn. */

--- a/overviewer_core/src/primitives/nether.c
+++ b/overviewer_core/src/primitives/nether.c
@@ -17,6 +17,7 @@
 
 #include "../overviewer.h"
 #include "../mc_id.h"
+#include "../block_class.h"
 #include "nether.h"
 
 static void
@@ -36,7 +37,7 @@ walk_chunk(RenderState *state, RenderPrimitiveNether *data) {
 
             for (y = NETHER_ROOF-1; y>=0; y--) {
                 id = get_data(state, BLOCKS, x, y - (state->chunky * 16), z);
-                if (id == block_bedrock || id == block_netherrack || id == block_quartz_ore || id == block_lava)
+                if (block_class_is_subset(id,(mc_block_t[]){block_bedrock,block_netherrack,block_quartz_ore,block_lava},4))
                     data->remove_block[x+1][y][z+1] = 1;
                 else
                     break;

--- a/overviewer_core/src/primitives/nether.c
+++ b/overviewer_core/src/primitives/nether.c
@@ -37,7 +37,7 @@ walk_chunk(RenderState *state, RenderPrimitiveNether *data) {
 
             for (y = NETHER_ROOF-1; y>=0; y--) {
                 id = get_data(state, BLOCKS, x, y - (state->chunky * 16), z);
-                if (block_class_is_subset(id,(mc_block_t[]){block_bedrock,block_netherrack,block_quartz_ore,block_lava},4))
+                if (block_class_is_subset(id, (mc_block_t[]){block_bedrock,block_netherrack,block_quartz_ore,block_lava}, 4))
                     data->remove_block[x+1][y][z+1] = 1;
                 else
                     break;

--- a/overviewer_core/src/primitives/smooth-lighting.c
+++ b/overviewer_core/src/primitives/smooth-lighting.c
@@ -220,9 +220,9 @@ smooth_lighting_draw(void *data, RenderState *state, PyObject *src, PyObject *ma
     
     /* special case for leaves, water 8, water 9, ice 79
        -- these are also smooth-lit! */
-    if (!block_class_is_subset(state->block,(mc_block_t[]){
+    if (!block_class_is_subset(state->block, (mc_block_t[]){
             block_leaves,block_flowing_water,block_water,block_ice
-        },4) && is_transparent(state->block))
+        }, 4) && is_transparent(state->block))
     {
         /* transparent blocks are rendered as usual, with flat lighting */
         primitive_lighting.draw(data, state, src, mask, mask_light);

--- a/overviewer_core/src/primitives/smooth-lighting.c
+++ b/overviewer_core/src/primitives/smooth-lighting.c
@@ -219,7 +219,9 @@ smooth_lighting_draw(void *data, RenderState *state, PyObject *src, PyObject *ma
     
     /* special case for leaves, water 8, water 9, ice 79
        -- these are also smooth-lit! */
-    if (state->block != block_leaves && state->block != block_flowing_water && state->block != block_water && state->block != block_ice && is_transparent(state->block))
+    if (!block_class_is_subset(state->block,(mc_block_t[]){
+            block_leaves,block_flowing_water,block_water,block_ice
+        },4) && is_transparent(state->block))
     {
         /* transparent blocks are rendered as usual, with flat lighting */
         primitive_lighting.draw(data, state, src, mask, mask_light);

--- a/overviewer_core/src/primitives/smooth-lighting.c
+++ b/overviewer_core/src/primitives/smooth-lighting.c
@@ -17,6 +17,7 @@
 
 #include "../overviewer.h"
 #include "../mc_id.h"
+#include "../block_class.h"
 #include "lighting.h"
 #include <math.h>
 

--- a/overviewer_core/src/utils.h
+++ b/overviewer_core/src/utils.h
@@ -14,4 +14,7 @@
 #define OV_BLEND(mask, in1, in2, tmp1, tmp2)\
         (OV_MULDIV255(in1, 255 - mask, tmp1) + OV_MULDIV255(in2, mask, tmp2))
 
+#define count_of(array) \
+    (sizeof(array) / sizeof(array[0]))
+
 #endif

--- a/overviewer_core/src/utils.h
+++ b/overviewer_core/src/utils.h
@@ -14,7 +14,7 @@
 #define OV_BLEND(mask, in1, in2, tmp1, tmp2)\
         (OV_MULDIV255(in1, 255 - mask, tmp1) + OV_MULDIV255(in2, mask, tmp2))
 
-#define count_of(array) \
+#define COUNT_OF(array) \
     (sizeof(array) / sizeof(array[0]))
 
 #endif

--- a/setup.py
+++ b/setup.py
@@ -175,7 +175,7 @@ for name in glob.glob("overviewer_core/src/primitives/*.c"):
     name = os.path.splitext(name)[0]
     primitives.append(name)
 
-c_overviewer_files = ['main.c', 'composite.c', 'iterate.c', 'endian.c', 'rendermodes.c']
+c_overviewer_files = ['main.c', 'composite.c', 'iterate.c', 'endian.c', 'rendermodes.c', 'block_class.c']
 c_overviewer_files += map(lambda mode: 'primitives/%s.c' % (mode,), primitives)
 c_overviewer_files += ['Draw.c']
 c_overviewer_includes = ['overviewer.h', 'rendermodes.h']


### PR DESCRIPTION
Replaces all `block == block_ice || block == block_water || block == block_flowing_water`... code with the `block_class_is_subset` routine that tests a block against an array of criteria, ensuring a short-circuit as soon as the first match is found. Vectorized versions of these comparison loops are added for `SSE2` and `MMX` that is enabled by pretty much any 64-bit compiler.

I'm finding about a 10 second improvement.

https://github.com/overviewer/Minecraft-Overviewer/commit/00b4e83822c8ba2f15066daf218ce2f30a8f11ea|this PR
-|-
[i3-6100](https://en.wikichip.org/wiki/intel/core_i3/i3-6100)
17:27.26|17:08.24
17:31.64|17:12.16
17:29.35|17:14.39
[i7-7500U](https://en.wikichip.org/wiki/intel/core_i7/i7-7500u)
10:59.71|10:47.32 
10:57.47|10:45.46
10:60.21|10:42.08