### PR TITLE
Create Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM python:3
+LABEL github="https://github.com/overviewer/Minecraft-Overviewer" maintainer="TheDruidsKeeper"
+WORKDIR /usr/local/src
+
+RUN echo "Installing c build tools" \
+    && apt-get update \
+    && apt-get install build-essential -y \
+    && rm -rf /var/lib/apt/lists/* \
+    && echo "Installing python dependencies" \
+    && pip3 install --no-cache-dir numpy pillow \
+    && echo "Fetching source code for Pillow since it doesn't come with headers" \
+    && PILLOW_VERSION=`pip show Pillow | awk '$1 == "Version:" {print $2}'` \
+    && wget https://github.com/python-pillow/Pillow/archive/${PILLOW_VERSION}.tar.gz \
+    && tar -xf ${PILLOW_VERSION}.tar.gz \
+    && rm ${PILLOW_VERSION}.tar.gz \
+    && ln -s Pillow-${PILLOW_VERSION} Pillow
+
+# Get & build source code
+COPY . minecraft-overviewer
+RUN echo "Copying pillow headers" \
+    && cp ./Pillow/src/libImaging/ImPlatform.h ./minecraft-overviewer/ImPlatform.h \
+    && cp ./Pillow/src/libImaging/Imaging.h ./minecraft-overviewer/Imaging.h \
+    && cp ./Pillow/src/libImaging/ImagingUtils.h ./minecraft-overviewer/ImagingUtils.h \
+    && echo "Building minecraft-overviewer" \
+    && cd minecraft-overviewer \
+    && python3 setup.py build
+
+WORKDIR /usr/local/src/minecraft-overviewer
+ENTRYPOINT ["python3", "./overviewer.py"]


### PR DESCRIPTION
This dockerfile gives an easy way for users to build the source and run locally with no dependencies beyond docker. Volume mounts must be used to provide files needed for runtime. Ex (using Windows paths):
```
docker build -t minecraft-overviewer .
docker run --rm -v F:/minecraft/client.jar:/root/.minecraft/versions/1.16/1.16.jar -v F:/minecraft/HelloWorld:/var/minecraft/input -v F:/minecraft/mcmap:/var/minecraft/output minecraft-overviewer /var/minecraft/input /var/minecraft/output
```

Example volume mounts explained:
1. the client.jar [required for textures](http://docs.overviewer.org/en/latest/running/#installing-the-textures)
2. the world to render, matches the first parameter passed to the image entrypoint
3. the where the map is saved to, matches the second parameter passed to the image entrypoint