### PR TITLE
feat: added 1.14 scaffolding block

### DIFF
--- a/overviewer_core/src/mc_id.h
+++ b/overviewer_core/src/mc_id.h
@@ -317,6 +317,7 @@ enum mc_block_id {
     block_jungle_wall_sign = 11410,
     block_acacia_wall_sign = 11411,
     block_dark_oak_wall_sign = 11412,
+    block_scaffolding = 11413,
 };
 
 typedef uint16_t mc_block_t;

--- a/overviewer_core/src/overviewer.h
+++ b/overviewer_core/src/overviewer.h
@@ -31,7 +31,7 @@
 
 // increment this value if you've made a change to the c extesion
 // and want to force users to rebuild
-#define OVERVIEWER_EXTENSION_VERSION 74
+#define OVERVIEWER_EXTENSION_VERSION 75
 
 #include <stdbool.h>
 #include <stdint.h>

--- a/overviewer_core/textures.py
+++ b/overviewer_core/textures.py
@@ -5068,3 +5068,6 @@ def glazed_terracotta(self, blockid, data):
 def sandstone(self, blockid, data):
     top = self.load_image_texture("assets/minecraft/textures/block/dried_kelp_top.png")
     return self.build_block(top, self.load_image_texture("assets/minecraft/textures/block/dried_kelp_side.png"))
+
+# scaffolding
+block(blockid=11413, top_image="assets/minecraft/textures/block/scaffolding_top.png", side_image="assets/minecraft/textures/block/scaffolding_side.png", solid=False, transparent=True)

--- a/overviewer_core/world.py
+++ b/overviewer_core/world.py
@@ -831,6 +831,7 @@ class RegionSet(object):
             'minecraft:andesite_stairs': (11382, 0),
             'minecraft:end_stone_brick_stairs': (11383, 0),
             'minecraft:red_nether_brick_stairs': (11384, 0),
+            'minecraft:scaffolding': (11413, 0),
         }
 
         colors = [   'white', 'orange', 'magenta', 'light_blue',


### PR DESCRIPTION
As the title says I've added the scaffolding block to Overviewer. Just the top texture with the side texture, transparent, non-solid.

Result:
![scaffolding-overviewer](https://user-images.githubusercontent.com/2047920/64066842-32369080-cc1f-11e9-9013-347775a4cd99.png)

First time working on the Overviewer code. I hope I did everything right?