### PR TITLE
Change lava ID from 10 to 11 (Fixes issue #1551)

### DIFF
--- a/overviewer_core/world.py
+++ b/overviewer_core/world.py
@@ -317,7 +317,7 @@ class RegionSet(object):
             'minecraft:sapling': (6, 0),
             'minecraft:bedrock': (7, 0),
             'minecraft:water': (8, 0),
-            'minecraft:lava': (10, 0),
+            'minecraft:lava': (11, 0),
             'minecraft:sand': (12, 0),
             'minecraft:red_sand': (12, 1),
             'minecraft:gravel': (13, 0),


### PR DESCRIPTION
Hiding the nether ceiling causes issues in 1.13+. Any block of lava in the ceiling and all netherrack directly underneath would not be hidden properly. Not tested on 1.12 or below.