### PR TITLE
Fixed incorrect rendering of blocks (issue #1578)

### DIFF
--- a/overviewer_core/world.py
+++ b/overviewer_core/world.py
@@ -1189,7 +1189,7 @@ class RegionSet(object):
             result[4::8] = ((b[4::7] & 0x07) << 4) | ((b[3::7] & 0xf0) >> 4)
             result[5::8] = ((b[5::7] & 0x03) << 5) | ((b[4::7] & 0xf8) >> 3)
             result[6::8] = ((b[6::7] & 0x01) << 6) | ((b[5::7] & 0xfc) >> 2)
-            result[7::8] =  (b[6::7] & 0xfc) >> 1
+            result[7::8] =  (b[6::7] & 0xfe) >> 1
         # bits_per_value == 8 is handled above
         elif bits_per_value == 9:
             result[0::8] = ((b[1::9] & 0x01) << 8) |   b[0::9]


### PR DESCRIPTION
As I said, smallest pull-request ever. But it is an important one. It just fix the issue #1578 

The unpacking of the block states missed a single bit when the bits per value was 7. Every 7 bytes it would miss one bit and store it as 0 instead of the actual value. This happened because 0xfc was used instead of 0xfe. 0xfc has six bits set to 1 and two to 0. 0xfe has correctly set seven bits to 1 and one bit to 0. We need those seven bits and not just the six.