### PR TITLE
Make icons in legend OptIn

### DIFF
--- a/docs/signs.rst
+++ b/docs/signs.rst
@@ -215,6 +215,9 @@ The following keys are accepted in the marker dictionary:
 ``createInfoWindow``
     Optional. Specifies whether or not the icon displays an info window on click. Defaults to True
 
+``showIconInLegend``
+    Optional. Specifies whether or not the icon is displayed in the legend. Defaults to False
+
 ``checked``
     Optional.  Specifies whether or not this marker group will be checked(visible) by default when
     the map loads.  Defaults to False

--- a/overviewer_core/aux_files/genPOI.py
+++ b/overviewer_core/aux_files/genPOI.py
@@ -568,7 +568,8 @@ def main():
                 displayName=f['name'],
                 icon=f.get('icon', 'signpost_icon.png'),
                 createInfoWindow=f.get('createInfoWindow', True),
-                checked=f.get('checked', False))
+                checked=f.get('checked', False),
+                showIconInLegend=f.get('showIconInLegend', False))
             marker_groups[rname].append(group)
 
     # initialize the structure for the markers

--- a/overviewer_core/data/js_src/util.js
+++ b/overviewer_core/data/js_src/util.js
@@ -424,8 +424,14 @@ overviewer.util = {
                             marker_group.addLayer(layerObj);
                         }
                         // Save marker group
-                        var layer_name_html = marker_entry.displayName +
-                            '<img class="ov-marker-legend" src="' + marker_entry.icon + '"></img>';
+                        var layer_name_html;
+                        if (marker_entry.showIconInLegend) {
+                            layer_name_html = marker_entry.displayName +
+                                '<img class="ov-marker-legend" src="' + marker_entry.icon + '"></img>';
+                        }
+                        else {
+                            layer_name_html = marker_entry.displayName;
+                        }
                         obj.marker_groups[layer_name_html] = marker_group;
                     }
                 }


### PR DESCRIPTION
Icons are now only shown in the legend if specified (fixes #1794)

After running overviewer once the icons will be removed. To get them again configure them as shown below and run genpoi

```'
markers': [
      dict(name="Towns123", filterFunction=townFilter, icon="icons/marker_town.png", showIconInLegend=True),
],`
```

In addition I've added a small margin between the text and the icon:

![2020-07-01_19:55:36](https://user-images.githubusercontent.com/8270201/86276132-a5f55100-bbd4-11ea-9153-555eb7823258.png)
