### PR TITLE
Fix GCC signed-unsigned and pointer-warnings

### DIFF
--- a/overviewer_core/src/composite.c
+++ b/overviewer_core/src/composite.c
@@ -114,7 +114,7 @@ alpha_over_full(PyObject* dest, PyObject* src, PyObject* mask, float overall_alp
     int32_t sx, sy;
     /* iteration variables */
     int32_t x, y;
-	uint32_t i;
+    uint32_t i;
     /* temporary calculation variables */
     int32_t tmp1, tmp2, tmp3;
     /* integer [0, 255] version of overall_alpha */

--- a/overviewer_core/src/composite.c
+++ b/overviewer_core/src/composite.c
@@ -113,7 +113,8 @@ alpha_over_full(PyObject* dest, PyObject* src, PyObject* mask, float overall_alp
     /* source position */
     int32_t sx, sy;
     /* iteration variables */
-    uint32_t x, y, i;
+    int32_t x, y;
+	uint32_t i;
     /* temporary calculation variables */
     int32_t tmp1, tmp2, tmp3;
     /* integer [0, 255] version of overall_alpha */
@@ -289,7 +290,7 @@ tint_with_mask(PyObject* dest,
     /* source position */
     int32_t sx, sy;
     /* iteration variables */
-    uint32_t x, y;
+    int32_t x, y;
     /* temporary calculation variables */
     int32_t tmp1, tmp2;
 
@@ -517,7 +518,7 @@ resize_half(PyObject* dest, PyObject* src) {
     /* temp color variables */
     uint32_t r, g, b, a;
     /* size values for source and destination */
-    int32_t src_width, src_height, dest_width, dest_height;
+    uint32_t src_width, src_height, dest_width, dest_height;
 
     imDest = imaging_python_to_c(dest);
     imSrc = imaging_python_to_c(src);

--- a/overviewer_core/src/primitives/depth.c
+++ b/overviewer_core/src/primitives/depth.c
@@ -18,8 +18,8 @@
 #include "../overviewer.h"
 
 typedef struct {
-    uint32_t min;
-    uint32_t max;
+    int32_t min;
+    int32_t max;
 } PrimitiveDepth;
 
 static bool

--- a/overviewer_core/src/primitives/lighting.c
+++ b/overviewer_core/src/primitives/lighting.c
@@ -241,7 +241,7 @@ do_shading_with_mask(RenderPrimitiveLighting* self, RenderState* state,
     tint_with_mask(state->img, r, g, b, 255, mask, state->imgx, state->imgy, 0, 0);
 }
 
-static int32_t
+static bool
 lighting_start(void* data, RenderState* state, PyObject* support) {
     RenderPrimitiveLighting* self;
     self = (RenderPrimitiveLighting*)data;

--- a/overviewer_core/src/primitives/overlay-biomes.c
+++ b/overviewer_core/src/primitives/overlay-biomes.c
@@ -146,7 +146,7 @@ overlay_biomes_start(void* data, RenderState* state, PyObject* support) {
         for (i = 0; i < biomes_size; i++) {
             PyObject* biome = PyList_GET_ITEM(opt, i);
             char* tmpname = NULL;
-            int32_t j = 0;
+            uint32_t j = 0;
 
             if (!PyArg_ParseTuple(biome, "s(bbb)", &tmpname, &(biomes[i].r), &(biomes[i].g), &(biomes[i].b))) {
                 free(biomes);

--- a/overviewer_core/src/primitives/overlay.c
+++ b/overviewer_core/src/primitives/overlay.c
@@ -28,7 +28,7 @@ static void get_color(void* data, RenderState* state,
     *a = self->color->a;
 }
 
-static int32_t
+static bool
 overlay_start(void* data, RenderState* state, PyObject* support) {
     PyObject* opt = NULL;
     OverlayColor* color = NULL;

--- a/overviewer_core/src/primitives/smooth-lighting.c
+++ b/overviewer_core/src/primitives/smooth-lighting.c
@@ -198,8 +198,8 @@ smooth_lighting_finish(void* data, RenderState* state) {
 
 static void
 smooth_lighting_draw(void* data, RenderState* state, PyObject* src, PyObject* mask, PyObject* mask_light) {
-    bool light_top   = true;
-    bool light_left  = true;
+    bool light_top = true;
+    bool light_left = true;
     bool light_right = true;
     RenderPrimitiveSmoothLighting* self = (RenderPrimitiveSmoothLighting*)data;
 


### PR DESCRIPTION
A lot of the signed/unsigned issues are related to the fact that I converted
a lot of indexing values to use unsigned types, little did I know that a lot of
other values used when indexing actually come from the python-end of the code. Python does
not have built-in unsigned types so all integers coming from Python are signed
implicitly and a lot of things like image-size and x, y coordinates and other values coming from python come paired with conditional code to handle negative-integer cases as well.

Guess we'll just take our `int32_t i = 0; i < blah; ++i` and like it.

Also fixed some pointer-casting warnings where some functions were still returning `int32_t` where they could have just been returning the standard `bool` type

Code now compiles with no warnings or naggings of any kind on `gcc 9.1.0`.