### PR TITLE
Fix construct requiring >=Python3.5

### DIFF
--- a/overviewer_core/textures.py
+++ b/overviewer_core/textures.py
@@ -4493,7 +4493,7 @@ def beacon(self, blockid, data):
 
 # cobblestone and mossy cobblestone walls, chorus plants, mossy stone brick walls
 # one additional bit of data value added for mossy and cobblestone
-@material(blockid=[199, *range(21000,21013+1)], data=list(range(32)), transparent=True, nospawn=True)
+@material(blockid=[199]+list(range(21000,21013+1)), data=list(range(32)), transparent=True, nospawn=True)
 def cobblestone_wall(self, blockid, data):
     walls_id_to_tex = {
           199: "assets/minecraft/textures/block/chorus_plant.png", # chorus plants


### PR DESCRIPTION
My understanding is the project requires 3.4 or greater, but this line of code used a construct apparently only available in 3.5 or afterwards.