### PR TITLE
Remove broken redundant code in Textures.generate

### DIFF
--- a/overviewer_core/textures.py
+++ b/overviewer_core/textures.py
@@ -135,18 +135,6 @@ class Textures(object):
             tex = texgen(self, blockid, data)
             self.blockmap[blockid * max_data + data] = self.generate_texture_tuple(tex)
         
-        if self.texture_size != 24:
-            # rescale biome grass
-            self.biome_grass_texture = self.biome_grass_texture.resize(self.texture_dimensions, Image.ANTIALIAS)
-            
-            # rescale the rest
-            for i, tex in enumerate(blockmap):
-                if tex is None:
-                    continue
-                block = tex[0]
-                scaled_block = block.resize(self.texture_dimensions, Image.ANTIALIAS)
-                blockmap[i] = self.generate_texture_tuple(scaled_block)
-        
         self.generated = True
     
     ##


### PR DESCRIPTION
I think removing the code makes more sense, because it isn't used and is broken

- Introduced in 2012
- Never executed because the value is always set to 24 in __init__
- Code doesn't work (probably because of other changes)