### PR TITLE
Web: Fix multiple layers being added on page load if a non-default layer is in the hash

### DIFF
--- a/overviewer_core/data/js_src/util.js
+++ b/overviewer_core/data/js_src/util.js
@@ -758,11 +758,9 @@ overviewer.util = {
             zoom = ovconf.minZoom;
 
         // build a fake event for the world switcher control
+        overviewer.current_layer[world_name] = target_layer;
         overviewer.worldCtrl.onChange({target: {value: world_name}});
         overviewer.worldCtrl.select.value = world_name;
-        if  (!overviewer.map.hasLayer(target_layer)) {
-            overviewer.map.addLayer(target_layer);
-        }
 
         overviewer.map.setView(latlngcoords, zoom);
 


### PR DESCRIPTION
Currently, if a map is loaded where there is already a hash in the URL, and that hash points to a layer other than the default for that world, multiple layers will be added to the map. This is only obvious when the non-default layer is made up of partially-transparent tiles (e.g. a cave view), in which case you get [a bit of a mess](https://i.imgur.com/oqALnVO.jpg) instead of [the intended effect](https://i.imgur.com/IiZO2Vu.jpg).

The reason for this seems to be that `Util.goToHash` never actually sets the `current_layer` property - it just fires the world control's `onChange` event (to ensure the correct world is loaded) and then manually adds the relevant layer to the map. So, that world's default layer will be added, and then the URL-requested layer is also added.

This change sets `current_layer` for the user-requested world to the user-requested layer, and _then_ calls `onChange` - which ensures the user-requested world gets loaded and then ensures that the correct layer is present in the map for us. Thus, there's also no longer a need to manually call `addLayer` afterwards.