### PR TITLE
Update Docs for Texture Install

### DIFF
--- a/docs/running.rst
+++ b/docs/running.rst
@@ -265,13 +265,16 @@ If you want or need to provide your own textures, you have several options:
 
   You can use the following commands to download the client jar on Linux or Mac.
   Run the first line in a terminal, changing the version string to the latest as appropriate
-  (these docs may not always be updated to reflect the latest). Then paste the second line
+  (these docs may not always be updated to reflect the latest). Then paste the second line into
+  your terminal to create directories if necessary. Then paste the third line
   into your terminal to download the latest version. ``${VERSION}`` will be replaced
-  by the actual version string from the first line.
+  by the actual version string from the first line. These 3 lines can be included in a shell
+  script prior to map generation to ensure the proper textures are always downloaded.
 
   ::
 
     VERSION=1.14
+    mkdir -p ~/.minecraft/versions/${VERSION}/
     wget https://overviewer.org/textures/${VERSION} -O ~/.minecraft/versions/${VERSION}/${VERSION}.jar
 
   If that's too confusing for you, then just take this single line and paste it into


### PR DESCRIPTION
Documentation Not Accounting for wget oddness with non-existing directories. When using wget options to create directories, results in errors. This change works reliably for utilizing with wget where directories do not already exist, and also adds note indicating ability to integrate with shell scripts.