### PR TITLE
Ensure coordinates are properly converted when changing views

### DIFF
--- a/overviewer_core/data/js_src/util.js
+++ b/overviewer_core/data/js_src/util.js
@@ -236,7 +236,10 @@ overviewer.util = {
                         currentWorldCoords.z, 
                         ev.layer.tileSetConfig);
                         
-                overviewer.map.setView(newMapCoords);
+                overviewer.map.setView(
+                        newMapCoords,
+                        overviewer.map.getZoom(),
+                        { animate: false });
             }
             
             // before updating the current_layer, remove the marker control, if it exists

--- a/overviewer_core/data/js_src/util.js
+++ b/overviewer_core/data/js_src/util.js
@@ -232,8 +232,8 @@ overviewer.util = {
                     
                 const newMapCoords = overviewer.util.fromWorldToLatLng(
                         currentWorldCoords.x, 
-                        coords.y, 
-                        coords.z, 
+                        currentWorldCoords.y, 
+                        currentWorldCoords.z, 
                         ev.layer.tileSetConfig);
                         
                 overviewer.map.setView(newMapCoords);

--- a/overviewer_core/data/js_src/util.js
+++ b/overviewer_core/data/js_src/util.js
@@ -221,6 +221,24 @@ overviewer.util = {
             '<a href="https://overviewer.org">Overviewer/Leaflet</a>');
 
         overviewer.map.on('baselayerchange', function(ev) {
+            
+            // when changing the layer, ensure coordinates remain correct
+            if (overviewer.current_layer[overviewer.current_world]) {
+                const center = overviewer.map.getCenter();
+                const currentWorldCoords = overviewer.util.fromLatLngToWorld(
+                        center.lat, 
+                        center.lng, 
+                        overviewer.current_layer[overviewer.current_world].tileSetConfig);
+                    
+                const newMapCoords = overviewer.util.fromWorldToLatLng(
+                        currentWorldCoords.x, 
+                        coords.y, 
+                        coords.z, 
+                        ev.layer.tileSetConfig);
+                        
+                overviewer.map.setView(newMapCoords);
+            }
+            
             // before updating the current_layer, remove the marker control, if it exists
             if (overviewer.current_world && overviewer.current_layer[overviewer.current_world]) {
                 let tsc = overviewer.current_layer[overviewer.current_world].tileSetConfig;


### PR DESCRIPTION
When changing to a layer with a different angle, the map center is not properly maintained. This PR fixes this by converting the map coordinates to world coordinates using the *current* layer's config, then converting the world coordinates to new map coordinates using the *new* layer's config. 

Closes #1450 and #1473