### PR TITLE
Add Icons to POI Legend

### DIFF
--- a/overviewer_core/data/js_src/util.js
+++ b/overviewer_core/data/js_src/util.js
@@ -424,7 +424,9 @@ overviewer.util = {
                             marker_group.addLayer(layerObj);
                         }
                         // Save marker group
-                        obj.marker_groups[marker_entry.displayName] = marker_group;
+                        var layer_name_html = marker_entry.displayName +
+                            '<img class="ov-marker-legend" src="' + marker_entry.icon + '"></img>';
+                        obj.marker_groups[layer_name_html] = marker_group;
                     }
                 }
             }

--- a/overviewer_core/data/web_assets/overviewer.css
+++ b/overviewer_core/data/web_assets/overviewer.css
@@ -180,6 +180,12 @@ div.worldcontrol select {
     margin-top:-50%;
 }
 
+.ov-marker-legend {
+    height: 1.5rem;
+    float: right;
+    clear: right;
+}
+
 .leaflet-div-icon {
     background: 0;
     border: 0;


### PR DESCRIPTION
- Fixes #1700
- Difference to #1700: The icons are on the right instead of left of the checkboxes

![2020-03-02_13:42:06](https://user-images.githubusercontent.com/8270201/75677870-b03a2980-5c8c-11ea-9575-eb61030d8109.png)
