### PR TITLE
Add regiondir property to CroppedRegionSet

### DIFF
--- a/overviewer_core/world.py
+++ b/overviewer_core/world.py
@@ -1547,9 +1547,24 @@ class RegionSetWrapper(object):
         itertools.groupby, which needs sorted keys, and Python 2 somehow
         just sorted objects like ???????? how????? why?????
         """
-        if isinstance(other, RegionSetWrapper):
-            other = other._r
-        return self._r.regiondir < other.regiondir
+        return self.regiondir < other.regiondir
+
+    @property
+    def regiondir(self):
+        """
+        RegionSetWrapper are wrappers around a RegionSet and thus should have all variables the RegionSet has.
+
+        Reason for addition: Issue #1706
+        The __lt__ check in RegionSet did not check if it is a RegionSetWrapper Instance
+        """
+        return self._r.regiondir
+
+    @regiondir.setter
+    def regiondir(self, value):
+        """
+        For completeness adding the setter to the property
+        """
+        self._r.regiondir = value
 
     def get_type(self):
         return self._r.get_type()


### PR DESCRIPTION
- CroppedRegionSet is a Wrapper for RegionSet and should have all of
  it's Variables / Parameters
- genPOI sorts a list by (Cropped)RegionSet objects
- The comparing method (__lt__) was correct in CroppedRegionSet but not
  in RegionSet. To prevent this issue from happening again, the
  RegionSetWrapper now has the regiondir property, too
- Fixes Issue: #1706
- Example config: see below

```python
def testFilter(poi):
    if poi['id'] == 'Town':
        return poi['name']
def townFilter(poi):
    if poi['id'] == 'Town':
        return poi['name']

renders["normalrender"] = {
    "world": "Test12985",
    "title": "Normal Render of Testworld",
    'markers': [dict(name="Towns", filterFunction=townFilter), dict(name="Test", filterFunction=testFilter)],
}

renders["secondrender"] = {
    "world": "Test12985",
    "title": "Second Render of Testworld",
    "crop": (180, -230, 220, -260),
    'markers': [dict(name="Towns", filterFunction=townFilter), dict(name="Test", filterFunction=testFilter)],
}
```