### PR TITLE
Remove unused imports

### DIFF
--- a/contrib/cyrillic_convert.py
+++ b/contrib/cyrillic_convert.py
@@ -4,7 +4,6 @@
 
 import fileinput
 import argparse
-import sys
 
 gibberish_to_cyrillic = {
     'À': 'А',

--- a/overviewer.py
+++ b/overviewer.py
@@ -17,7 +17,6 @@
 
 from __future__ import print_function
 
-import platform
 import sys
 
 # quick version check
@@ -28,7 +27,6 @@ if sys.version_info[0] == 2 or (sys.version_info[0] == 3 and sys.version_info[1]
 import os
 import os.path
 import re
-import subprocess
 import multiprocessing
 import time
 import logging
@@ -38,10 +36,9 @@ from collections import OrderedDict
 from overviewer_core import util
 from overviewer_core import logger
 from overviewer_core import textures
-from overviewer_core import optimizeimages, world
+from overviewer_core import world
 from overviewer_core import config_parser, tileset, assetmanager, dispatcher
 from overviewer_core import cache
-from overviewer_core import observer
 from overviewer_core.nbt import CorruptNBTError
 
 helptext = """

--- a/overviewer_core/biome.py
+++ b/overviewer_core/biome.py
@@ -14,8 +14,6 @@
 #    You should have received a copy of the GNU General Public License along
 #    with the Overviewer.  If not, see <http://www.gnu.org/licenses/>.
 
-import numpy
-
 class BiomeDispensary:
     """Turns biome arrays of either 256 or 1024 integer values into 16x16 2d arrays,
     which can then be retrieved for any Y level with get_biome.

--- a/overviewer_core/progressbar.py
+++ b/overviewer_core/progressbar.py
@@ -343,8 +343,6 @@ class ProgressBar(object):
 
 
 if __name__=='__main__':
-    import os
-
     def example1():
         widgets = ['Test: ', Percentage(), ' ', Bar(marker=RotatingMarker()),
                    ' ', ETA(), ' ', FileTransferSpeed()]

--- a/overviewer_core/settingsDefinition.py
+++ b/overviewer_core/settingsDefinition.py
@@ -46,8 +46,7 @@
 from collections import OrderedDict
 
 from .settingsValidators import *
-from .observer import ProgressBarObserver, LoggingObserver, JSObserver
-from .optimizeimages import pngnq, optipng, pngcrush
+from .observer import ProgressBarObserver, LoggingObserver
 import platform
 import sys
 

--- a/overviewer_core/settingsValidators.py
+++ b/overviewer_core/settingsValidators.py
@@ -5,7 +5,6 @@ import os.path
 from collections import OrderedDict
 
 from . import rendermodes
-from . import util
 from .optimizeimages import Optimizer
 from .world import LOWER_LEFT, LOWER_RIGHT, UPPER_LEFT, UPPER_RIGHT
 

--- a/overviewer_core/tileset.py
+++ b/overviewer_core/tileset.py
@@ -15,7 +15,6 @@
 
 import errno
 import functools
-import itertools
 import logging
 import os
 import os.path

--- a/overviewer_core/util.py
+++ b/overviewer_core/util.py
@@ -22,7 +22,7 @@ import imp
 import os.path
 import platform
 import sys
-from itertools import cycle, islice, product
+from itertools import cycle, islice
 from string import hexdigits
 from subprocess import PIPE, Popen
 

--- a/overviewer_core/world.py
+++ b/overviewer_core/world.py
@@ -18,9 +18,7 @@ import os
 import os.path
 import logging
 import time
-import random
 import re
-import locale
 
 import numpy
 

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,6 @@ from distutils.command.build import build
 from distutils.command.clean import clean
 from distutils.command.build_ext import build_ext
 from distutils.command.sdist import sdist
-from distutils.cmd import Command
-from distutils.dir_util import remove_tree
 from distutils.sysconfig import get_python_inc
 from distutils import log
 import os, os.path


### PR DESCRIPTION
Remove unnecessary imports. I used [LGTM](https://lgtm.com/projects/g/overviewer/Minecraft-Overviewer/?mode=list&id=py%2Funused-import) to find these imports, and then manually verified that they were actually not being used.