### PR TITLE
Track centers by layer instead of by world

### DIFF
--- a/overviewer_core/data/js_src/overviewer.js
+++ b/overviewer_core/data/js_src/overviewer.js
@@ -39,7 +39,7 @@ overviewer.collections = {
 
         /**
          * When switching regionsets, where should we zoom to?
-         * Defaults to spawn.  Stored as map of world names to [latlng, zoom]
+         * Defaults to spawn.  Stored as map of maps: world names to layer names to [latlng, zoom]
          */
         'centers': {},
 


### PR DESCRIPTION
## Summary of issue

This fixes a bug where a world with multiple layers with different `northdirection` values would initially load at the wrong center point because only one center can be stored per world in the `overview.collections.centers` map.

See the config below. I've been assuming that multiple renders per world is intended usage.

```
renders["llc-latest-ul"] = {
    "world": "llc-latest",
    "title": "Latest UL",
    "northdirection": "upper-left",
    "defaultzoom": 7,
    "crop": (-500, -500, 500, 500),
    "center": [-250, 64, -250]
}

renders["llc-latest-lr"] = {
    "world": "llc-latest",
    "title": "Latest LR",
    "northdirection": "lower-right",
    "defaultzoom": 7,
    "crop": (-500, -500, 500, 500),
    "center": [-250, 64, -250]
}
```

When Overviewer loaded, it would display the "UL" map at an incorrect position `265/64/265`. This is because the center point in `overviewer.collections.centers["llc-latest"]` was the one calculated for the second layer which had a different orientation, hence flipping the coordinates around the origin.

See the code here that loops over the tile sets and eventually stores the centers.
https://github.com/overviewer/Minecraft-Overviewer/blob/751ba39bd06ed780c7746357f2a9b90ca032a549/overviewer_core/data/js_src/util.js#L357-L417

The `tileSets.forEach` executes for each layer and on line 412 the center is set per-world: the center point from the last layer defined for a world will always "win".

## The fix

The code changes are pretty simple: `overviewer.collections.centers` is now a map of maps, keyed by world name and layer name, so that each layer gets its own center point.

## Testing

I updated the Overviewer source and ran the following command to push the changes into the map I've been using for testing

`cat overviewer.js util.js > /mnt/c/dev/code/ov-test/output/overviewer.js`

The map defaults to the correct x/y now, and I can switch between layers and worlds and the coordinates load as expected. I haven't made use of overlays yet; not sure if this would have any impact to those.