### PR TITLE
Decode Popen stdout bytes to utf-8

### DIFF
--- a/overviewer_core/util.py
+++ b/overviewer_core/util.py
@@ -43,7 +43,7 @@ def findGitHash():
     try:
         p = Popen('git rev-parse HEAD', stdout=PIPE, stderr=PIPE, shell=True)
         p.stderr.close()
-        line = p.stdout.readlines()[0].strip()
+        line = p.stdout.readlines()[0].decode('utf-8').strip()
         if line and len(line) == 40 and all(c in hexdigits for c in line):
             return line
     except Exception:
@@ -59,7 +59,7 @@ def findGitVersion():
     try:
         p = Popen('git describe --tags --match "v*.*.*"', stdout=PIPE, stderr=PIPE, shell=True)
         p.stderr.close()
-        line = p.stdout.readlines()[0]
+        line = p.stdout.readlines()[0].decode('utf-8')
         if line.startswith('release-'):
             line = line.split('-', 1)[1]
         if line.startswith('v'):


### PR DESCRIPTION
# Problem
Running `python3 setup.py --version` outputs `unknown`. This is caused by the `except` block [here](https://github.com/overviewer/Minecraft-Overviewer/blob/e348a548b6cce2af2066db243b3c4d76ec40de32/overviewer_core/util.py#L78) catching the `TypeError` thrown by calling `string.startswith()` on the bytes` object from `stdout` [here](https://github.com/overviewer/Minecraft-Overviewer/blob/e348a548b6cce2af2066db243b3c4d76ec40de32/overviewer_core/util.py#L63). 

This issue is also present in `util.findGitHash` [here](https://github.com/overviewer/Minecraft-Overviewer/blob/e348a548b6cce2af2066db243b3c4d76ec40de32/overviewer_core/util.py#L46)

# Changes
- Decode `bytes` object from `stdout` to a UTF-8 string