### PR TITLE
Update C codebase to standardized types

### DIFF
--- a/overviewer_core/src/Draw.c
+++ b/overviewer_core/src/Draw.c
@@ -71,27 +71,27 @@
 
 typedef struct {
     /* edge descriptor for polygon engine */
-    int d;
-    int x0, y0;
-    int xmin, ymin, xmax, ymax;
+    int32_t d;
+    int32_t x0, y0;
+    int32_t xmin, ymin, xmax, ymax;
     float dx;
 } Edge;
 
 static inline void
-point8(Imaging im, int x, int y, int ink) {
+point8(Imaging im, int32_t x, int32_t y, int32_t ink) {
     if (x >= 0 && x < im->xsize && y >= 0 && y < im->ysize)
         im->image8[y][x] = (UINT8)ink;
 }
 
 static inline void
-point32(Imaging im, int x, int y, int ink) {
+point32(Imaging im, int32_t x, int32_t y, int32_t ink) {
     if (x >= 0 && x < im->xsize && y >= 0 && y < im->ysize)
         im->image32[y][x] = ink;
 }
 
 static inline void
-point32rgba(Imaging im, int x, int y, int ink) {
-    unsigned int tmp1, tmp2;
+point32rgba(Imaging im, int32_t x, int32_t y, int32_t ink) {
+    uint32_t tmp1, tmp2;
 
     if (x >= 0 && x < im->xsize && y >= 0 && y < im->ysize) {
         UINT8* out = (UINT8*)im->image[y] + x * 4;
@@ -103,8 +103,8 @@ point32rgba(Imaging im, int x, int y, int ink) {
 }
 
 static inline void
-hline8(Imaging im, int x0, int y0, int x1, int ink) {
-    int tmp;
+hline8(Imaging im, int32_t x0, int32_t y0, int32_t x1, int32_t ink) {
+    int32_t tmp;
 
     if (y0 >= 0 && y0 < im->ysize) {
         if (x0 > x1)
@@ -123,8 +123,8 @@ hline8(Imaging im, int x0, int y0, int x1, int ink) {
 }
 
 static inline void
-hline32(Imaging im, int x0, int y0, int x1, int ink) {
-    int tmp;
+hline32(Imaging im, int32_t x0, int32_t y0, int32_t x1, int32_t ink) {
+    int32_t tmp;
     INT32* p;
 
     if (y0 >= 0 && y0 < im->ysize) {
@@ -145,9 +145,9 @@ hline32(Imaging im, int x0, int y0, int x1, int ink) {
 }
 
 static inline void
-hline32rgba(Imaging im, int x0, int y0, int x1, int ink) {
-    int tmp;
-    unsigned int tmp1, tmp2;
+hline32rgba(Imaging im, int32_t x0, int32_t y0, int32_t x1, int32_t ink) {
+    int32_t tmp;
+    uint32_t tmp1, tmp2;
 
     if (y0 >= 0 && y0 < im->ysize) {
         if (x0 > x1)
@@ -175,10 +175,10 @@ hline32rgba(Imaging im, int x0, int y0, int x1, int ink) {
 }
 
 static inline void
-line8(Imaging im, int x0, int y0, int x1, int y1, int ink) {
-    int i, n, e;
-    int dx, dy;
-    int xs, ys;
+line8(Imaging im, int32_t x0, int32_t y0, int32_t x1, int32_t y1, int32_t ink) {
+    int32_t i, n, e;
+    int32_t dx, dy;
+    int32_t xs, ys;
 
     /* normalize coordinates */
     dx = x1 - x0;
@@ -249,10 +249,10 @@ line8(Imaging im, int x0, int y0, int x1, int y1, int ink) {
 }
 
 static inline void
-line32(Imaging im, int x0, int y0, int x1, int y1, int ink) {
-    int i, n, e;
-    int dx, dy;
-    int xs, ys;
+line32(Imaging im, int32_t x0, int32_t y0, int32_t x1, int32_t y1, int32_t ink) {
+    int32_t i, n, e;
+    int32_t dx, dy;
+    int32_t xs, ys;
 
     /* normalize coordinates */
     dx = x1 - x0;
@@ -323,10 +323,10 @@ line32(Imaging im, int x0, int y0, int x1, int y1, int ink) {
 }
 
 static inline void
-line32rgba(Imaging im, int x0, int y0, int x1, int y1, int ink) {
-    int i, n, e;
-    int dx, dy;
-    int xs, ys;
+line32rgba(Imaging im, int32_t x0, int32_t y0, int32_t x1, int32_t y1, int32_t ink) {
+    int32_t i, n, e;
+    int32_t dx, dy;
+    int32_t xs, ys;
 
     /* normalize coordinates */
     dx = x1 - x0;
@@ -396,7 +396,7 @@ line32rgba(Imaging im, int x0, int y0, int x1, int y1, int ink) {
     }
 }
 
-static int
+static int32_t
 x_cmp(const void* x0, const void* x1) {
     float diff = *((float*)x0) - *((float*)x1);
     if (diff < 0)
@@ -407,11 +407,11 @@ x_cmp(const void* x0, const void* x1) {
         return 0;
 }
 
-static inline int
-polygon8(Imaging im, int n, Edge* e, int ink, int eofill) {
-    int i, j;
+static inline int32_t
+polygon8(Imaging im, int32_t n, Edge* e, int32_t ink, int32_t eofill) {
+    int32_t i, j;
     float* xx;
-    int ymin, ymax;
+    int32_t ymin, ymax;
     float y;
 
     if (n <= 0)
@@ -465,11 +465,11 @@ polygon8(Imaging im, int n, Edge* e, int ink, int eofill) {
     return 0;
 }
 
-static inline int
-polygon32(Imaging im, int n, Edge* e, int ink, int eofill) {
-    int i, j;
+static inline int32_t
+polygon32(Imaging im, int32_t n, Edge* e, int32_t ink, int32_t eofill) {
+    int32_t i, j;
     float* xx;
-    int ymin, ymax;
+    int32_t ymin, ymax;
     float y;
 
     if (n <= 0)
@@ -524,11 +524,11 @@ polygon32(Imaging im, int n, Edge* e, int ink, int eofill) {
     return 0;
 }
 
-static inline int
-polygon32rgba(Imaging im, int n, Edge* e, int ink, int eofill) {
-    int i, j;
+static inline int32_t
+polygon32rgba(Imaging im, int32_t n, Edge* e, int32_t ink, int32_t eofill) {
+    int32_t i, j;
     float* xx;
-    int ymin, ymax;
+    int32_t ymin, ymax;
     float y;
 
     if (n <= 0)
@@ -584,7 +584,7 @@ polygon32rgba(Imaging im, int n, Edge* e, int ink, int eofill) {
 }
 
 static inline void
-add_edge(Edge* e, int x0, int y0, int x1, int y1) {
+add_edge(Edge* e, int32_t x0, int32_t y0, int32_t x1, int32_t y1) {
     /* printf("edge %d %d %d %d\n", x0, y0, x1, y1); */
 
     if (x0 <= x1)
@@ -613,10 +613,10 @@ add_edge(Edge* e, int x0, int y0, int x1, int y1) {
 }
 
 typedef struct {
-    void (*point)(Imaging im, int x, int y, int ink);
-    void (*hline)(Imaging im, int x0, int y0, int x1, int ink);
-    void (*line)(Imaging im, int x0, int y0, int x1, int y1, int ink);
-    int (*polygon)(Imaging im, int n, Edge* e, int ink, int eofill);
+    void (*point)(Imaging im, int32_t x, int32_t y, int32_t ink);
+    void (*hline)(Imaging im, int32_t x0, int32_t y0, int32_t x1, int32_t ink);
+    void (*line)(Imaging im, int32_t x0, int32_t y0, int32_t x1, int32_t y1, int32_t ink);
+    int32_t (*polygon)(Imaging im, int32_t n, Edge* e, int32_t ink, int32_t eofill);
 } DRAW;
 
 DRAW draw8 = {point8, hline8, line8, polygon8};
@@ -636,7 +636,7 @@ DRAW draw32rgba = {point32rgba, hline32rgba, line32rgba, polygon32rgba};
         ink = INK32(ink_);                   \
     }
 
-int ImagingDrawPoint(Imaging im, int x0, int y0, const void* ink_, int op) {
+int32_t ImagingDrawPoint(Imaging im, int32_t x0, int32_t y0, const void* ink_, int32_t op) {
     DRAW* draw;
     INT32 ink;
 
@@ -647,8 +647,8 @@ int ImagingDrawPoint(Imaging im, int x0, int y0, const void* ink_, int op) {
     return 0;
 }
 
-int ImagingDrawLine(Imaging im, int x0, int y0, int x1, int y1, const void* ink_,
-                    int op) {
+int32_t ImagingDrawLine(Imaging im, int32_t x0, int32_t y0, int32_t x1, int32_t y1, const void* ink_,
+                        int32_t op) {
     DRAW* draw;
     INT32 ink;
 
@@ -659,14 +659,14 @@ int ImagingDrawLine(Imaging im, int x0, int y0, int x1, int y1, const void* ink_
     return 0;
 }
 
-int ImagingDrawWideLine(Imaging im, int x0, int y0, int x1, int y1,
-                        const void* ink_, int width, int op) {
+int32_t ImagingDrawWideLine(Imaging im, int32_t x0, int32_t y0, int32_t x1, int32_t y1,
+                            const void* ink_, int32_t width, int32_t op) {
     DRAW* draw;
     INT32 ink;
 
     Edge e[4];
 
-    int dx, dy;
+    int32_t dx, dy;
     double d;
 
     DRAWINIT();
@@ -721,10 +721,10 @@ struct ImagingOutlineInstance {
 
     float x, y;
 
-    int count;
+    int32_t count;
     Edge* edges;
 
-    int size;
+    int32_t size;
 };
 
 void ImagingOutlineDelete(ImagingOutline outline) {
@@ -738,7 +738,7 @@ void ImagingOutlineDelete(ImagingOutline outline) {
 }
 
 static Edge*
-allocate(ImagingOutline outline, int extra) {
+allocate(ImagingOutline outline, int32_t extra) {
     Edge* e;
 
     if (outline->count + extra > outline->size) {
@@ -760,14 +760,14 @@ allocate(ImagingOutline outline, int extra) {
     return e;
 }
 
-int ImagingOutlineMove(ImagingOutline outline, float x0, float y0) {
+int32_t ImagingOutlineMove(ImagingOutline outline, float x0, float y0) {
     outline->x = outline->x0 = x0;
     outline->y = outline->y0 = y0;
 
     return 0;
 }
 
-int ImagingOutlineLine(ImagingOutline outline, float x1, float y1) {
+int32_t ImagingOutlineLine(ImagingOutline outline, float x1, float y1) {
     Edge* e;
 
     e = allocate(outline, 1);
@@ -782,10 +782,10 @@ int ImagingOutlineLine(ImagingOutline outline, float x1, float y1) {
     return 0;
 }
 
-int ImagingOutlineCurve(ImagingOutline outline, float x1, float y1,
-                        float x2, float y2, float x3, float y3) {
+int32_t ImagingOutlineCurve(ImagingOutline outline, float x1, float y1,
+                            float x2, float y2, float x3, float y3) {
     Edge* e;
-    int i;
+    int32_t i;
     float xo, yo;
 
 #define STEPS 32
@@ -823,8 +823,8 @@ int ImagingOutlineCurve(ImagingOutline outline, float x1, float y1,
     return 0;
 }
 
-int ImagingOutlineCurve2(ImagingOutline outline, float cx, float cy,
-                         float x3, float y3) {
+int32_t ImagingOutlineCurve2(ImagingOutline outline, float cx, float cy,
+                             float x3, float y3) {
     /* add bezier curve based on three control points (as
        in the Flash file format) */
 
@@ -835,14 +835,14 @@ int ImagingOutlineCurve2(ImagingOutline outline, float cx, float cy,
         x3, y3);
 }
 
-int ImagingOutlineClose(ImagingOutline outline) {
+int32_t ImagingOutlineClose(ImagingOutline outline) {
     if (outline->x == outline->x0 && outline->y == outline->y0)
         return 0;
     return ImagingOutlineLine(outline, outline->x0, outline->y0);
 }
 
-int ImagingDrawOutline(Imaging im, ImagingOutline outline, const void* ink_,
-                       int fill, int op) {
+int32_t ImagingDrawOutline(Imaging im, ImagingOutline outline, const void* ink_,
+                           int32_t fill, int32_t op) {
     DRAW* draw;
     INT32 ink;
 

--- a/overviewer_core/src/composite.c
+++ b/overviewer_core/src/composite.c
@@ -56,7 +56,9 @@ imaging_python_to_c(PyObject* obj) {
    in these composite functions -- even handles auto-sizing to src! */
 static inline void
 setup_source_destination(Imaging src, Imaging dest,
-                         int* sx, int* sy, int* dx, int* dy, int* xsize, int* ysize) {
+                         int32_t* sx, int32_t* sy,
+                         int32_t* dx, int32_t* dy,
+                         int32_t* xsize, int32_t* ysize) {
     /* handle negative/zero sizes appropriately */
     if (*xsize <= 0 || *ysize <= 0) {
         *xsize = src->xsize;
@@ -275,9 +277,11 @@ alpha_over_wrap(PyObject* self, PyObject* args) {
  * also, it multiplies instead of doing an over operation
  */
 PyObject*
-tint_with_mask(PyObject* dest, uint8_t sr, uint8_t sg,
-               uint8_t sb, uint8_t sa,
-               PyObject* mask, int32_t dx, int32_t dy, int32_t xsize, int32_t ysize) {
+tint_with_mask(PyObject* dest,
+               uint8_t sr, uint8_t sg, uint8_t sb, uint8_t sa,
+               PyObject* mask,
+               int32_t dx, int32_t dy,
+               int32_t xsize, int32_t ysize) {
     /* libImaging handles */
     Imaging imDest, imMask;
     /* cached blend properties */
@@ -378,7 +382,8 @@ draw_triangle(PyObject* dest, int32_t inclusive,
               uint8_t r1, uint8_t g1, uint8_t b1,
               int32_t x2, int32_t y2,
               uint8_t r2, uint8_t g2, uint8_t b2,
-              int32_t tux, int32_t tuy, int* touchups, uint32_t num_touchups) {
+              int32_t tux, int32_t tuy,
+              int32_t* touchups, uint32_t num_touchups) {
 
     /* destination image */
     Imaging imDest;

--- a/overviewer_core/src/composite.c
+++ b/overviewer_core/src/composite.c
@@ -92,7 +92,7 @@ setup_source_destination(Imaging src, Imaging dest,
 
 /* convenience alpha_over with 1.0 as overall_alpha */
 inline PyObject* alpha_over(PyObject* dest, PyObject* src, PyObject* mask,
-                            int dx, int dy, int xsize, int ysize) {
+                            int32_t dx, int32_t dy, int32_t xsize, int32_t ysize) {
     return alpha_over_full(dest, src, mask, 1.0f, dx, dy, xsize, ysize);
 }
 
@@ -103,17 +103,17 @@ inline PyObject* alpha_over(PyObject* dest, PyObject* src, PyObject* mask,
  */
 inline PyObject*
 alpha_over_full(PyObject* dest, PyObject* src, PyObject* mask, float overall_alpha,
-                int dx, int dy, int xsize, int ysize) {
+                int32_t dx, int32_t dy, int32_t xsize, int32_t ysize) {
     /* libImaging handles */
     Imaging imDest, imSrc, imMask;
     /* cached blend properties */
-    int src_has_alpha, mask_offset, mask_stride;
+    int32_t src_has_alpha, mask_offset, mask_stride;
     /* source position */
-    int sx, sy;
+    int32_t sx, sy;
     /* iteration variables */
-    unsigned int x, y, i;
+    uint32_t x, y, i;
     /* temporary calculation variables */
-    int tmp1, tmp2, tmp3;
+    int32_t tmp1, tmp2, tmp3;
     /* integer [0, 255] version of overall_alpha */
     UINT8 overall_alpha_int = 255 * overall_alpha;
 
@@ -202,7 +202,7 @@ alpha_over_full(PyObject* dest, PyObject* src, PyObject* mask, float overall_alp
                 in += 3;
             } else {
                 /* general case */
-                int alpha = in_alpha + OV_MULDIV255(*outmask, 255 - in_alpha, tmp1);
+                int32_t alpha = in_alpha + OV_MULDIV255(*outmask, 255 - in_alpha, tmp1);
                 for (i = 0; i < 3; i++) {
                     /* general case */
                     *out = OV_MULDIV255(*in, in_alpha, tmp1) +
@@ -233,7 +233,7 @@ alpha_over_wrap(PyObject* self, PyObject* args) {
     /* raw input python variables */
     PyObject *dest, *src, *pos = NULL, *mask = NULL;
     /* destination position and size */
-    int dx, dy, xsize, ysize;
+    int32_t dx, dy, xsize, ysize;
     /* return value: dest image on success */
     PyObject* ret;
 
@@ -275,19 +275,19 @@ alpha_over_wrap(PyObject* self, PyObject* args) {
  * also, it multiplies instead of doing an over operation
  */
 PyObject*
-tint_with_mask(PyObject* dest, unsigned char sr, unsigned char sg,
-               unsigned char sb, unsigned char sa,
-               PyObject* mask, int dx, int dy, int xsize, int ysize) {
+tint_with_mask(PyObject* dest, uint8_t sr, uint8_t sg,
+               uint8_t sb, uint8_t sa,
+               PyObject* mask, int32_t dx, int32_t dy, int32_t xsize, int32_t ysize) {
     /* libImaging handles */
     Imaging imDest, imMask;
     /* cached blend properties */
-    int mask_offset, mask_stride;
+    int32_t mask_offset, mask_stride;
     /* source position */
-    int sx, sy;
+    int32_t sx, sy;
     /* iteration variables */
-    unsigned int x, y;
+    uint32_t x, y;
     /* temporary calculation variables */
-    int tmp1, tmp2;
+    int32_t tmp1, tmp2;
 
     imDest = imaging_python_to_c(dest);
     imMask = imaging_python_to_c(mask);
@@ -371,29 +371,29 @@ tint_with_mask(PyObject* dest, unsigned char sr, unsigned char sg,
  *  http://www.gidforums.com/t-20838.html )
  */
 PyObject*
-draw_triangle(PyObject* dest, int inclusive,
-              int x0, int y0,
-              unsigned char r0, unsigned char g0, unsigned char b0,
-              int x1, int y1,
-              unsigned char r1, unsigned char g1, unsigned char b1,
-              int x2, int y2,
-              unsigned char r2, unsigned char g2, unsigned char b2,
-              int tux, int tuy, int* touchups, unsigned int num_touchups) {
+draw_triangle(PyObject* dest, int32_t inclusive,
+              int32_t x0, int32_t y0,
+              uint8_t r0, uint8_t g0, uint8_t b0,
+              int32_t x1, int32_t y1,
+              uint8_t r1, uint8_t g1, uint8_t b1,
+              int32_t x2, int32_t y2,
+              uint8_t r2, uint8_t g2, uint8_t b2,
+              int32_t tux, int32_t tuy, int* touchups, uint32_t num_touchups) {
 
     /* destination image */
     Imaging imDest;
     /* ranges of pixels that are affected */
-    int xmin, xmax, ymin, ymax;
+    int32_t xmin, xmax, ymin, ymax;
     /* constant coefficients for alpha, beta, gamma */
-    int a12, a20, a01;
-    int b12, b20, b01;
-    int c12, c20, c01;
+    int32_t a12, a20, a01;
+    int32_t b12, b20, b01;
+    int32_t c12, c20, c01;
     /* constant normalizers for alpha, beta, gamma */
     float alpha_norm, beta_norm, gamma_norm;
     /* temporary variables */
-    int tmp;
+    int32_t tmp;
     /* iteration variables */
-    int x, y;
+    int32_t x, y;
 
     imDest = imaging_python_to_c(dest);
     if (!imDest)
@@ -445,9 +445,9 @@ draw_triangle(PyObject* dest, int inclusive,
 
             if (alpha >= 0 && beta >= 0 && gamma >= 0 &&
                 (inclusive || (alpha * beta * gamma > 0))) {
-                unsigned int r = alpha * r0 + beta * r1 + gamma * r2;
-                unsigned int g = alpha * g0 + beta * g1 + gamma * g2;
-                unsigned int b = alpha * b0 + beta * b1 + gamma * b2;
+                uint32_t r = alpha * r0 + beta * r1 + gamma * r2;
+                uint32_t g = alpha * g0 + beta * g1 + gamma * g2;
+                uint32_t b = alpha * b0 + beta * b1 + gamma * b2;
 
                 *out = OV_MULDIV255(*out, r, tmp);
                 out++;
@@ -467,7 +467,7 @@ draw_triangle(PyObject* dest, int inclusive,
 
     while (num_touchups > 0) {
         float alpha, beta, gamma;
-        unsigned int r, g, b;
+        uint32_t r, g, b;
         UINT8* out;
 
         x = touchups[0] + tux;
@@ -506,13 +506,13 @@ resize_half(PyObject* dest, PyObject* src) {
     /* libImaging handles */
     Imaging imDest, imSrc;
     /* alpha properties */
-    int src_has_alpha, dest_has_alpha;
+    int32_t src_has_alpha, dest_has_alpha;
     /* iteration variables */
-    unsigned int x, y;
+    uint32_t x, y;
     /* temp color variables */
-    unsigned int r, g, b, a;
+    uint32_t r, g, b, a;
     /* size values for source and destination */
-    int src_width, src_height, dest_width, dest_height;
+    int32_t src_width, src_height, dest_width, dest_height;
 
     imDest = imaging_python_to_c(dest);
     imSrc = imaging_python_to_c(src);

--- a/overviewer_core/src/endian.c
+++ b/overviewer_core/src/endian.c
@@ -17,23 +17,25 @@
 
 /* simple routines for dealing with endian conversion */
 
+#include <stdint.h>
+
 #define UNKNOWN_ENDIAN 0
 #define BIG_ENDIAN 1
 #define LITTLE_ENDIAN 2
 
-static int endianness = UNKNOWN_ENDIAN;
+static int32_t endianness = UNKNOWN_ENDIAN;
 
 void init_endian(void) {
     /* figure out what our endianness is! */
-    short word = 0x0001;
+    int16_t word = 0x0001;
     char* byte = (char*)(&word);
     endianness = byte[0] ? LITTLE_ENDIAN : BIG_ENDIAN;
 }
 
-unsigned short big_endian_ushort(unsigned short in) {
+uint16_t big_endian_ushort(uint16_t in) {
     return (endianness == LITTLE_ENDIAN) ? ((in >> 8) | (in << 8)) : in;
 }
 
-unsigned int big_endian_uint(unsigned int in) {
+uint32_t big_endian_uint(uint32_t in) {
     return (endianness == LITTLE_ENDIAN) ? (((in & 0x000000FF) << 24) + ((in & 0x0000FF00) << 8) + ((in & 0x00FF0000) >> 8) + ((in & 0xFF000000) >> 24)) : in;
 }

--- a/overviewer_core/src/endian.c
+++ b/overviewer_core/src/endian.c
@@ -28,7 +28,7 @@ static int32_t endianness = UNKNOWN_ENDIAN;
 void init_endian(void) {
     /* figure out what our endianness is! */
     int16_t word = 0x0001;
-    char* byte = (char*)(&word);
+    uint8_t* byte = (uint8_t*)(&word);
     endianness = byte[0] ? LITTLE_ENDIAN : BIG_ENDIAN;
 }
 

--- a/overviewer_core/src/iterate.c
+++ b/overviewer_core/src/iterate.c
@@ -21,9 +21,9 @@
 
 static PyObject* textures = NULL;
 
-unsigned int max_blockid = 0;
-unsigned int max_data = 0;
-unsigned char* block_properties = NULL;
+uint32_t max_blockid = 0;
+uint32_t max_data = 0;
+uint8_t* block_properties = NULL;
 
 static PyObject* known_blocks = NULL;
 static PyObject* transparent_blocks = NULL;
@@ -35,7 +35,7 @@ static PyObject* nodata_blocks = NULL;
 PyObject* init_chunk_render(void) {
 
     PyObject* tmp = NULL;
-    unsigned int i;
+    uint32_t i;
 
     /* this function only needs to be called once, anything more should be
      * ignored */
@@ -80,7 +80,7 @@ PyObject* init_chunk_render(void) {
     if (!nodata_blocks)
         return NULL;
 
-    block_properties = calloc(max_blockid, sizeof(unsigned char));
+    block_properties = calloc(max_blockid, sizeof(uint8_t));
     for (i = 0; i < max_blockid; i++) {
         PyObject* block = PyLong_FromLong(i);
 
@@ -104,7 +104,7 @@ PyObject* init_chunk_render(void) {
 }
 
 /* helper for load_chunk, loads a section into a chunk */
-static inline void load_chunk_section(ChunkData* dest, int i, PyObject* section) {
+static inline void load_chunk_section(ChunkData* dest, int32_t i, PyObject* section) {
     dest->sections[i].blocks = (PyArrayObject*)PyDict_GetItemString(section, "Blocks");
     dest->sections[i].data = (PyArrayObject*)PyDict_GetItemString(section, "Data");
     dest->sections[i].skylight = (PyArrayObject*)PyDict_GetItemString(section, "SkyLight");
@@ -121,9 +121,9 @@ static inline void load_chunk_section(ChunkData* dest, int i, PyObject* section)
  * if required is true, failure to load the chunk will raise a python
  * exception and return true.
  */
-int load_chunk(RenderState* state, int x, int z, unsigned char required) {
+int32_t load_chunk(RenderState* state, int32_t x, int32_t z, uint8_t required) {
     ChunkData* dest = &(state->chunks[1 + x][1 + z]);
-    int i;
+    int32_t i;
     PyObject* chunk = NULL;
     PyObject* sections = NULL;
 
@@ -171,7 +171,7 @@ int load_chunk(RenderState* state, int x, int z, unsigned char required) {
 
     for (i = 0; i < PySequence_Fast_GET_SIZE(sections); i++) {
         PyObject* ycoord = NULL;
-        int sectiony = 0;
+        int32_t sectiony = 0;
         PyObject* section = PySequence_Fast_GET_ITEM(sections, i);
         ycoord = PyDict_GetItemString(section, "Y");
         if (!ycoord)
@@ -190,7 +190,7 @@ int load_chunk(RenderState* state, int x, int z, unsigned char required) {
 /* helper to unload all loaded chunks */
 static void
 unload_all_chunks(RenderState* state) {
-    unsigned int i, j, k;
+    uint32_t i, j, k;
     for (i = 0; i < 3; i++) {
         for (j = 0; j < 3; j++) {
             if (state->chunks[i][j].loaded) {
@@ -207,8 +207,8 @@ unload_all_chunks(RenderState* state) {
     }
 }
 
-unsigned short
-check_adjacent_blocks(RenderState* state, int x, int y, int z, unsigned short blockid) {
+uint16_t
+check_adjacent_blocks(RenderState* state, int32_t x, int32_t y, int32_t z, mc_block_t blockid) {
     /*
      * Generates a pseudo ancillary data for blocks that depend of 
      * what are surrounded and don't have ancillary data. This 
@@ -225,7 +225,7 @@ check_adjacent_blocks(RenderState* state, int x, int y, int z, unsigned short bl
      * blockid in the side of the +x direction.
      */
 
-    unsigned char pdata = 0;
+    uint8_t pdata = 0;
 
     if (get_data(state, BLOCKS, x + 1, y, z) == blockid) {
         pdata = pdata | (1 << 3);
@@ -243,14 +243,14 @@ check_adjacent_blocks(RenderState* state, int x, int y, int z, unsigned short bl
     return pdata;
 }
 
-unsigned short
-generate_pseudo_data(RenderState* state, unsigned short ancilData) {
+uint16_t
+generate_pseudo_data(RenderState* state, uint16_t ancilData) {
     /*
      * Generates a fake ancillary data for blocks that are drawn 
      * depending on what are surrounded.
      */
-    int x = state->x, y = state->y, z = state->z;
-    unsigned short data = 0;
+    int32_t x = state->x, y = state->y, z = state->z;
+    uint16_t data = 0;
 
     if (state->block == block_grass) { /* grass */
         /* return 0x10 if grass is covered in snow */
@@ -265,8 +265,8 @@ generate_pseudo_data(RenderState* state, unsigned short ancilData) {
         return data;
     } else if (block_class_is_subset(state->block, (mc_block_t[]){block_glass, block_ice, block_stained_glass}, 3)) { /* glass and ice and stained glass*/
         /* an aditional bit for top is added to the 4 bits of check_adjacent_blocks
-         * Note that stained glass encodes 16 colors using 4 bits.  this pushes us over the 8-bits of an unsigned char, 
-         * forcing us to use an unsigned short to hold 16 bits of pseudo ancil data
+         * Note that stained glass encodes 16 colors using 4 bits.  this pushes us over the 8-bits of an uint8_t, 
+         * forcing us to use an uint16_t to hold 16 bits of pseudo ancil data
          * */
         if ((get_data(state, BLOCKS, x, y + 1, z) == 20) || (get_data(state, BLOCKS, x, y + 1, z) == 95)) {
             data = 0;
@@ -285,7 +285,7 @@ generate_pseudo_data(RenderState* state, unsigned short ancilData) {
         /* three addiotional bit are added, one for on/off state, and
          * another two for going-up redstone wire in the same block
          * (connection with the level y+1) */
-        unsigned char above_level_data = 0, same_level_data = 0, below_level_data = 0, possibly_connected = 0, final_data = 0;
+        uint8_t above_level_data = 0, same_level_data = 0, below_level_data = 0, possibly_connected = 0, final_data = 0;
 
         /* check for air in y+1, no air = no connection with upper level */
         if (get_data(state, BLOCKS, x, y + 1, z) == 0) {
@@ -324,7 +324,7 @@ generate_pseudo_data(RenderState* state, unsigned short ancilData) {
           * and which half of the chest it is: bit 0x10 = second half
           *                                    bit 0x8 = first half */
 
-        unsigned char chest_data = 0, final_data = 0;
+        uint8_t chest_data = 0, final_data = 0;
 
         /* search for adjacent chests of the same type */
         chest_data = check_adjacent_blocks(state, x, y, z, state->block);
@@ -369,10 +369,10 @@ generate_pseudo_data(RenderState* state, unsigned short ancilData) {
         /* use bottom block data format plus one bit for top/down
          * block (0x8) and one bit for hinge position (0x10)
          */
-        unsigned char data = 0;
+        uint8_t data = 0;
         if ((ancilData & 0x8) == 0x8) {
             /* top door block */
-            unsigned char b_data = get_data(state, DATA, x, y - 1, z);
+            uint8_t b_data = get_data(state, DATA, x, y - 1, z);
             if ((ancilData & 0x1) == 0x1) {
                 /* hinge on the left */
                 data = b_data | 0x8 | 0x10;
@@ -381,7 +381,7 @@ generate_pseudo_data(RenderState* state, unsigned short ancilData) {
             }
         } else {
             /* bottom door block */
-            unsigned char t_data = get_data(state, DATA, x, y + 1, z);
+            uint8_t t_data = get_data(state, DATA, x, y + 1, z);
             if ((t_data & 0x1) == 0x1) {
                 /* hinge on the left */
                 data = ancilData | 0x10;
@@ -398,8 +398,8 @@ generate_pseudo_data(RenderState* state, unsigned short ancilData) {
             return check_adjacent_blocks(state, x, y, z, state->block);
         }
     } else if (state->block == block_waterlily) {
-        int wx, wz, wy, rotation;
-        long pr;
+        int32_t wx, wz, wy, rotation;
+        int64_t pr;
         /* calculate the global block coordinates of this position */
         wx = (state->chunkx * 16) + x;
         wz = (state->chunkz * 16) + z;
@@ -426,10 +426,10 @@ generate_pseudo_data(RenderState* state, unsigned short ancilData) {
          */
 
         /* keep track of whether neighbors are stairs, and their data */
-        unsigned char stairs_base[8];
-        unsigned char neigh_base[8];
-        unsigned char* stairs = stairs_base;
-        unsigned char* neigh = neigh_base;
+        uint8_t stairs_base[8];
+        uint8_t neigh_base[8];
+        uint8_t* stairs = stairs_base;
+        uint8_t* neigh = neigh_base;
 
         /* amount to rotate/roll to get to east, west, south, north */
         size_t rotations[] = {0, 2, 3, 1};
@@ -437,25 +437,25 @@ generate_pseudo_data(RenderState* state, unsigned short ancilData) {
         /* masks for the filled (ridge) stair quarters: */
         /* Example: the ridge for an east-ascending stair are the two east quarters */
         /*                  ascending: east  west south north */
-        unsigned char ridge_mask[] = {0x30, 0x48, 0x60, 0x18};
+        uint8_t ridge_mask[] = {0x30, 0x48, 0x60, 0x18};
 
         /* masks for the open (trench) stair quarters: */
-        unsigned char trench_mask[] = {0x48, 0x30, 0x18, 0x60};
+        uint8_t trench_mask[] = {0x48, 0x30, 0x18, 0x60};
 
         /* boat analogy! up the stairs is toward the bow of the boat */
         /* masks for port and starboard, i.e. left and right sides while ascending: */
-        unsigned char port_mask[] = {0x18, 0x60, 0x30, 0x48};
-        unsigned char starboard_mask[] = {0x60, 0x18, 0x48, 0x30};
+        uint8_t port_mask[] = {0x18, 0x60, 0x30, 0x48};
+        uint8_t starboard_mask[] = {0x60, 0x18, 0x48, 0x30};
 
         /* we may need to lock some quarters into place depending on neighbors */
-        unsigned char lock_mask = 0;
+        uint8_t lock_mask = 0;
 
-        unsigned char repair_rot[] = {0, 1, 2, 3, 2, 3, 1, 0, 1, 0, 3, 2, 3, 2, 0, 1};
+        uint8_t repair_rot[] = {0, 1, 2, 3, 2, 3, 1, 0, 1, 0, 3, 2, 3, 2, 0, 1};
 
         /* need to get northdirection of the render */
         /* TODO: get this just once? store in state? */
         PyObject* texrot;
-        int northdir;
+        int32_t northdir;
         texrot = PyObject_GetAttrString(state->textures, "rotation");
         northdir = PyLong_AsLong(texrot);
 
@@ -540,10 +540,10 @@ chunk_render(PyObject* self, PyObject* args) {
     PyObject* modeobj;
     PyObject* blockmap;
 
-    int xoff, yoff;
+    int32_t xoff, yoff;
 
     PyObject *imgsize, *imgsize0_py, *imgsize1_py;
-    int imgsize0, imgsize1;
+    int32_t imgsize0, imgsize1;
 
     PyArrayObject* blocks_py;
     PyArrayObject* left_blocks_py;
@@ -553,7 +553,7 @@ chunk_render(PyObject* self, PyObject* args) {
 
     RenderMode* rendermode;
 
-    int i, j;
+    int32_t i, j;
 
     PyObject* t = NULL;
 
@@ -629,7 +629,7 @@ chunk_render(PyObject* self, PyObject* args) {
             state.imgy = yoff - state.x * 6 + state.z * 6 + 16 * 12 + 15 * 6;
 
             for (state.y = 0; state.y < 16; state.y++) {
-                unsigned short ancilData;
+                uint16_t ancilData;
 
                 state.imgy -= 12;
                 /* get blockid */
@@ -687,8 +687,8 @@ chunk_render(PyObject* self, PyObject* args) {
                 /* if we found a proper texture, render it! */
                 if (t != NULL && t != Py_None) {
                     PyObject *src, *mask, *mask_light;
-                    int do_rand = (state.block == block_tallgrass /*|| state.block == block_red_flower || state.block == block_double_plant*/);
-                    int randx = 0, randy = 0;
+                    int32_t do_rand = (state.block == block_tallgrass /*|| state.block == block_red_flower || state.block == block_double_plant*/);
+                    int32_t randx = 0, randy = 0;
                     src = PyTuple_GetItem(t, 0);
                     mask = PyTuple_GetItem(t, 0);
                     mask_light = PyTuple_GetItem(t, 1);

--- a/overviewer_core/src/iterate.c
+++ b/overviewer_core/src/iterate.c
@@ -121,14 +121,14 @@ static inline void load_chunk_section(ChunkData* dest, int32_t i, PyObject* sect
  * if required is true, failure to load the chunk will raise a python
  * exception and return true.
  */
-int32_t load_chunk(RenderState* state, int32_t x, int32_t z, uint8_t required) {
+bool load_chunk(RenderState* state, int32_t x, int32_t z, uint8_t required) {
     ChunkData* dest = &(state->chunks[1 + x][1 + z]);
     int32_t i;
     PyObject* chunk = NULL;
     PyObject* sections = NULL;
 
     if (dest->loaded)
-        return 0;
+        return false;
 
     /* set up reasonable defaults */
     dest->biomes = NULL;
@@ -150,7 +150,7 @@ int32_t load_chunk(RenderState* state, int32_t x, int32_t z, uint8_t required) {
         if (!required) {
             PyErr_Clear();
         }
-        return 1;
+        return true;
     }
 
     sections = PyDict_GetItemString(chunk, "Sections");
@@ -163,7 +163,7 @@ int32_t load_chunk(RenderState* state, int32_t x, int32_t z, uint8_t required) {
         if (!required) {
             PyErr_Clear();
         }
-        return 1;
+        return true;
     }
 
     dest->biomes = (PyArrayObject*)PyDict_GetItemString(chunk, "Biomes");
@@ -184,7 +184,7 @@ int32_t load_chunk(RenderState* state, int32_t x, int32_t z, uint8_t required) {
     Py_DECREF(sections);
     Py_DECREF(chunk);
 
-    return 0;
+    return false;
 }
 
 /* helper to unload all loaded chunks */

--- a/overviewer_core/src/overviewer.h
+++ b/overviewer_core/src/overviewer.h
@@ -121,7 +121,7 @@ typedef struct {
 } RenderState;
 PyObject* init_chunk_render(void);
 /* returns true on error, x,z relative */
-int32_t load_chunk(RenderState* state, int32_t x, int32_t z, uint8_t required);
+bool load_chunk(RenderState* state, int32_t x, int32_t z, uint8_t required);
 PyObject* chunk_render(PyObject* self, PyObject* args);
 typedef enum {
     KNOWN,
@@ -141,8 +141,8 @@ block_has_property(mc_block_t b, BlockProperty prop) {
     if (b >= max_blockid || !(block_properties[b] & (1 << KNOWN))) {
         /* block is unknown, return defaults */
         if (prop == TRANSPARENT)
-            return 1;
-        return 0;
+            return true;
+        return false;
     }
 
     return block_properties[b] & (1 << prop);

--- a/overviewer_core/src/overviewer.h
+++ b/overviewer_core/src/overviewer.h
@@ -70,7 +70,7 @@ PyObject* draw_triangle(PyObject* dest, int32_t inclusive,
                         uint8_t r1, uint8_t g1, uint8_t b1,
                         int32_t x2, int32_t y2,
                         uint8_t r2, uint8_t g2, uint8_t b2,
-                        int32_t tux, int32_t tuy, int* touchups, uint32_t num_touchups);
+                        int32_t tux, int32_t tuy, int32_t* touchups, uint32_t num_touchups);
 PyObject* resize_half(PyObject* dest, PyObject* src);
 PyObject* resize_half_wrap(PyObject* self, PyObject* args);
 

--- a/overviewer_core/src/primitives/base.c
+++ b/overviewer_core/src/primitives/base.c
@@ -21,14 +21,14 @@
 #include "biomes.h"
 
 typedef struct {
-    int use_biomes;
+    int32_t use_biomes;
     /* grasscolor and foliagecolor lookup tables */
     PyObject *grasscolor, *foliagecolor, *watercolor;
     /* biome-compatible grass/leaf textures */
     PyObject* grass_texture;
 } PrimitiveBase;
 
-static int
+static int32_t
 base_start(void* data, RenderState* state, PyObject* support) {
     PrimitiveBase* self = (PrimitiveBase*)data;
 
@@ -56,8 +56,8 @@ base_finish(void* data, RenderState* state) {
     Py_DECREF(self->grass_texture);
 }
 
-static int
-base_occluded(void* data, RenderState* state, int x, int y, int z) {
+static int32_t
+base_occluded(void* data, RenderState* state, int32_t x, int32_t y, int32_t z) {
     if ((x != 0) && (y != 15) && (z != 15) &&
         !render_mode_hidden(state->rendermode, x - 1, y, z) &&
         !render_mode_hidden(state->rendermode, x, y, z + 1) &&
@@ -76,8 +76,8 @@ base_draw(void* data, RenderState* state, PyObject* src, PyObject* mask, PyObjec
     PrimitiveBase* self = (PrimitiveBase*)data;
 
     /* in order to detect top parts of doublePlant grass & ferns */
-    unsigned short below_block = get_data(state, BLOCKS, state->x, state->y - 1, state->z);
-    unsigned char below_data = get_data(state, DATA, state->x, state->y - 1, state->z);
+    mc_block_t below_block = get_data(state, BLOCKS, state->x, state->y - 1, state->z);
+    uint8_t below_data = get_data(state, DATA, state->x, state->y - 1, state->z);
 
     /* draw the block! */
     alpha_over(state->img, src, mask, state->imgx, state->imgy, 0, 0);
@@ -108,9 +108,9 @@ base_draw(void* data, RenderState* state, PyObject* src, PyObject* mask, PyObjec
         (state->block == block_double_plant && below_block == block_double_plant && (below_data == 2 || below_data == 3))) {
         /* do the biome stuff! */
         PyObject* facemask = mask;
-        unsigned char r = 255, g = 255, b = 255;
+        uint8_t r = 255, g = 255, b = 255;
         PyObject* color_table = NULL;
-        unsigned char flip_xy = 0;
+        uint8_t flip_xy = 0;
 
         if (state->block == block_grass) {
             /* grass needs a special facemask */
@@ -130,12 +130,12 @@ base_draw(void* data, RenderState* state, PyObject* src, PyObject* mask, PyObjec
         }
 
         if (color_table) {
-            unsigned char biome;
-            int dx, dz;
-            unsigned char tablex, tabley;
+            uint8_t biome;
+            int32_t dx, dz;
+            uint8_t tablex, tabley;
             float temp = 0.0, rain = 0.0;
-            unsigned int multr = 0, multg = 0, multb = 0;
-            int tmp;
+            uint32_t multr = 0, multg = 0, multb = 0;
+            int32_t tmp;
             PyObject* color = NULL;
 
             if (self->use_biomes) {
@@ -184,7 +184,7 @@ base_draw(void* data, RenderState* state, PyObject* src, PyObject* mask, PyObjec
             tablex = 255 - (255 * temp);
             tabley = 255 - (255 * rain);
             if (flip_xy) {
-                unsigned char tmp = 255 - tablex;
+                uint8_t tmp = 255 - tablex;
                 tablex = 255 - tabley;
                 tabley = tmp;
             }

--- a/overviewer_core/src/primitives/biomes.h
+++ b/overviewer_core/src/primitives/biomes.h
@@ -15,6 +15,8 @@
  * with the Overviewer.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <stdint.h>
+
 #define DEFAULT_BIOME 4 /* forest, nice and green */
 
 typedef struct {
@@ -23,7 +25,7 @@ typedef struct {
     float temperature;
     float rainfall;
 
-    unsigned int r, g, b;
+    uint32_t r, g, b;
 } Biome;
 
 /* each entry in this table is yanked *directly* out of the minecraft source

--- a/overviewer_core/src/primitives/cave.c
+++ b/overviewer_core/src/primitives/cave.c
@@ -19,11 +19,11 @@
 #include "../overviewer.h"
 
 typedef struct {
-    int only_lit;
+    int32_t only_lit;
 } RenderPrimitiveCave;
 
-static inline int
-touches_light(RenderState* state, DataType type, unsigned int x, unsigned int y, unsigned int z) {
+static inline int32_t
+touches_light(RenderState* state, DataType type, uint32_t x, uint32_t y, uint32_t z) {
     if (get_data(state, type, x, y + 1, z))
         return 1;
 
@@ -38,8 +38,8 @@ touches_light(RenderState* state, DataType type, unsigned int x, unsigned int y,
     return 0;
 }
 
-static int
-cave_occluded(void* data, RenderState* state, int x, int y, int z) {
+static int32_t
+cave_occluded(void* data, RenderState* state, int32_t x, int32_t y, int32_t z) {
     /* check for normal occlusion */
     /* use ajacent chunks, if not you get blocks spreaded in chunk edges */
 
@@ -60,10 +60,10 @@ cave_occluded(void* data, RenderState* state, int x, int y, int z) {
     return 0;
 }
 
-static int
-cave_hidden(void* data, RenderState* state, int x, int y, int z) {
+static int32_t
+cave_hidden(void* data, RenderState* state, int32_t x, int32_t y, int32_t z) {
     RenderPrimitiveCave* self;
-    int dy = 0;
+    int32_t dy = 0;
     self = (RenderPrimitiveCave*)data;
 
     /* check if the block is touching skylight */
@@ -102,7 +102,7 @@ cave_hidden(void* data, RenderState* state, int x, int y, int z) {
     return cave_occluded(data, state, x, y, z);
 }
 
-static int
+static int32_t
 cave_start(void* data, RenderState* state, PyObject* support) {
     RenderPrimitiveCave* self;
     self = (RenderPrimitiveCave*)data;

--- a/overviewer_core/src/primitives/cave.c
+++ b/overviewer_core/src/primitives/cave.c
@@ -22,23 +22,22 @@ typedef struct {
     int32_t only_lit;
 } RenderPrimitiveCave;
 
-static inline int32_t
+static inline bool
 touches_light(RenderState* state, DataType type, uint32_t x, uint32_t y, uint32_t z) {
     if (get_data(state, type, x, y + 1, z))
-        return 1;
-
+        return true;
     if (get_data(state, type, x + 1, y, z))
-        return 1;
+        return true;
     if (get_data(state, type, x - 1, y, z))
-        return 1;
+        return true;
     if (get_data(state, type, x, y, z + 1))
-        return 1;
+        return true;
     if (get_data(state, type, x, y, z - 1))
-        return 1;
-    return 0;
+        return true;
+    return false;
 }
 
-static int32_t
+static bool
 cave_occluded(void* data, RenderState* state, int32_t x, int32_t y, int32_t z) {
     /* check for normal occlusion */
     /* use ajacent chunks, if not you get blocks spreaded in chunk edges */
@@ -46,21 +45,21 @@ cave_occluded(void* data, RenderState* state, int32_t x, int32_t y, int32_t z) {
     if (!is_known_transparent(get_data(state, BLOCKS, x - 1, y, z)) &&
         !is_known_transparent(get_data(state, BLOCKS, x, y, z + 1)) &&
         !is_known_transparent(get_data(state, BLOCKS, x, y + 1, z))) {
-        return 1;
+        return true;
     }
 
     /* special handling for section boundaries */
     if (x == 0 && (!(state->chunks[0][1].loaded) || state->chunks[0][1].sections[state->chunky].blocks == NULL))
-        return 1;
+        return true;
     if (y == 15 && (state->chunky + 1 >= SECTIONS_PER_CHUNK || state->chunks[1][1].sections[state->chunky + 1].blocks == NULL))
-        return 1;
+        return true;
     if (z == 15 && (!(state->chunks[1][2].loaded) || state->chunks[1][2].sections[state->chunky].blocks == NULL))
-        return 1;
+        return true;
 
-    return 0;
+    return false;
 }
 
-static int32_t
+static bool
 cave_hidden(void* data, RenderState* state, int32_t x, int32_t y, int32_t z) {
     RenderPrimitiveCave* self;
     int32_t dy = 0;
@@ -68,11 +67,11 @@ cave_hidden(void* data, RenderState* state, int32_t x, int32_t y, int32_t z) {
 
     /* check if the block is touching skylight */
     if (touches_light(state, SKYLIGHT, x, y, z)) {
-        return 1;
+        return true;
     }
 
     if (self->only_lit && !touches_light(state, BLOCKLIGHT, x, y, z)) {
-        return 1;
+        return true;
     }
 
     /* check for lakes and seas and don't render them
@@ -85,7 +84,7 @@ cave_hidden(void* data, RenderState* state, int32_t x, int32_t y, int32_t z) {
         for (dy = y + 1; dy < (SECTIONS_PER_CHUNK - state->chunky) * 16; dy++) {
             /* go up and check for skylight */
             if (get_data(state, SKYLIGHT, x, dy, z) != 0) {
-                return 1;
+                return true;
             }
             if (get_data(state, BLOCKS, x, dy, z) != 9) {
                 /* we are out of the water! and there's no skylight
@@ -102,15 +101,15 @@ cave_hidden(void* data, RenderState* state, int32_t x, int32_t y, int32_t z) {
     return cave_occluded(data, state, x, y, z);
 }
 
-static int32_t
+static bool
 cave_start(void* data, RenderState* state, PyObject* support) {
     RenderPrimitiveCave* self;
     self = (RenderPrimitiveCave*)data;
 
     if (!render_mode_parse_option(support, "only_lit", "i", &(self->only_lit)))
-        return 1;
+        return true;
 
-    return 0;
+    return false;
 }
 
 RenderPrimitiveInterface primitive_cave = {

--- a/overviewer_core/src/primitives/clear-base.c
+++ b/overviewer_core/src/primitives/clear-base.c
@@ -17,8 +17,8 @@
 
 #include "../overviewer.h"
 
-static int
-clear_base_occluded(void* data, RenderState* state, int x, int y, int z) {
+static int32_t
+clear_base_occluded(void* data, RenderState* state, int32_t x, int32_t y, int32_t z) {
     if ((x != 0) && (y != 15) && (z != 127) &&
         !render_mode_hidden(state->rendermode, x - 1, y, z) &&
         !render_mode_hidden(state->rendermode, x, y, z + 1) &&

--- a/overviewer_core/src/primitives/clear-base.c
+++ b/overviewer_core/src/primitives/clear-base.c
@@ -17,7 +17,7 @@
 
 #include "../overviewer.h"
 
-static int32_t
+static bool
 clear_base_occluded(void* data, RenderState* state, int32_t x, int32_t y, int32_t z) {
     if ((x != 0) && (y != 15) && (z != 127) &&
         !render_mode_hidden(state->rendermode, x - 1, y, z) &&
@@ -26,10 +26,10 @@ clear_base_occluded(void* data, RenderState* state, int32_t x, int32_t y, int32_
         !is_transparent(getArrayShort3D(state->blocks, x - 1, y, z)) &&
         !is_transparent(getArrayShort3D(state->blocks, x, y, z + 1)) &&
         !is_transparent(getArrayShort3D(state->blocks, x, y + 1, z))) {
-        return 1;
+        return true;
     }
 
-    return 0;
+    return false;
 }
 
 static void

--- a/overviewer_core/src/primitives/depth-tinting.c
+++ b/overviewer_core/src/primitives/depth-tinting.c
@@ -23,16 +23,16 @@ typedef struct {
     PyObject* depth_colors;
 } RenderPrimitiveDepthTinting;
 
-static int32_t
+static bool
 depth_tinting_start(void* data, RenderState* state, PyObject* support) {
     RenderPrimitiveDepthTinting* self;
     self = (RenderPrimitiveDepthTinting*)data;
 
     self->depth_colors = PyObject_GetAttrString(support, "depth_colors");
     if (self->depth_colors == NULL)
-        return 1;
+        return true;
 
-    return 0;
+    return false;
 }
 
 static void

--- a/overviewer_core/src/primitives/depth-tinting.c
+++ b/overviewer_core/src/primitives/depth-tinting.c
@@ -23,7 +23,7 @@ typedef struct {
     PyObject* depth_colors;
 } RenderPrimitiveDepthTinting;
 
-static int
+static int32_t
 depth_tinting_start(void* data, RenderState* state, PyObject* support) {
     RenderPrimitiveDepthTinting* self;
     self = (RenderPrimitiveDepthTinting*)data;
@@ -46,7 +46,7 @@ depth_tinting_finish(void* data, RenderState* state) {
 static void
 depth_tinting_draw(void* data, RenderState* state, PyObject* src, PyObject* mask, PyObject* mask_light) {
     RenderPrimitiveDepthTinting* self;
-    int y, r, g, b;
+    int32_t y, r, g, b;
     self = (RenderPrimitiveDepthTinting*)data;
 
     y = state->chunky * 16 + state->y;

--- a/overviewer_core/src/primitives/depth.c
+++ b/overviewer_core/src/primitives/depth.c
@@ -22,26 +22,26 @@ typedef struct {
     uint32_t max;
 } PrimitiveDepth;
 
-static int32_t
+static bool
 depth_start(void* data, RenderState* state, PyObject* support) {
     PrimitiveDepth* self = (PrimitiveDepth*)data;
 
     if (!render_mode_parse_option(support, "min", "I", &(self->min)))
-        return 1;
+        return true;
     if (!render_mode_parse_option(support, "max", "I", &(self->max)))
-        return 1;
+        return true;
 
-    return 0;
+    return false;
 }
 
-static int32_t
+static bool
 depth_hidden(void* data, RenderState* state, int32_t x, int32_t y, int32_t z) {
     PrimitiveDepth* self = (PrimitiveDepth*)data;
     y += 16 * state->chunky;
     if (y > self->max || y < self->min) {
-        return 1;
+        return true;
     }
-    return 0;
+    return false;
 }
 
 RenderPrimitiveInterface primitive_depth = {

--- a/overviewer_core/src/primitives/depth.c
+++ b/overviewer_core/src/primitives/depth.c
@@ -18,11 +18,11 @@
 #include "../overviewer.h"
 
 typedef struct {
-    unsigned int min;
-    unsigned int max;
+    uint32_t min;
+    uint32_t max;
 } PrimitiveDepth;
 
-static int
+static int32_t
 depth_start(void* data, RenderState* state, PyObject* support) {
     PrimitiveDepth* self = (PrimitiveDepth*)data;
 
@@ -34,8 +34,8 @@ depth_start(void* data, RenderState* state, PyObject* support) {
     return 0;
 }
 
-static int
-depth_hidden(void* data, RenderState* state, int x, int y, int z) {
+static int32_t
+depth_hidden(void* data, RenderState* state, int32_t x, int32_t y, int32_t z) {
     PrimitiveDepth* self = (PrimitiveDepth*)data;
     y += 16 * state->chunky;
     if (y > self->max || y < self->min) {

--- a/overviewer_core/src/primitives/edge-lines.c
+++ b/overviewer_core/src/primitives/edge-lines.c
@@ -23,7 +23,7 @@ typedef struct {
     float opacity;
 } PrimitiveEdgeLines;
 
-static int
+static int32_t
 edge_lines_start(void* data, RenderState* state, PyObject* support) {
     PrimitiveEdgeLines* self = (PrimitiveEdgeLines*)data;
     if (!render_mode_parse_option(support, "opacity", "f", &(self->opacity)))
@@ -38,11 +38,11 @@ edge_lines_draw(void* data, RenderState* state, PyObject* src, PyObject* mask, P
     /* Draw some edge lines! */
     if (block_class_is_subset(state->block, (mc_block_t[]){block_stone_slab, block_snow_layer}, 2) || !is_transparent(state->block)) {
         Imaging img_i = imaging_python_to_c(state->img);
-        unsigned char ink[] = {0, 0, 0, 255 * self->opacity};
-        unsigned short side_block;
-        int x = state->x, y = state->y, z = state->z;
+        uint8_t ink[] = {0, 0, 0, 255 * self->opacity};
+        mc_block_t side_block;
+        int32_t x = state->x, y = state->y, z = state->z;
 
-        int increment = 0;
+        int32_t increment = 0;
         if (block_class_is_subset(state->block, (mc_block_t[]){block_wooden_slab, block_stone_slab}, 2) && ((state->block_data & 0x8) == 0)) // half-steps BUT no upsidown half-steps
             increment = 6;
         else if (block_class_is_subset(state->block, (mc_block_t[]){block_snow_layer, block_unpowered_repeater, block_powered_repeater}, 3)) // snow, redstone repeaters (on and off)

--- a/overviewer_core/src/primitives/edge-lines.c
+++ b/overviewer_core/src/primitives/edge-lines.c
@@ -23,12 +23,12 @@ typedef struct {
     float opacity;
 } PrimitiveEdgeLines;
 
-static int32_t
+static bool
 edge_lines_start(void* data, RenderState* state, PyObject* support) {
     PrimitiveEdgeLines* self = (PrimitiveEdgeLines*)data;
     if (!render_mode_parse_option(support, "opacity", "f", &(self->opacity)))
-        return 1;
-    return 0;
+        return true;
+    return false;
 }
 
 static void

--- a/overviewer_core/src/primitives/exposed.c
+++ b/overviewer_core/src/primitives/exposed.c
@@ -18,10 +18,10 @@
 #include "../overviewer.h"
 
 typedef struct {
-    unsigned int mode; /* 0 = exposed only, 1 = unexposed only */
+    uint32_t mode; /* 0 = exposed only, 1 = unexposed only */
 } PrimitiveExposed;
 
-static int
+static int32_t
 exposed_start(void* data, RenderState* state, PyObject* support) {
     PrimitiveExposed* self = (PrimitiveExposed*)data;
 
@@ -31,19 +31,19 @@ exposed_start(void* data, RenderState* state, PyObject* support) {
     return 0;
 }
 
-static int
-exposed_hidden(void* data, RenderState* state, int x, int y, int z) {
+static int32_t
+exposed_hidden(void* data, RenderState* state, int32_t x, int32_t y, int32_t z) {
     PrimitiveExposed* self = (PrimitiveExposed*)data;
 
     /* Unset these flags if seeming exposure from any of these directions would
      * be due to not having data there.
      */
-    int validMinusX = 1;
-    int validPlusX = 1;
-    int validMinusY = 1;
-    int validPlusY = 1;
-    int validMinusZ = 1;
-    int validPlusZ = 1;
+    int32_t validMinusX = 1;
+    int32_t validPlusX = 1;
+    int32_t validMinusY = 1;
+    int32_t validPlusY = 1;
+    int32_t validMinusZ = 1;
+    int32_t validPlusZ = 1;
 
     /* special handling for section boundaries */
     /* If the neighboring section has no block data, ignore exposure from that

--- a/overviewer_core/src/primitives/exposed.c
+++ b/overviewer_core/src/primitives/exposed.c
@@ -21,29 +21,29 @@ typedef struct {
     uint32_t mode; /* 0 = exposed only, 1 = unexposed only */
 } PrimitiveExposed;
 
-static int32_t
+static bool
 exposed_start(void* data, RenderState* state, PyObject* support) {
     PrimitiveExposed* self = (PrimitiveExposed*)data;
 
     if (!render_mode_parse_option(support, "mode", "I", &(self->mode)))
-        return 1;
+        return true;
 
-    return 0;
+    return false;
 }
 
-static int32_t
+static bool
 exposed_hidden(void* data, RenderState* state, int32_t x, int32_t y, int32_t z) {
     PrimitiveExposed* self = (PrimitiveExposed*)data;
 
     /* Unset these flags if seeming exposure from any of these directions would
      * be due to not having data there.
      */
-    int32_t validMinusX = 1;
-    int32_t validPlusX = 1;
-    int32_t validMinusY = 1;
-    int32_t validPlusY = 1;
-    int32_t validMinusZ = 1;
-    int32_t validPlusZ = 1;
+    bool validMinusX = true;
+    bool validPlusX = true;
+    bool validMinusY = true;
+    bool validPlusY = true;
+    bool validMinusZ = true;
+    bool validPlusZ = true;
 
     /* special handling for section boundaries */
     /* If the neighboring section has no block data, ignore exposure from that
@@ -51,32 +51,32 @@ exposed_hidden(void* data, RenderState* state, int32_t x, int32_t y, int32_t z) 
      */
     if (x == 0 && (!(state->chunks[0][1].loaded) || state->chunks[0][1].sections[state->chunky].blocks == NULL)) {
         /* No data in -x direction */
-        validMinusX = 0;
+        validMinusX = false;
     }
 
     if (x == 15 && (!(state->chunks[2][1].loaded) || state->chunks[2][1].sections[state->chunky].blocks == NULL)) {
         /* No data in +x direction */
-        validPlusX = 0;
+        validPlusX = false;
     }
 
     if (y == 0 && (state->chunky - 1 < 0 || state->chunks[1][1].sections[state->chunky - 1].blocks == NULL)) {
         /* No data in -y direction */
-        validMinusY = 0;
+        validMinusY = false;
     }
 
     if (y == 15 && (state->chunky + 1 >= SECTIONS_PER_CHUNK || state->chunks[1][1].sections[state->chunky + 1].blocks == NULL)) {
         /* No data in +y direction */
-        validPlusY = 0;
+        validPlusY = false;
     }
 
     if (z == 0 && (!(state->chunks[1][0].loaded) || state->chunks[1][0].sections[state->chunky].blocks == NULL)) {
         /* No data in -z direction */
-        validMinusZ = 0;
+        validMinusZ = false;
     }
 
     if (z == 15 && (!(state->chunks[1][2].loaded) || state->chunks[1][2].sections[state->chunky].blocks == NULL)) {
         /* No data in +z direction */
-        validPlusZ = 0;
+        validPlusZ = false;
     }
 
     /* If any of the 6 blocks adjacent to us are transparent, we're exposed */

--- a/overviewer_core/src/primitives/height-fading.c
+++ b/overviewer_core/src/primitives/height-fading.c
@@ -20,10 +20,10 @@
 typedef struct {
     PyObject* black_color;
     PyObject* white_color;
-    unsigned int sealevel;
+    uint32_t sealevel;
 } PrimitiveHeightFading;
 
-static int
+static int32_t
 height_fading_start(void* data, RenderState* state, PyObject* support) {
     PrimitiveHeightFading* self = (PrimitiveHeightFading*)data;
 
@@ -48,7 +48,7 @@ static void
 height_fading_draw(void* data, RenderState* state, PyObject* src, PyObject* mask, PyObject* mask_light) {
     float alpha;
     PrimitiveHeightFading* self = (PrimitiveHeightFading*)data;
-    int y = 16 * state->chunky + state->y;
+    int32_t y = 16 * state->chunky + state->y;
 
     /* do some height fading */
     PyObject* height_color = self->white_color;

--- a/overviewer_core/src/primitives/height-fading.c
+++ b/overviewer_core/src/primitives/height-fading.c
@@ -23,17 +23,17 @@ typedef struct {
     uint32_t sealevel;
 } PrimitiveHeightFading;
 
-static int32_t
+static bool
 height_fading_start(void* data, RenderState* state, PyObject* support) {
     PrimitiveHeightFading* self = (PrimitiveHeightFading*)data;
 
     if (!render_mode_parse_option(support, "sealevel", "I", &(self->sealevel)))
-        return 1;
+        return true;
 
     self->black_color = PyObject_GetAttrString(support, "black_color");
     self->white_color = PyObject_GetAttrString(support, "white_color");
 
-    return 0;
+    return false;
 }
 
 static void

--- a/overviewer_core/src/primitives/hide.c
+++ b/overviewer_core/src/primitives/hide.c
@@ -28,26 +28,26 @@ typedef struct {
     struct HideRule* rules;
 } RenderPrimitiveHide;
 
-static int32_t
+static bool
 hide_start(void* data, RenderState* state, PyObject* support) {
     PyObject* opt;
     RenderPrimitiveHide* self = (RenderPrimitiveHide*)data;
     self->rules = NULL;
 
     if (!render_mode_parse_option(support, "blocks", "O", &(opt)))
-        return 1;
+        return true;
     if (opt && opt != Py_None) {
         Py_ssize_t blocks_size = 0, i;
 
         if (!PyList_Check(opt)) {
             PyErr_SetString(PyExc_TypeError, "'blocks' must be a list");
-            return 1;
+            return true;
         }
 
         blocks_size = PyList_GET_SIZE(opt);
         self->rules = calloc(blocks_size + 1, sizeof(struct HideRule));
         if (self->rules == NULL) {
-            return 1;
+            return true;
         }
 
         for (i = 0; i < blocks_size; i++) {
@@ -64,12 +64,12 @@ hide_start(void* data, RenderState* state, PyObject* support) {
                 /* format not recognized */
                 free(self->rules);
                 self->rules = NULL;
-                return 1;
+                return true;
             }
         }
     }
 
-    return 0;
+    return false;
 }
 
 static void
@@ -81,14 +81,14 @@ hide_finish(void* data, RenderState* state) {
     }
 }
 
-static int32_t
+static bool
 hide_hidden(void* data, RenderState* state, int32_t x, int32_t y, int32_t z) {
     RenderPrimitiveHide* self = (RenderPrimitiveHide*)data;
     uint32_t i;
     mc_block_t block;
 
     if (self->rules == NULL)
-        return 0;
+        return false;
 
     block = get_data(state, BLOCKS, x, y, z);
     for (i = 0; self->rules[i].blockid != block_air; i++) {
@@ -96,15 +96,15 @@ hide_hidden(void* data, RenderState* state, int32_t x, int32_t y, int32_t z) {
             uint8_t data;
 
             if (!(self->rules[i].has_data))
-                return 1;
+                return true;
 
             data = get_data(state, DATA, x, y, z);
             if (data == self->rules[i].data)
-                return 1;
+                return true;
         }
     }
 
-    return 0;
+    return false;
 }
 
 RenderPrimitiveInterface primitive_hide = {

--- a/overviewer_core/src/primitives/hide.c
+++ b/overviewer_core/src/primitives/hide.c
@@ -19,16 +19,16 @@
 #include "../overviewer.h"
 
 struct HideRule {
-    unsigned short blockid;
-    unsigned char has_data;
-    unsigned char data;
+    mc_block_t blockid;
+    bool has_data;
+    uint8_t data;
 };
 
 typedef struct {
     struct HideRule* rules;
 } RenderPrimitiveHide;
 
-static int
+static int32_t
 hide_start(void* data, RenderState* state, PyObject* support) {
     PyObject* opt;
     RenderPrimitiveHide* self = (RenderPrimitiveHide*)data;
@@ -56,10 +56,10 @@ hide_start(void* data, RenderState* state, PyObject* support) {
             if (PyLong_Check(block)) {
                 /* format 1: just a block id */
                 self->rules[i].blockid = PyLong_AsLong(block);
-                self->rules[i].has_data = 0;
+                self->rules[i].has_data = false;
             } else if (PyArg_ParseTuple(block, "Hb", &(self->rules[i].blockid), &(self->rules[i].data))) {
                 /* format 2: (blockid, data) */
-                self->rules[i].has_data = 1;
+                self->rules[i].has_data = true;
             } else {
                 /* format not recognized */
                 free(self->rules);
@@ -81,11 +81,11 @@ hide_finish(void* data, RenderState* state) {
     }
 }
 
-static int
-hide_hidden(void* data, RenderState* state, int x, int y, int z) {
+static int32_t
+hide_hidden(void* data, RenderState* state, int32_t x, int32_t y, int32_t z) {
     RenderPrimitiveHide* self = (RenderPrimitiveHide*)data;
-    unsigned int i;
-    unsigned short block;
+    uint32_t i;
+    mc_block_t block;
 
     if (self->rules == NULL)
         return 0;
@@ -93,7 +93,7 @@ hide_hidden(void* data, RenderState* state, int x, int y, int z) {
     block = get_data(state, BLOCKS, x, y, z);
     for (i = 0; self->rules[i].blockid != block_air; i++) {
         if (block == self->rules[i].blockid) {
-            unsigned char data;
+            uint8_t data;
 
             if (!(self->rules[i].has_data))
                 return 1;

--- a/overviewer_core/src/primitives/lighting.c
+++ b/overviewer_core/src/primitives/lighting.c
@@ -25,9 +25,9 @@
    used in lighting calculations */
 static void
 calculate_light_color(void* data,
-                      unsigned char skylight, unsigned char blocklight,
-                      unsigned char* r, unsigned char* g, unsigned char* b) {
-    unsigned char v = 255 * powf(0.8f, 15.0 - OV_MAX(blocklight, skylight));
+                      uint8_t skylight, uint8_t blocklight,
+                      uint8_t* r, uint8_t* g, uint8_t* b) {
+    uint8_t v = 255 * powf(0.8f, 15.0 - OV_MAX(blocklight, skylight));
     *r = v;
     *g = v;
     *b = v;
@@ -36,10 +36,10 @@ calculate_light_color(void* data,
 /* fancy version that uses the colored light texture */
 static void
 calculate_light_color_fancy(void* data,
-                            unsigned char skylight, unsigned char blocklight,
-                            unsigned char* r, unsigned char* g, unsigned char* b) {
+                            uint8_t skylight, uint8_t blocklight,
+                            uint8_t* r, uint8_t* g, uint8_t* b) {
     RenderPrimitiveLighting* mode = (RenderPrimitiveLighting*)(data);
-    unsigned int index;
+    uint32_t index;
     PyObject* color;
 
     blocklight = OV_MAX(blocklight, skylight);
@@ -60,9 +60,9 @@ calculate_light_color_fancy(void* data,
 */
 static void
 calculate_light_color_night(void* data,
-                            unsigned char skylight, unsigned char blocklight,
-                            unsigned char* r, unsigned char* g, unsigned char* b) {
-    unsigned char v = 255 * powf(0.8f, 15.0 - OV_MAX(blocklight, skylight - 11));
+                            uint8_t skylight, uint8_t blocklight,
+                            uint8_t* r, uint8_t* g, uint8_t* b) {
+    uint8_t v = 255 * powf(0.8f, 15.0 - OV_MAX(blocklight, skylight - 11));
     *r = v;
     *g = v;
     *b = v;
@@ -71,10 +71,10 @@ calculate_light_color_night(void* data,
 /* fancy night version that uses the colored light texture */
 static void
 calculate_light_color_fancy_night(void* data,
-                                  unsigned char skylight, unsigned char blocklight,
-                                  unsigned char* r, unsigned char* g, unsigned char* b) {
+                                  uint8_t skylight, uint8_t blocklight,
+                                  uint8_t* r, uint8_t* g, uint8_t* b) {
     RenderPrimitiveLighting* mode = (RenderPrimitiveLighting*)(data);
-    unsigned int index;
+    uint32_t index;
     PyObject* color;
 
     index = skylight + blocklight * 16;
@@ -97,14 +97,14 @@ calculate_light_color_fancy_night(void* data,
  * may (and probably should) pass NULL.
  */
 
-unsigned char
+uint8_t
 estimate_blocklevel(RenderPrimitiveLighting* self, RenderState* state,
-                    int x, int y, int z, int* authoratative) {
+                    int32_t x, int32_t y, int32_t z, int* authoratative) {
 
     /* placeholders for later data arrays, coordinates */
-    unsigned short block;
-    unsigned char blocklevel;
-    unsigned int average_count = 0, average_gather = 0, coeff = 0;
+    mc_block_t block;
+    uint8_t blocklevel;
+    uint32_t average_count = 0, average_gather = 0, coeff = 0;
 
     /* defaults to "guess" until told otherwise */
     if (authoratative)
@@ -113,10 +113,10 @@ estimate_blocklevel(RenderPrimitiveLighting* self, RenderState* state,
     block = get_data(state, BLOCKS, x, y, z);
 
     if (authoratative == NULL) {
-        int auth;
+        int32_t auth;
 
         /* iterate through all surrounding blocks to take an average */
-        int dx, dy, dz, local_block;
+        int32_t dx, dy, dz, local_block;
         for (dx = -1; dx <= 1; dx += 2) {
             for (dy = -1; dy <= 1; dy += 2) {
                 for (dz = -1; dz <= 1; dz += 2) {
@@ -150,12 +150,12 @@ estimate_blocklevel(RenderPrimitiveLighting* self, RenderState* state,
 
 inline void
 get_lighting_color(RenderPrimitiveLighting* self, RenderState* state,
-                   int x, int y, int z,
-                   unsigned char* r, unsigned char* g, unsigned char* b) {
+                   int32_t x, int32_t y, int32_t z,
+                   uint8_t* r, uint8_t* g, uint8_t* b) {
 
     /* placeholders for later data arrays, coordinates */
-    unsigned short block;
-    unsigned char skylevel, blocklevel;
+    mc_block_t block;
+    uint8_t skylevel, blocklevel;
 
     block = get_data(state, BLOCKS, x, y, z);
     skylevel = get_data(state, SKYLIGHT, x, y, z);
@@ -164,10 +164,10 @@ get_lighting_color(RenderPrimitiveLighting* self, RenderState* state,
     /* special half-step handling, stairs handling */
     /* Anvil also needs to be here, blockid 145 */
     if (block_class_is_subset(block, block_class_alt_height, block_class_alt_height_len) || block == block_anvil) {
-        unsigned int upper_block;
+        uint32_t upper_block;
 
         /* stairs and half-blocks take the skylevel from the upper block if it's transparent */
-        int upper_counter = 0;
+        int32_t upper_counter = 0;
         /* but if the upper_block is one of these special half-steps, we need to look at *its* upper_block */
         do {
             upper_counter++;
@@ -196,18 +196,18 @@ get_lighting_color(RenderPrimitiveLighting* self, RenderState* state,
 }
 
 /* does per-face occlusion checking for do_shading_with_mask */
-inline int
-lighting_is_face_occluded(RenderState* state, int skip_sides, int x, int y, int z) {
+inline int32_t
+lighting_is_face_occluded(RenderState* state, int32_t skip_sides, int32_t x, int32_t y, int32_t z) {
     /* first, check for occlusion if the block is in the local chunk */
     if (x >= 0 && x < 16 && y >= 0 && y < 16 && z >= 0 && z < 16) {
-        unsigned short block = getArrayShort3D(state->blocks, x, y, z);
+        mc_block_t block = getArrayShort3D(state->blocks, x, y, z);
 
         if (!is_transparent(block) && !render_mode_hidden(state->rendermode, x, y, z)) {
             /* this face isn't visible, so don't draw anything */
             return 1;
         }
     } else if (!skip_sides) {
-        unsigned short block = get_data(state, BLOCKS, x, y, z);
+        mc_block_t block = get_data(state, BLOCKS, x, y, z);
         if (!is_transparent(block)) {
             /* the same thing but for adjacent chunks, this solves an
                ugly black doted line between chunks in night rendermode.
@@ -223,8 +223,8 @@ lighting_is_face_occluded(RenderState* state, int skip_sides, int x, int y, int 
    lighting results from (x, y, z) */
 static inline void
 do_shading_with_mask(RenderPrimitiveLighting* self, RenderState* state,
-                     int x, int y, int z, PyObject* mask) {
-    unsigned char r, g, b;
+                     int32_t x, int32_t y, int32_t z, PyObject* mask) {
+    uint8_t r, g, b;
     float comp_strength;
 
     /* check occlusion */
@@ -241,7 +241,7 @@ do_shading_with_mask(RenderPrimitiveLighting* self, RenderState* state,
     tint_with_mask(state->img, r, g, b, 255, mask, state->imgx, state->imgy, 0, 0);
 }
 
-static int
+static int32_t
 lighting_start(void* data, RenderState* state, PyObject* support) {
     RenderPrimitiveLighting* self;
     self = (RenderPrimitiveLighting*)data;
@@ -298,7 +298,7 @@ lighting_finish(void* data, RenderState* state) {
 static void
 lighting_draw(void* data, RenderState* state, PyObject* src, PyObject* mask, PyObject* mask_light) {
     RenderPrimitiveLighting* self;
-    int x, y, z;
+    int32_t x, y, z;
 
     self = (RenderPrimitiveLighting*)data;
     x = state->x, y = state->y, z = state->z;

--- a/overviewer_core/src/primitives/lighting.h
+++ b/overviewer_core/src/primitives/lighting.h
@@ -31,7 +31,7 @@ typedef struct {
     /* can be set to 0 in derived modes to indicate that lighting the chunk
      * sides is actually important. Right now, this is used in cave mode
      */
-    int32_t skip_sides;
+    bool skip_sides;
 
     float strength;
     int32_t color;
@@ -40,7 +40,7 @@ typedef struct {
 
 /* exposed so that smooth-lighting can use them */
 extern RenderPrimitiveInterface primitive_lighting;
-int32_t lighting_is_face_occluded(RenderState* state, int32_t skip_sides, int32_t x, int32_t y, int32_t z);
+bool lighting_is_face_occluded(RenderState* state, bool skip_sides, int32_t x, int32_t y, int32_t z);
 void get_lighting_color(RenderPrimitiveLighting* self, RenderState* state,
                         int32_t x, int32_t y, int32_t z,
                         uint8_t* r, uint8_t* g, uint8_t* b);

--- a/overviewer_core/src/primitives/lighting.h
+++ b/overviewer_core/src/primitives/lighting.h
@@ -26,21 +26,21 @@ typedef struct {
 
     /* can be overridden in derived rendermodes to control lighting
        arguments are data, skylight, blocklight, return RGB */
-    void (*calculate_light_color)(void*, unsigned char, unsigned char, unsigned char*, unsigned char*, unsigned char*);
+    void (*calculate_light_color)(void*, uint8_t, uint8_t, uint8_t*, uint8_t*, uint8_t*);
 
     /* can be set to 0 in derived modes to indicate that lighting the chunk
      * sides is actually important. Right now, this is used in cave mode
      */
-    int skip_sides;
+    int32_t skip_sides;
 
     float strength;
-    int color;
-    int night;
+    int32_t color;
+    int32_t night;
 } RenderPrimitiveLighting;
 
 /* exposed so that smooth-lighting can use them */
 extern RenderPrimitiveInterface primitive_lighting;
-int lighting_is_face_occluded(RenderState* state, int skip_sides, int x, int y, int z);
+int32_t lighting_is_face_occluded(RenderState* state, int32_t skip_sides, int32_t x, int32_t y, int32_t z);
 void get_lighting_color(RenderPrimitiveLighting* self, RenderState* state,
-                        int x, int y, int z,
-                        unsigned char* r, unsigned char* g, unsigned char* b);
+                        int32_t x, int32_t y, int32_t z,
+                        uint8_t* r, uint8_t* g, uint8_t* b);

--- a/overviewer_core/src/primitives/nether.c
+++ b/overviewer_core/src/primitives/nether.c
@@ -22,8 +22,8 @@
 
 static void
 walk_chunk(RenderState* state, RenderPrimitiveNether* data) {
-    int x, y, z;
-    int id;
+    int32_t x, y, z;
+    int32_t id;
 
     for (x = -1; x < WIDTH + 1; x++) {
         for (z = -1; z < DEPTH + 1; z++) {
@@ -47,10 +47,10 @@ walk_chunk(RenderState* state, RenderPrimitiveNether* data) {
     data->walked_chunk = 1;
 }
 
-static int
-nether_hidden(void* data, RenderState* state, int x, int y, int z) {
+static int32_t
+nether_hidden(void* data, RenderState* state, int32_t x, int32_t y, int32_t z) {
     RenderPrimitiveNether* self;
-    int real_y;
+    int32_t real_y;
 
     self = (RenderPrimitiveNether*)data;
 

--- a/overviewer_core/src/primitives/nether.c
+++ b/overviewer_core/src/primitives/nether.c
@@ -23,31 +23,31 @@
 static void
 walk_chunk(RenderState* state, RenderPrimitiveNether* data) {
     int32_t x, y, z;
-    int32_t id;
+    mc_block_t blockid;
 
     for (x = -1; x < WIDTH + 1; x++) {
         for (z = -1; z < DEPTH + 1; z++) {
-            id = get_data(state, BLOCKS, x, NETHER_ROOF - (state->chunky * 16), z);
-            if (id == block_bedrock) {
-                data->remove_block[x + 1][NETHER_ROOF][z + 1] = 1;
-                id = get_data(state, BLOCKS, x, (NETHER_ROOF + 1) - (state->chunky * 16), z);
-                if (id == block_brown_mushroom || id == block_red_mushroom)
-                    data->remove_block[x + 1][NETHER_ROOF + 1][z + 1] = 1;
+            blockid = get_data(state, BLOCKS, x, NETHER_ROOF - (state->chunky * 16), z);
+            if (blockid == block_bedrock) {
+                data->remove_block[x + 1][NETHER_ROOF][z + 1] = true;
+                blockid = get_data(state, BLOCKS, x, (NETHER_ROOF + 1) - (state->chunky * 16), z);
+                if (blockid == block_brown_mushroom || blockid == block_red_mushroom)
+                    data->remove_block[x + 1][NETHER_ROOF + 1][z + 1] = true;
             }
 
             for (y = NETHER_ROOF - 1; y >= 0; y--) {
-                id = get_data(state, BLOCKS, x, y - (state->chunky * 16), z);
-                if (block_class_is_subset(id, (mc_block_t[]){block_bedrock, block_netherrack, block_quartz_ore, block_lava}, 4))
-                    data->remove_block[x + 1][y][z + 1] = 1;
+                blockid = get_data(state, BLOCKS, x, y - (state->chunky * 16), z);
+                if (block_class_is_subset(blockid, (mc_block_t[]){block_bedrock, block_netherrack, block_quartz_ore, block_lava}, 4))
+                    data->remove_block[x + 1][y][z + 1] = true;
                 else
                     break;
             }
         }
     }
-    data->walked_chunk = 1;
+    data->walked_chunk = true;
 }
 
-static int32_t
+static bool
 nether_hidden(void* data, RenderState* state, int32_t x, int32_t y, int32_t z) {
     RenderPrimitiveNether* self;
     int32_t real_y;

--- a/overviewer_core/src/primitives/nether.h
+++ b/overviewer_core/src/primitives/nether.h
@@ -25,8 +25,8 @@
 // add two to these because the primative functions should expect to
 // deal with x and z values of -1 and 16
 typedef struct {
-    int32_t walked_chunk;
+    bool walked_chunk;
 
-    int32_t remove_block[WIDTH + 2][HEIGHT][DEPTH + 2];
+    bool remove_block[WIDTH + 2][HEIGHT][DEPTH + 2];
 
 } RenderPrimitiveNether;

--- a/overviewer_core/src/primitives/nether.h
+++ b/overviewer_core/src/primitives/nether.h
@@ -25,8 +25,8 @@
 // add two to these because the primative functions should expect to
 // deal with x and z values of -1 and 16
 typedef struct {
-    int walked_chunk;
+    int32_t walked_chunk;
 
-    int remove_block[WIDTH + 2][HEIGHT][DEPTH + 2];
+    int32_t remove_block[WIDTH + 2][HEIGHT][DEPTH + 2];
 
 } RenderPrimitiveNether;

--- a/overviewer_core/src/primitives/nether_old.c
+++ b/overviewer_core/src/primitives/nether_old.c
@@ -17,14 +17,14 @@
 
 #include "../overviewer.h"
 
-static int
-netherold_hidden(void* data, RenderState* state, int x, int y, int z) {
+static int32_t
+netherold_hidden(void* data, RenderState* state, int32_t x, int32_t y, int32_t z) {
     /* hide all blocks above all air blocks
        
        due to how the nether is currently generated, this will also count
        empty sections as 'solid'
     */
-    unsigned char missing_section = 0;
+    uint8_t missing_section = 0;
     while (y < (SECTIONS_PER_CHUNK - state->chunky) * 16) {
         if (state->chunks[1][1].sections[state->chunky + (y / 16)].blocks == NULL) {
             missing_section = 1;

--- a/overviewer_core/src/primitives/nether_old.c
+++ b/overviewer_core/src/primitives/nether_old.c
@@ -17,33 +17,33 @@
 
 #include "../overviewer.h"
 
-static int32_t
+static bool
 netherold_hidden(void* data, RenderState* state, int32_t x, int32_t y, int32_t z) {
     /* hide all blocks above all air blocks
        
        due to how the nether is currently generated, this will also count
        empty sections as 'solid'
     */
-    uint8_t missing_section = 0;
+    bool missing_section = false;
     while (y < (SECTIONS_PER_CHUNK - state->chunky) * 16) {
         if (state->chunks[1][1].sections[state->chunky + (y / 16)].blocks == NULL) {
-            missing_section = 1;
+            missing_section = true;
             y += 16;
             continue;
         } else {
             /* if we passed through a missing section, but now are back in,
                that counts as air */
             if (missing_section)
-                return 0;
-            missing_section = 0;
+                return false;
+            missing_section = true;
         }
 
         if (!missing_section && get_data(state, BLOCKS, x, y, z) == 0) {
-            return 0;
+            return false;
         }
         y++;
     }
-    return 1;
+    return true;
 }
 
 RenderPrimitiveInterface primitive_nether_old = {

--- a/overviewer_core/src/primitives/no-fluids.c
+++ b/overviewer_core/src/primitives/no-fluids.c
@@ -17,13 +17,13 @@
 
 #include "../overviewer.h"
 
-static int
+static int32_t
 no_fluids_start(void* data, RenderState* state, PyObject* support) {
     return 0;
 }
 
-static int
-no_fluids_hidden(void* data, RenderState* state, int x, int y, int z) {
+static int32_t
+no_fluids_hidden(void* data, RenderState* state, int32_t x, int32_t y, int32_t z) {
     return block_has_property(state->block, FLUID);
 }
 

--- a/overviewer_core/src/primitives/no-fluids.c
+++ b/overviewer_core/src/primitives/no-fluids.c
@@ -17,12 +17,12 @@
 
 #include "../overviewer.h"
 
-static int32_t
+static bool
 no_fluids_start(void* data, RenderState* state, PyObject* support) {
-    return 0;
+    return false;
 }
 
-static int32_t
+static bool
 no_fluids_hidden(void* data, RenderState* state, int32_t x, int32_t y, int32_t z) {
     return block_has_property(state->block, FLUID);
 }

--- a/overviewer_core/src/primitives/overlay-biomes.c
+++ b/overviewer_core/src/primitives/overlay-biomes.c
@@ -110,15 +110,15 @@ static void get_color(void* data, RenderState* state,
     }
 }
 
-static int32_t
+static bool
 overlay_biomes_start(void* data, RenderState* state, PyObject* support) {
     PyObject* opt;
     RenderPrimitiveBiomes* self;
     uint8_t alpha_tmp = 0;
 
     /* first, chain up */
-    int32_t ret = primitive_overlay.start(data, state, support);
-    if (ret != 0)
+    bool ret = primitive_overlay.start(data, state, support);
+    if (ret != false)
         return ret;
 
     /* now do custom initializations */
@@ -126,7 +126,7 @@ overlay_biomes_start(void* data, RenderState* state, PyObject* support) {
 
     // opt is a borrowed reference.  do not deref
     if (!render_mode_parse_option(support, "biomes", "O", &(opt)))
-        return 1;
+        return true;
     if (opt && opt != Py_None) {
         struct BiomeColor* biomes = NULL;
         Py_ssize_t biomes_size = 0, i;
@@ -134,13 +134,13 @@ overlay_biomes_start(void* data, RenderState* state, PyObject* support) {
 
         if (!PyList_Check(opt)) {
             PyErr_SetString(PyExc_TypeError, "'biomes' must be a list");
-            return 1;
+            return true;
         }
 
         biomes_size = PyList_GET_SIZE(opt);
         biomes = self->biomes = calloc(biomes_size + 1, sizeof(struct BiomeColor));
         if (biomes == NULL) {
-            return 1;
+            return true;
         }
 
         for (i = 0; i < biomes_size; i++) {
@@ -151,7 +151,7 @@ overlay_biomes_start(void* data, RenderState* state, PyObject* support) {
             if (!PyArg_ParseTuple(biome, "s(bbb)", &tmpname, &(biomes[i].r), &(biomes[i].g), &(biomes[i].b))) {
                 free(biomes);
                 self->biomes = NULL;
-                return 1;
+                return true;
             }
 
             //printf("%s, (%d, %d, %d) ->", tmpname, biomes[i].r, biomes[i].g, biomes[i].b);
@@ -181,7 +181,7 @@ overlay_biomes_start(void* data, RenderState* state, PyObject* support) {
     /* setup custom color */
     self->parent.get_color = get_color;
 
-    return 0;
+    return false;
 }
 
 static void

--- a/overviewer_core/src/primitives/overlay-biomes.c
+++ b/overviewer_core/src/primitives/overlay-biomes.c
@@ -26,8 +26,8 @@ typedef struct {
 } RenderPrimitiveBiomes;
 
 struct BiomeColor {
-    unsigned char biome;
-    unsigned char r, g, b;
+    uint8_t biome;
+    uint8_t r, g, b;
 };
 
 static struct BiomeColor default_biomes[] = {
@@ -76,18 +76,18 @@ static struct BiomeColor default_biomes[] = {
     {255, 0, 0, 0}};
 
 static void get_color(void* data, RenderState* state,
-                      unsigned char* r, unsigned char* g, unsigned char* b, unsigned char* a) {
+                      uint8_t* r, uint8_t* g, uint8_t* b, uint8_t* a) {
 
-    unsigned char biome;
-    int x = state->x, z = state->z, y_max, y;
-    int max_i = -1;
+    uint8_t biome;
+    int32_t x = state->x, z = state->z, y_max, y;
+    int32_t max_i = -1;
     RenderPrimitiveBiomes* self = (RenderPrimitiveBiomes*)data;
     struct BiomeColor* biomes = (struct BiomeColor*)(self->biomes);
     *a = 0;
 
     y_max = state->y + 1;
     for (y = state->chunky * -16; y <= y_max; y++) {
-        int i, tmp;
+        int32_t i, tmp;
         biome = get_data(state, BIOMES, x, y, z);
 
         if (biome >= NUM_BIOMES) {
@@ -110,14 +110,14 @@ static void get_color(void* data, RenderState* state,
     }
 }
 
-static int
+static int32_t
 overlay_biomes_start(void* data, RenderState* state, PyObject* support) {
     PyObject* opt;
     RenderPrimitiveBiomes* self;
-    unsigned char alpha_tmp = 0;
+    uint8_t alpha_tmp = 0;
 
     /* first, chain up */
-    int ret = primitive_overlay.start(data, state, support);
+    int32_t ret = primitive_overlay.start(data, state, support);
     if (ret != 0)
         return ret;
 
@@ -146,7 +146,7 @@ overlay_biomes_start(void* data, RenderState* state, PyObject* support) {
         for (i = 0; i < biomes_size; i++) {
             PyObject* biome = PyList_GET_ITEM(opt, i);
             char* tmpname = NULL;
-            int j = 0;
+            int32_t j = 0;
 
             if (!PyArg_ParseTuple(biome, "s(bbb)", &tmpname, &(biomes[i].r), &(biomes[i].g), &(biomes[i].b))) {
                 free(biomes);

--- a/overviewer_core/src/primitives/overlay-mineral.c
+++ b/overviewer_core/src/primitives/overlay-mineral.c
@@ -26,7 +26,7 @@ typedef struct {
 } RenderPrimitiveMineral;
 
 struct MineralColor {
-    uint8_t blockid;
+    mc_block_t block;
     uint8_t r, g, b;
 };
 
@@ -59,10 +59,10 @@ static void get_color(void* data, RenderState* state,
     y_max = state->y + 1;
     for (y = state->chunky * -16; y <= y_max; y++) {
         int32_t i, tmp;
-        mc_block_t blockid = get_data(state, BLOCKS, x, y, z);
+        mc_block_t block = get_data(state, BLOCKS, x, y, z);
 
-        for (i = 0; (max_i == -1 || i < max_i) && minerals[i].blockid != block_air; i++) {
-            if (minerals[i].blockid == blockid) {
+        for (i = 0; (max_i == -1 || i < max_i) && minerals[i].block != block_air; i++) {
+            if (minerals[i].block == block) {
                 *r = minerals[i].r;
                 *g = minerals[i].g;
                 *b = minerals[i].b;
@@ -77,14 +77,14 @@ static void get_color(void* data, RenderState* state,
     }
 }
 
-static int32_t
+static bool
 overlay_mineral_start(void* data, RenderState* state, PyObject* support) {
     PyObject* opt;
     RenderPrimitiveMineral* self;
 
     /* first, chain up */
-    int32_t ret = primitive_overlay.start(data, state, support);
-    if (ret != 0)
+    bool ret = primitive_overlay.start(data, state, support);
+    if (ret != false)
         return ret;
 
     /* now do custom initializations */
@@ -92,7 +92,7 @@ overlay_mineral_start(void* data, RenderState* state, PyObject* support) {
 
     // opt is a borrowed reference.  do not deref
     if (!render_mode_parse_option(support, "minerals", "O", &(opt)))
-        return 1;
+        return true;
     if (opt && opt != Py_None) {
         struct MineralColor* minerals = NULL;
         Py_ssize_t minerals_size = 0, i;
@@ -100,21 +100,21 @@ overlay_mineral_start(void* data, RenderState* state, PyObject* support) {
 
         if (!PyList_Check(opt)) {
             PyErr_SetString(PyExc_TypeError, "'minerals' must be a list");
-            return 1;
+            return true;
         }
 
         minerals_size = PyList_GET_SIZE(opt);
         minerals = self->minerals = calloc(minerals_size + 1, sizeof(struct MineralColor));
         if (minerals == NULL) {
-            return 1;
+            return true;
         }
 
         for (i = 0; i < minerals_size; i++) {
             PyObject* mineral = PyList_GET_ITEM(opt, i);
-            if (!PyArg_ParseTuple(mineral, "b(bbb)", &(minerals[i].blockid), &(minerals[i].r), &(minerals[i].g), &(minerals[i].b))) {
+            if (!PyArg_ParseTuple(mineral, "b(bbb)", &(minerals[i].block), &(minerals[i].r), &(minerals[i].g), &(minerals[i].b))) {
                 free(minerals);
                 self->minerals = NULL;
-                return 1;
+                return true;
             }
         }
     } else {
@@ -124,7 +124,7 @@ overlay_mineral_start(void* data, RenderState* state, PyObject* support) {
     /* setup custom color */
     self->parent.get_color = get_color;
 
-    return 0;
+    return false;
 }
 
 static void

--- a/overviewer_core/src/primitives/overlay-mineral.c
+++ b/overviewer_core/src/primitives/overlay-mineral.c
@@ -26,8 +26,8 @@ typedef struct {
 } RenderPrimitiveMineral;
 
 struct MineralColor {
-    unsigned char blockid;
-    unsigned char r, g, b;
+    uint8_t blockid;
+    uint8_t r, g, b;
 };
 
 /* put more valuable ores first -- they take precedence */
@@ -48,18 +48,18 @@ static struct MineralColor default_minerals[] = {
     {0, 0, 0, 0}};
 
 static void get_color(void* data, RenderState* state,
-                      unsigned char* r, unsigned char* g, unsigned char* b, unsigned char* a) {
+                      uint8_t* r, uint8_t* g, uint8_t* b, uint8_t* a) {
 
-    int x = state->x, z = state->z, y_max, y;
-    int max_i = -1;
+    int32_t x = state->x, z = state->z, y_max, y;
+    int32_t max_i = -1;
     RenderPrimitiveMineral* self = (RenderPrimitiveMineral*)data;
     struct MineralColor* minerals = (struct MineralColor*)(self->minerals);
     *a = 0;
 
     y_max = state->y + 1;
     for (y = state->chunky * -16; y <= y_max; y++) {
-        int i, tmp;
-        unsigned short blockid = get_data(state, BLOCKS, x, y, z);
+        int32_t i, tmp;
+        mc_block_t blockid = get_data(state, BLOCKS, x, y, z);
 
         for (i = 0; (max_i == -1 || i < max_i) && minerals[i].blockid != block_air; i++) {
             if (minerals[i].blockid == blockid) {
@@ -77,13 +77,13 @@ static void get_color(void* data, RenderState* state,
     }
 }
 
-static int
+static int32_t
 overlay_mineral_start(void* data, RenderState* state, PyObject* support) {
     PyObject* opt;
     RenderPrimitiveMineral* self;
 
     /* first, chain up */
-    int ret = primitive_overlay.start(data, state, support);
+    int32_t ret = primitive_overlay.start(data, state, support);
     if (ret != 0)
         return ret;
 

--- a/overviewer_core/src/primitives/overlay-slime.c
+++ b/overviewer_core/src/primitives/overlay-slime.c
@@ -21,7 +21,7 @@
 typedef struct {
     /* inherits from overlay */
     RenderPrimitiveOverlay parent;
-    long long seed; // needs to be at least 64-bits
+    int64_t seed; // needs to be at least 64-bits
 } RenderPrimitiveSlime;
 
 /*
@@ -30,43 +30,38 @@ typedef struct {
  * http://docs.oracle.com/javase/1.4.2/docs/api/java/util/Random.html
  */
 
-static void random_set_seed(long long* seed, long long new_seed) {
+static void random_set_seed(int64_t* seed, int64_t new_seed) {
     *seed = (new_seed ^ 0x5deece66dLL) & ((1LL << 48) - 1);
 }
 
-static int32_t random_next(long long* seed, int32_t bits) {
+static int64_t random_next(int64_t* seed, int32_t bits) {
     *seed = (*seed * 0x5deece66dLL + 0xbL) & ((1LL << 48) - 1);
-    return (int)(*seed >> (48 - bits));
+    return (int64_t)(*seed >> (48 - bits));
 }
 
-static int32_t random_next_int(long long* seed, int32_t n) {
-    int32_t bits, val;
+static int64_t random_next_int(int64_t* seed, uint32_t modulo) {
+    int64_t bits, val;
 
-    if (n <= 0) {
-        /* invalid */
-        return 0;
-    }
-
-    if ((n & -n) == n) {
-        /* n is a power of two */
-        return (int)((n * (long long)random_next(seed, 31)) >> 31);
+    if ((modulo & -modulo) == modulo) {
+        /* modulo is a power of two */
+        return (int64_t)((modulo * (int64_t)random_next(seed, 31)) >> 31);
     }
 
     do {
         bits = random_next(seed, 31);
-        val = bits % n;
-    } while (bits - val + (n - 1) < 0);
+        val = bits % modulo;
+    } while (bits - val + (modulo - 1) < 0);
     return val;
 }
 
-static int32_t is_slime(long long map_seed, int32_t chunkx, int32_t chunkz) {
+static bool is_slime(int64_t map_seed, int32_t chunkx, int32_t chunkz) {
     /* lots of magic numbers, but they're all correct! I swear! */
-    long long seed;
+    int64_t seed;
     random_set_seed(&seed, (map_seed +
-                            (long long)(chunkx * chunkx * 0x4c1906) +
-                            (long long)(chunkx * 0x5ac0db) +
-                            (long long)(chunkz * chunkz * 0x4307a7LL) +
-                            (long long)(chunkz * 0x5f24f)) ^
+                            (int64_t)(chunkx * chunkx * 0x4c1906) +
+                            (int64_t)(chunkx * 0x5ac0db) +
+                            (int64_t)(chunkz * chunkz * 0x4307a7LL) +
+                            (int64_t)(chunkz * 0x5f24f)) ^
                                0x3ad8025f);
     return (random_next_int(&seed, 10) == 0);
 }
@@ -89,14 +84,14 @@ static void get_color(void* data, RenderState* state,
     }
 }
 
-static int32_t
+static bool
 overlay_slime_start(void* data, RenderState* state, PyObject* support) {
     RenderPrimitiveSlime* self;
     PyObject* pyseed;
 
     /* first, chain up */
-    int32_t ret = primitive_overlay.start(data, state, support);
-    if (ret != 0)
+    bool ret = primitive_overlay.start(data, state, support);
+    if (ret != false)
         return ret;
 
     /* now do custom initializations */
@@ -110,13 +105,13 @@ overlay_slime_start(void* data, RenderState* state, PyObject* support) {
 
     pyseed = PyObject_GetAttrString(state->world, "seed");
     if (!pyseed)
-        return 1;
+        return true;
     self->seed = PyLong_AsLongLong(pyseed);
     Py_DECREF(pyseed);
     if (PyErr_Occurred())
-        return 1;
+        return true;
 
-    return 0;
+    return false;
 }
 
 static void

--- a/overviewer_core/src/primitives/overlay-slime.c
+++ b/overviewer_core/src/primitives/overlay-slime.c
@@ -34,13 +34,13 @@ static void random_set_seed(long long* seed, long long new_seed) {
     *seed = (new_seed ^ 0x5deece66dLL) & ((1LL << 48) - 1);
 }
 
-static int random_next(long long* seed, int bits) {
+static int32_t random_next(long long* seed, int32_t bits) {
     *seed = (*seed * 0x5deece66dLL + 0xbL) & ((1LL << 48) - 1);
     return (int)(*seed >> (48 - bits));
 }
 
-static int random_next_int(long long* seed, int n) {
-    int bits, val;
+static int32_t random_next_int(long long* seed, int32_t n) {
+    int32_t bits, val;
 
     if (n <= 0) {
         /* invalid */
@@ -59,7 +59,7 @@ static int random_next_int(long long* seed, int n) {
     return val;
 }
 
-static int is_slime(long long map_seed, int chunkx, int chunkz) {
+static int32_t is_slime(long long map_seed, int32_t chunkx, int32_t chunkz) {
     /* lots of magic numbers, but they're all correct! I swear! */
     long long seed;
     random_set_seed(&seed, (map_seed +
@@ -72,7 +72,7 @@ static int is_slime(long long map_seed, int chunkx, int chunkz) {
 }
 
 static void get_color(void* data, RenderState* state,
-                      unsigned char* r, unsigned char* g, unsigned char* b, unsigned char* a) {
+                      uint8_t* r, uint8_t* g, uint8_t* b, uint8_t* a) {
     RenderPrimitiveSlime* self = (RenderPrimitiveSlime*)data;
 
     /* set a nice, pretty green color */
@@ -89,13 +89,13 @@ static void get_color(void* data, RenderState* state,
     }
 }
 
-static int
+static int32_t
 overlay_slime_start(void* data, RenderState* state, PyObject* support) {
     RenderPrimitiveSlime* self;
     PyObject* pyseed;
 
     /* first, chain up */
-    int ret = primitive_overlay.start(data, state, support);
+    int32_t ret = primitive_overlay.start(data, state, support);
     if (ret != 0)
         return ret;
 

--- a/overviewer_core/src/primitives/overlay-spawn.c
+++ b/overviewer_core/src/primitives/overlay-spawn.c
@@ -24,11 +24,11 @@ typedef struct {
 } RenderPrimitiveSpawn;
 
 static void get_color(void* data, RenderState* state,
-                      unsigned char* r, unsigned char* g, unsigned char* b, unsigned char* a) {
+                      uint8_t* r, uint8_t* g, uint8_t* b, uint8_t* a) {
     RenderPrimitiveSpawn* self = (RenderPrimitiveSpawn*)data;
-    int x = state->x, y = state->y, z = state->z;
-    int y_light = y + 1;
-    unsigned char blocklight, skylight;
+    int32_t x = state->x, y = state->y, z = state->z;
+    int32_t y_light = y + 1;
+    uint8_t blocklight, skylight;
 
     /* set a nice, pretty red color */
     *r = self->parent.color->r;
@@ -55,12 +55,12 @@ static void get_color(void* data, RenderState* state,
     }
 }
 
-static int
+static int32_t
 overlay_spawn_start(void* data, RenderState* state, PyObject* support) {
     RenderPrimitiveSpawn* self;
 
     /* first, chain up */
-    int ret = primitive_overlay.start(data, state, support);
+    int32_t ret = primitive_overlay.start(data, state, support);
     if (ret != 0)
         return ret;
 

--- a/overviewer_core/src/primitives/overlay-spawn.c
+++ b/overviewer_core/src/primitives/overlay-spawn.c
@@ -55,13 +55,13 @@ static void get_color(void* data, RenderState* state,
     }
 }
 
-static int32_t
+static bool
 overlay_spawn_start(void* data, RenderState* state, PyObject* support) {
     RenderPrimitiveSpawn* self;
 
     /* first, chain up */
-    int32_t ret = primitive_overlay.start(data, state, support);
-    if (ret != 0)
+    bool ret = primitive_overlay.start(data, state, support);
+    if (ret != false)
         return ret;
 
     /* now do custom initializations */
@@ -73,7 +73,7 @@ overlay_spawn_start(void* data, RenderState* state, PyObject* support) {
     self->parent.default_color.b = 38;
     self->parent.default_color.a = 0;
 
-    return 0;
+    return false;
 }
 
 static void

--- a/overviewer_core/src/primitives/overlay-structure.c
+++ b/overviewer_core/src/primitives/overlay-structure.c
@@ -83,7 +83,7 @@ static void get_color(void* data,
     return;
 }
 
-static int32_t overlay_structure_start(void* data, RenderState* state, PyObject* support) {
+static bool overlay_structure_start(void* data, RenderState* state, PyObject* support) {
     /**
      * Initializing the search for structures by parsing the arguments and storing them into
      * appropriate structures. If no arguments are passed create and use default values.
@@ -92,8 +92,8 @@ static int32_t overlay_structure_start(void* data, RenderState* state, PyObject*
     RenderPrimitiveStructure* self;
 
     /* first, chain up */
-    int32_t ret = primitive_overlay.start(data, state, support);
-    if (ret != 0)
+    bool ret = primitive_overlay.start(data, state, support);
+    if (ret != false)
         return ret;
 
     /* now do custom initializations */
@@ -102,7 +102,7 @@ static int32_t overlay_structure_start(void* data, RenderState* state, PyObject*
     // opt is a borrowed reference.  do not deref
     // store the structures python object into opt.
     if (!render_mode_parse_option(support, "structures", "O", &(opt)))
-        return 1;
+        return true;
 
     /**
      * Check if a sane option was passed.
@@ -116,7 +116,7 @@ static int32_t overlay_structure_start(void* data, RenderState* state, PyObject*
         opt = PySequence_Fast(opt, "expected a sequence");
         if (!opt) {
             PyErr_SetString(PyExc_TypeError, "'structures' must be a a sequence");
-            return 1;
+            return true;
         }
 
         structures_size = PySequence_Fast_GET_SIZE(opt);
@@ -125,7 +125,7 @@ static int32_t overlay_structure_start(void* data, RenderState* state, PyObject*
         self->numcolors = structures_size;
         if (structures == NULL) {
             PyErr_SetString(PyExc_MemoryError, "failed to allocate memory");
-            return 1;
+            return true;
         }
 
         /**
@@ -144,7 +144,7 @@ static int32_t overlay_structure_start(void* data, RenderState* state, PyObject*
                     // Exception set automatically
                     free(structures);
                     self->structures = NULL;
-                    return 1;
+                    return true;
                 }
 
                 // Parse colorpy into a c-struct.
@@ -155,7 +155,7 @@ static int32_t overlay_structure_start(void* data, RenderState* state, PyObject*
                                       &structures[i].a)) {
                     free(structures);
                     self->structures = NULL;
-                    return 1;
+                    return true;
                 }
 
                 // Convert condspy to a fast sequence
@@ -163,7 +163,7 @@ static int32_t overlay_structure_start(void* data, RenderState* state, PyObject*
                 if (condspy == NULL) {
                     free(structures);
                     self->structures = NULL;
-                    return 1;
+                    return true;
                 }
 
                 // get the number of conditions.
@@ -176,7 +176,7 @@ static int32_t overlay_structure_start(void* data, RenderState* state, PyObject*
                     PyErr_SetString(PyExc_MemoryError, "failed to allocate memory");
                     free(structures);
                     self->structures = NULL;
-                    return 1;
+                    return true;
                 }
 
                 // iterate over all the conditions and read them.
@@ -193,7 +193,7 @@ static int32_t overlay_structure_start(void* data, RenderState* state, PyObject*
                         }
                         free(structures);
                         self->structures = NULL;
-                        return 1;
+                        return true;
                     }
                 }
             }
@@ -203,7 +203,7 @@ static int32_t overlay_structure_start(void* data, RenderState* state, PyObject*
     /* setup custom color */
     self->parent.get_color = get_color;
 
-    return 0;
+    return false;
 }
 
 static void overlay_structure_finish(void* data, RenderState* state) {

--- a/overviewer_core/src/primitives/overlay-structure.c
+++ b/overviewer_core/src/primitives/overlay-structure.c
@@ -18,38 +18,35 @@
 #include "../mc_id.h"
 #include "overlay.h"
 
-typedef enum { false,
-               true } bool;
-
 typedef struct {
     /* inherits from overlay */
     RenderPrimitiveOverlay parent;
     void* structures;
-    int numcolors;
+    int32_t numcolors;
 } RenderPrimitiveStructure;
 
 struct Condition {
-    int relx, rely, relz;
-    unsigned short block;
+    int32_t relx, rely, relz;
+    mc_block_t block;
 };
 
 struct Color {
-    int numconds;
+    int32_t numconds;
     struct Condition* conditions;
-    unsigned char r, g, b, a;
+    uint8_t r, g, b, a;
 };
 
 static void get_color(void* data,
                       RenderState* state,
-                      unsigned char* r,
-                      unsigned char* g,
-                      unsigned char* b,
-                      unsigned char* a) {
+                      uint8_t* r,
+                      uint8_t* g,
+                      uint8_t* b,
+                      uint8_t* a) {
     /**
      * Calculate the color at the current position and store the values to r,g,b,a.
      **/
     RenderPrimitiveStructure* self = (RenderPrimitiveStructure*)data;
-    int x = state->x, z = state->z, y_max, y, col, cond;
+    int32_t x = state->x, z = state->z, y_max, y, col, cond;
     struct Color* structures = (struct Color*)(self->structures);
     struct Condition* c = NULL;
     bool all = true;
@@ -86,7 +83,7 @@ static void get_color(void* data,
     return;
 }
 
-static int overlay_structure_start(void* data, RenderState* state, PyObject* support) {
+static int32_t overlay_structure_start(void* data, RenderState* state, PyObject* support) {
     /**
      * Initializing the search for structures by parsing the arguments and storing them into
      * appropriate structures. If no arguments are passed create and use default values.
@@ -95,7 +92,7 @@ static int overlay_structure_start(void* data, RenderState* state, PyObject* sup
     RenderPrimitiveStructure* self;
 
     /* first, chain up */
-    int ret = primitive_overlay.start(data, state, support);
+    int32_t ret = primitive_overlay.start(data, state, support);
     if (ret != 0)
         return ret;
 
@@ -190,7 +187,7 @@ static int overlay_structure_start(void* data, RenderState* state, PyObject* sup
                                           &cond[n].rely,
                                           &cond[n].relz,
                                           &cond[n].block)) {
-                        int x = 0;
+                        int32_t x = 0;
                         for (x = 0; x < structures_size; x++) {
                             free(structures[x].conditions);
                         }
@@ -212,7 +209,7 @@ static int overlay_structure_start(void* data, RenderState* state, PyObject* sup
 static void overlay_structure_finish(void* data, RenderState* state) {
     /* first free all *our* stuff */
     RenderPrimitiveStructure* self = (RenderPrimitiveStructure*)data;
-    int i = 0;
+    int32_t i = 0;
 
     if (self->structures) {
         // freeing the nested structure

--- a/overviewer_core/src/primitives/overlay.c
+++ b/overviewer_core/src/primitives/overlay.c
@@ -19,7 +19,7 @@
 #include "../mc_id.h"
 
 static void get_color(void* data, RenderState* state,
-                      unsigned char* r, unsigned char* g, unsigned char* b, unsigned char* a) {
+                      uint8_t* r, uint8_t* g, uint8_t* b, uint8_t* a) {
     RenderPrimitiveOverlay* self = (RenderPrimitiveOverlay*)data;
 
     *r = self->color->r;
@@ -28,7 +28,7 @@ static void get_color(void* data, RenderState* state,
     *a = self->color->a;
 }
 
-static int
+static int32_t
 overlay_start(void* data, RenderState* state, PyObject* support) {
     PyObject* opt = NULL;
     OverlayColor* color = NULL;
@@ -80,11 +80,11 @@ overlay_finish(void* data, RenderState* state) {
 
 void overlay_draw(void* data, RenderState* state, PyObject* src, PyObject* mask, PyObject* mask_light) {
     RenderPrimitiveOverlay* self = (RenderPrimitiveOverlay*)data;
-    unsigned char r, g, b, a;
-    unsigned short top_block;
+    uint8_t r, g, b, a;
+    mc_block_t top_block;
 
     // exactly analogous to edge-line code for these special blocks
-    int increment = 0;
+    int32_t increment = 0;
     if (state->block == block_stone_slab) // half-step
         increment = 6;
     else if (state->block == block_snow_layer) // snow

--- a/overviewer_core/src/primitives/overlay.c
+++ b/overviewer_core/src/primitives/overlay.c
@@ -41,7 +41,7 @@ overlay_start(void* data, RenderState* state, PyObject* support) {
     color = self->color = calloc(1, sizeof(OverlayColor));
 
     if (color == NULL) {
-        return 1;
+        return true;
     }
 
     self->default_color.r = 200;
@@ -58,12 +58,12 @@ overlay_start(void* data, RenderState* state, PyObject* support) {
         if (render_mode_parse_option(support, "overlay_color", "O", &(opt))) {
             // If it is an object, check to see if it is None, if it is, use the default.
             if (opt && opt != Py_None) {
-                return 1;
+                return true;
             }
         }
     }
 
-    return 0;
+    return false;
 }
 
 static void

--- a/overviewer_core/src/primitives/overlay.h
+++ b/overviewer_core/src/primitives/overlay.h
@@ -18,7 +18,7 @@
 #include "../overviewer.h"
 
 typedef struct {
-    unsigned char r, g, b, a;
+    uint8_t r, g, b, a;
 } OverlayColor;
 
 typedef struct {
@@ -33,7 +33,7 @@ typedef struct {
        overlay alpha and color
        last four vars are r, g, b, a out */
     void (*get_color)(void*, RenderState*,
-                      unsigned char*, unsigned char*, unsigned char*, unsigned char*);
+                      uint8_t*, uint8_t*, uint8_t*, uint8_t*);
 } RenderPrimitiveOverlay;
 extern RenderPrimitiveInterface primitive_overlay;
 

--- a/overviewer_core/src/primitives/smooth-lighting.c
+++ b/overviewer_core/src/primitives/smooth-lighting.c
@@ -181,13 +181,13 @@ do_shading_with_rule(RenderPrimitiveSmoothLighting* self, RenderState* state, st
                   x, y, NULL, 0);
 }
 
-static int32_t
+static bool
 smooth_lighting_start(void* data, RenderState* state, PyObject* support) {
     /* first, chain up */
-    int32_t ret = primitive_lighting.start(data, state, support);
-    if (ret != 0)
+    bool ret = primitive_lighting.start(data, state, support);
+    if (ret != false)
         return ret;
-    return 0;
+    return false;
 }
 
 static void
@@ -198,9 +198,9 @@ smooth_lighting_finish(void* data, RenderState* state) {
 
 static void
 smooth_lighting_draw(void* data, RenderState* state, PyObject* src, PyObject* mask, PyObject* mask_light) {
-    int32_t light_top = 1;
-    int32_t light_left = 1;
-    int32_t light_right = 1;
+    bool light_top   = true;
+    bool light_left  = true;
+    bool light_right = true;
     RenderPrimitiveSmoothLighting* self = (RenderPrimitiveSmoothLighting*)data;
 
     /* special case for leaves, water 8, water 9, ice 79
@@ -216,11 +216,11 @@ smooth_lighting_draw(void* data, RenderState* state, PyObject* src, PyObject* ma
     /* special code for water */
     if (state->block == block_water) {
         if (!(state->block_pdata & (1 << 4)))
-            light_top = 0;
+            light_top = false;
         if (!(state->block_pdata & (1 << 1)))
-            light_left = 0;
+            light_left = false;
         if (!(state->block_pdata & (1 << 2)))
-            light_right = 0;
+            light_right = false;
     }
 
     if (light_top)

--- a/overviewer_core/src/primitives/smooth-lighting.c
+++ b/overviewer_core/src/primitives/smooth-lighting.c
@@ -29,29 +29,29 @@ typedef struct {
 /* structure representing one corner of a face (see below) */
 struct SmoothLightingCorner {
     /* where this corner shows up on each block texture */
-    int imgx, imgy;
+    int32_t imgx, imgy;
 
     /* the two block offsets that (together) determine the 4 blocks to use */
-    int dx1, dy1, dz1;
-    int dx2, dy2, dz2;
+    int32_t dx1, dy1, dz1;
+    int32_t dx2, dy2, dz2;
 };
 
 /* structure for rule table handling lighting */
 struct SmoothLightingFace {
     /* offset from current coordinate to the block this face points towards
        used for occlusion calculations, and as a base for later */
-    int dx, dy, dz;
+    int32_t dx, dy, dz;
 
     /* the points that form the corners of this face */
     struct SmoothLightingCorner corners[4];
 
     /* pairs of (x,y) in order, as touch-up points, or NULL for none */
     int* touch_up_points;
-    unsigned int num_touch_up_points;
+    uint32_t num_touch_up_points;
 };
 
 /* top face touchups, pulled from textures.py (_build_block) */
-static int top_touchups[] = {1, 5, 3, 4, 5, 3, 7, 2, 9, 1, 11, 0};
+static int32_t top_touchups[] = {1, 5, 3, 4, 5, 3, 7, 2, 9, 1, 11, 0};
 
 /* the lighting face rule list! */
 static struct SmoothLightingFace lighting_rules[] = {
@@ -110,17 +110,17 @@ enum {
 
 static void
 do_shading_with_rule(RenderPrimitiveSmoothLighting* self, RenderState* state, struct SmoothLightingFace face) {
-    int i;
+    int32_t i;
     RenderPrimitiveLighting* lighting = (RenderPrimitiveLighting*)self;
-    int x = state->imgx, y = state->imgy;
+    int32_t x = state->imgx, y = state->imgy;
     struct SmoothLightingCorner* pts = face.corners;
     float comp_shade_strength = 1.0 - lighting->strength;
-    unsigned char pts_r[4] = {0, 0, 0, 0};
-    unsigned char pts_g[4] = {0, 0, 0, 0};
-    unsigned char pts_b[4] = {0, 0, 0, 0};
-    int cx = state->x + face.dx;
-    int cy = state->y + face.dy;
-    int cz = state->z + face.dz;
+    uint8_t pts_r[4] = {0, 0, 0, 0};
+    uint8_t pts_g[4] = {0, 0, 0, 0};
+    uint8_t pts_b[4] = {0, 0, 0, 0};
+    int32_t cx = state->x + face.dx;
+    int32_t cy = state->y + face.dy;
+    int32_t cz = state->z + face.dz;
 
     /* first, check for occlusion if the block is in the local chunk */
     if (lighting_is_face_occluded(state, 0, cx, cy, cz))
@@ -128,8 +128,8 @@ do_shading_with_rule(RenderPrimitiveSmoothLighting* self, RenderState* state, st
 
     /* calculate the lighting colors for each point */
     for (i = 0; i < 4; i++) {
-        unsigned char r, g, b;
-        unsigned int rgather = 0, ggather = 0, bgather = 0;
+        uint8_t r, g, b;
+        uint32_t rgather = 0, ggather = 0, bgather = 0;
 
         get_lighting_color(lighting, state, cx, cy, cz,
                            &r, &g, &b);
@@ -181,10 +181,10 @@ do_shading_with_rule(RenderPrimitiveSmoothLighting* self, RenderState* state, st
                   x, y, NULL, 0);
 }
 
-static int
+static int32_t
 smooth_lighting_start(void* data, RenderState* state, PyObject* support) {
     /* first, chain up */
-    int ret = primitive_lighting.start(data, state, support);
+    int32_t ret = primitive_lighting.start(data, state, support);
     if (ret != 0)
         return ret;
     return 0;
@@ -198,9 +198,9 @@ smooth_lighting_finish(void* data, RenderState* state) {
 
 static void
 smooth_lighting_draw(void* data, RenderState* state, PyObject* src, PyObject* mask, PyObject* mask_light) {
-    int light_top = 1;
-    int light_left = 1;
-    int light_right = 1;
+    int32_t light_top = 1;
+    int32_t light_left = 1;
+    int32_t light_right = 1;
     RenderPrimitiveSmoothLighting* self = (RenderPrimitiveSmoothLighting*)data;
 
     /* special case for leaves, water 8, water 9, ice 79

--- a/overviewer_core/src/rendermodes.c
+++ b/overviewer_core/src/rendermodes.c
@@ -33,7 +33,7 @@
 RenderPrimitive* render_primitive_create(PyObject* prim, RenderState* state) {
     RenderPrimitive* ret = NULL;
     RenderPrimitiveInterface* iface = NULL;
-    unsigned int i;
+    uint32_t i;
     PyObject* pyname;
     const char* name;
 
@@ -82,7 +82,7 @@ RenderPrimitive* render_primitive_create(PyObject* prim, RenderState* state) {
 RenderMode* render_mode_create(PyObject* mode, RenderState* state) {
     RenderMode* ret = NULL;
     PyObject* mode_fast = NULL;
-    unsigned int i;
+    uint32_t i;
 
     mode_fast = PySequence_Fast(mode, "Mode is not a sequence type");
     if (!mode_fast)
@@ -109,7 +109,7 @@ RenderMode* render_mode_create(PyObject* mode, RenderState* state) {
 }
 
 void render_mode_destroy(RenderMode* self) {
-    unsigned int i;
+    uint32_t i;
 
     for (i = 0; i < self->num_primitives; i++) {
         RenderPrimitive* prim = self->primitives[i];
@@ -129,9 +129,9 @@ void render_mode_destroy(RenderMode* self) {
     free(self);
 }
 
-int render_mode_occluded(RenderMode* self, int x, int y, int z) {
-    unsigned int i;
-    int occluded = 0;
+int32_t render_mode_occluded(RenderMode* self, int32_t x, int32_t y, int32_t z) {
+    uint32_t i;
+    int32_t occluded = 0;
     for (i = 0; i < self->num_primitives; i++) {
         RenderPrimitive* prim = self->primitives[i];
         if (prim->iface->occluded) {
@@ -144,9 +144,9 @@ int render_mode_occluded(RenderMode* self, int x, int y, int z) {
     return occluded;
 }
 
-int render_mode_hidden(RenderMode* self, int x, int y, int z) {
-    unsigned int i;
-    int hidden = 0;
+int32_t render_mode_hidden(RenderMode* self, int32_t x, int32_t y, int32_t z) {
+    uint32_t i;
+    int32_t hidden = 0;
     for (i = 0; i < self->num_primitives; i++) {
         RenderPrimitive* prim = self->primitives[i];
         if (prim->iface->hidden) {
@@ -160,7 +160,7 @@ int render_mode_hidden(RenderMode* self, int x, int y, int z) {
 }
 
 void render_mode_draw(RenderMode* self, PyObject* img, PyObject* mask, PyObject* mask_light) {
-    unsigned int i;
+    uint32_t i;
     for (i = 0; i < self->num_primitives; i++) {
         RenderPrimitive* prim = self->primitives[i];
         if (prim->iface->draw) {
@@ -170,10 +170,10 @@ void render_mode_draw(RenderMode* self, PyObject* img, PyObject* mask, PyObject*
 }
 
 /* options parse helper */
-int render_mode_parse_option(PyObject* support, const char* name, const char* format, ...) {
+int32_t render_mode_parse_option(PyObject* support, const char* name, const char* format, ...) {
     va_list ap;
     PyObject *item, *dict;
-    int ret;
+    int32_t ret;
 
     if (support == NULL || name == NULL)
         return 0;

--- a/overviewer_core/src/rendermodes.c
+++ b/overviewer_core/src/rendermodes.c
@@ -129,9 +129,9 @@ void render_mode_destroy(RenderMode* self) {
     free(self);
 }
 
-int32_t render_mode_occluded(RenderMode* self, int32_t x, int32_t y, int32_t z) {
+bool render_mode_occluded(RenderMode* self, int32_t x, int32_t y, int32_t z) {
     uint32_t i;
-    int32_t occluded = 0;
+    bool occluded = false;
     for (i = 0; i < self->num_primitives; i++) {
         RenderPrimitive* prim = self->primitives[i];
         if (prim->iface->occluded) {
@@ -144,9 +144,9 @@ int32_t render_mode_occluded(RenderMode* self, int32_t x, int32_t y, int32_t z) 
     return occluded;
 }
 
-int32_t render_mode_hidden(RenderMode* self, int32_t x, int32_t y, int32_t z) {
+bool render_mode_hidden(RenderMode* self, int32_t x, int32_t y, int32_t z) {
     uint32_t i;
-    int32_t hidden = 0;
+    bool hidden = false;
     for (i = 0; i < self->num_primitives; i++) {
         RenderPrimitive* prim = self->primitives[i];
         if (prim->iface->hidden) {
@@ -170,22 +170,22 @@ void render_mode_draw(RenderMode* self, PyObject* img, PyObject* mask, PyObject*
 }
 
 /* options parse helper */
-int32_t render_mode_parse_option(PyObject* support, const char* name, const char* format, ...) {
+bool render_mode_parse_option(PyObject* support, const char* name, const char* format, ...) {
     va_list ap;
     PyObject *item, *dict;
-    int32_t ret;
+    bool ret;
 
     if (support == NULL || name == NULL)
-        return 0;
+        return false;
 
     dict = PyObject_GetAttrString(support, "option_values");
     if (!dict)
-        return 0;
+        return false;
 
     item = PyDict_GetItemString(dict, name);
     if (item == NULL) {
         Py_DECREF(dict);
-        return 0;
+        return false;
     };
 
     /* make sure the item we're parsing is a tuple

--- a/overviewer_core/src/rendermodes.h
+++ b/overviewer_core/src/rendermodes.h
@@ -51,14 +51,14 @@ typedef struct {
     /* the size of the local storage for this rendermode */
     uint32_t data_size;
 
-    /* may return non-zero on error, last arg is the python support object */
-    int32_t (*start)(void*, RenderState*, PyObject*);
+    /* may return true on error, last arg is the python support object */
+    bool (*start)(void*, RenderState*, PyObject*);
     void (*finish)(void*, RenderState*);
-    /* returns non-zero to skip rendering this block because it's not visible */
-    int32_t (*occluded)(void*, RenderState*, int, int, int);
-    /* returns non-zero to skip rendering this block because the user doesn't
+    /* returns true to skip rendering this block because it's not visible */
+    bool (*occluded)(void*, RenderState*, int, int, int);
+    /* returns true to skip rendering this block because the user doesn't
      * want it visible */
-    int32_t (*hidden)(void*, RenderState*, int, int, int);
+    bool (*hidden)(void*, RenderState*, int, int, int);
     /* last two arguments are img and mask, from texture lookup */
     void (*draw)(void*, RenderState*, PyObject*, PyObject*, PyObject*);
 } RenderPrimitiveInterface;
@@ -94,12 +94,12 @@ struct _RenderMode {
 /* functions for creating / using rendermodes */
 RenderMode* render_mode_create(PyObject* mode, RenderState* state);
 void render_mode_destroy(RenderMode* self);
-int32_t render_mode_occluded(RenderMode* self, int32_t x, int32_t y, int32_t z);
-int32_t render_mode_hidden(RenderMode* self, int32_t x, int32_t y, int32_t z);
+bool render_mode_occluded(RenderMode* self, int32_t x, int32_t y, int32_t z);
+bool render_mode_hidden(RenderMode* self, int32_t x, int32_t y, int32_t z);
 void render_mode_draw(RenderMode* self, PyObject* img, PyObject* mask, PyObject* mask_light);
 
 /* helper function for reading in rendermode options
    works like PyArg_ParseTuple on a support object */
-int32_t render_mode_parse_option(PyObject* support, const char* name, const char* format, ...);
+bool render_mode_parse_option(PyObject* support, const char* name, const char* format, ...);
 
 #endif /* __RENDERMODES_H_INCLUDED__ */

--- a/overviewer_core/src/rendermodes.h
+++ b/overviewer_core/src/rendermodes.h
@@ -55,10 +55,10 @@ typedef struct {
     bool (*start)(void*, RenderState*, PyObject*);
     void (*finish)(void*, RenderState*);
     /* returns true to skip rendering this block because it's not visible */
-    bool (*occluded)(void*, RenderState*, int, int, int);
+    bool (*occluded)(void*, RenderState*, int32_t, int32_t, int32_t);
     /* returns true to skip rendering this block because the user doesn't
      * want it visible */
-    bool (*hidden)(void*, RenderState*, int, int, int);
+    bool (*hidden)(void*, RenderState*, int32_t, int32_t, int32_t);
     /* last two arguments are img and mask, from texture lookup */
     void (*draw)(void*, RenderState*, PyObject*, PyObject*, PyObject*);
 } RenderPrimitiveInterface;

--- a/overviewer_core/src/rendermodes.h
+++ b/overviewer_core/src/rendermodes.h
@@ -49,16 +49,16 @@ typedef struct {
     /* the name of this mode */
     const char* name;
     /* the size of the local storage for this rendermode */
-    unsigned int data_size;
+    uint32_t data_size;
 
     /* may return non-zero on error, last arg is the python support object */
-    int (*start)(void*, RenderState*, PyObject*);
+    int32_t (*start)(void*, RenderState*, PyObject*);
     void (*finish)(void*, RenderState*);
     /* returns non-zero to skip rendering this block because it's not visible */
-    int (*occluded)(void*, RenderState*, int, int, int);
+    int32_t (*occluded)(void*, RenderState*, int, int, int);
     /* returns non-zero to skip rendering this block because the user doesn't
      * want it visible */
-    int (*hidden)(void*, RenderState*, int, int, int);
+    int32_t (*hidden)(void*, RenderState*, int, int, int);
     /* last two arguments are img and mask, from texture lookup */
     void (*draw)(void*, RenderState*, PyObject*, PyObject*, PyObject*);
 } RenderPrimitiveInterface;
@@ -86,7 +86,7 @@ typedef struct {
 
 /* wrapper for passing around rendermodes */
 struct _RenderMode {
-    unsigned int num_primitives;
+    uint32_t num_primitives;
     RenderPrimitive** primitives;
     RenderState* state;
 };
@@ -94,12 +94,12 @@ struct _RenderMode {
 /* functions for creating / using rendermodes */
 RenderMode* render_mode_create(PyObject* mode, RenderState* state);
 void render_mode_destroy(RenderMode* self);
-int render_mode_occluded(RenderMode* self, int x, int y, int z);
-int render_mode_hidden(RenderMode* self, int x, int y, int z);
+int32_t render_mode_occluded(RenderMode* self, int32_t x, int32_t y, int32_t z);
+int32_t render_mode_hidden(RenderMode* self, int32_t x, int32_t y, int32_t z);
 void render_mode_draw(RenderMode* self, PyObject* img, PyObject* mask, PyObject* mask_light);
 
 /* helper function for reading in rendermode options
    works like PyArg_ParseTuple on a support object */
-int render_mode_parse_option(PyObject* support, const char* name, const char* format, ...);
+int32_t render_mode_parse_option(PyObject* support, const char* name, const char* format, ...);
 
 #endif /* __RENDERMODES_H_INCLUDED__ */


### PR DESCRIPTION
This PR is a pass across the C codebase to clean up our type usage to more concise and self-documenting [posix-standard](https://pubs.opengroup.org/onlinepubs/009695399/basedefs/stdint.h.html) type aliases(such as going from `unsigned int` to `uint32_t` and `uint16_t block;` to `mc_block_t block;`).
This standardization will make further contributions to the codebase a lot easier

_(Also, in particular, being explicit with the sizes of certain types will make future data-parallelism speedups a lot easier. Like implementing a SIMD speedup when we know that a certain type will always be a `uint16_t` or `uint8_t`. Definitely been eyeing a lot of these RGB color values being split across three `uint8_t`s as function arguments)_