### PR TITLE
[WIP] Issue 1647 rendered banner poi

### DIFF
--- a/overviewer_core/aux_files/genPOI.py
+++ b/overviewer_core/aux_files/genPOI.py
@@ -31,7 +31,7 @@ from contextlib import closing
 from multiprocessing import Pool
 from argparse import ArgumentParser
 
-from overviewer_core import config_parser, logger, nbt, world
+from overviewer_core import config_parser, logger, nbt, world, textures
 from overviewer_core.files import FileReplacer, get_fs_caps
 
 UUID_LOOKUP_URL = 'https://sessionserver.mojang.com/session/minecraft/profile/'
@@ -157,7 +157,7 @@ def signWrangler(poi):
     return poi
 
 
-def handleEntities(rset, config, config_path, filters, markers):
+def handleEntities(rset, config, config_path, filters, markers, tex):
     """
     Add markers for Entities or TileEntities.
 
@@ -216,6 +216,14 @@ def handleEntities(rset, config, config_path, filters, markers):
             for name, marker_list in marker_dict.items():
                 markers[name]['raw'].extend(marker_list)
 
+    # Banner Rendering requires a Textures object. Because I don't know if that object is completely thread save
+    # I've placed the code here. This means rendering of banners only happens on a single thread.
+    for name, value in markers.items():
+        for m in value['raw']:
+            print(name, m)
+            #if poi['id'] == "Banner" or poi['id'] == "minecraft:banner":
+            #    # For Banners: render the banner and set as default for this poi
+            #    poi['icon'] = render_and_store_dynamic_icon(render_banner, 0, poi)
     logging.info("Done.")
 
 
@@ -555,6 +563,14 @@ def main():
                 checked=f.get('checked', False))
             marker_groups[rname].append(group)
 
+    # Initialize a Textures object. This is required for the rendering of banners
+    # TODO: Is this the correct way to instantiate Textures?
+    tex = textures.Textures(config['texturepath'])
+    f = tex.find_file("assets/minecraft/textures/block/sandstone_top.png", verbose=True)
+    f = tex.find_file("assets/minecraft/textures/block/grass_block_top.png", verbose=True)
+    f = tex.find_file("assets/minecraft/textures/block/diamond_ore.png", verbose=True)
+    f = tex.find_file("assets/minecraft/textures/block/oak_planks.png", verbose=True)
+
     # initialize the structure for the markers
     markers = dict((name, dict(created=False, raw=[], name=filter_name))
                    for name, filter_name, __, __, __, __ in filters)
@@ -566,7 +582,7 @@ def main():
             return x[3]
         sfilters = sorted(filters, key=keyfunc)
         for rset, rset_filters in itertools.groupby(sfilters, keyfunc):
-            handleEntities(rset, config, args.config, list(rset_filters), markers)
+            handleEntities(rset, config, args.config, list(rset_filters), markers, tex)
 
     # apply filters to players
     if not args.skipplayers:


### PR DESCRIPTION
Working on #1647 

I have implemented code to render a banner using it's NBT data (see first commit). 
When trying to use it from genPOI I have the following problems / questions:
- For rendering we need access to a Textures object. This is never created for genPOI. Is the creation I've used ok?
- Is the Textures object thread save or do we need a lock when it is used (only load_image is used)
- Can we just pass the Textures object as an additional parameter to the threads?
- What do you think is the best way for the filenames. I was thinking of having a global counter but I'm not sure where to place it. I haven't done much multiprocessing in python yet.

Note: Because the render_banner function requires a Textures object placing the code in the filter itself would probably not work (no access to the config)

The second commit contains some of my thoughts (partially commented). Maybe you can help me with the questions above.

The config I used (including the Filters): [config.txt](https://github.com/overviewer/Minecraft-Overviewer/files/4277939/config.txt)

