### PR TITLE
Add data-value (optional) to StructureOverlay

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1213,23 +1213,24 @@ StructureOverlay
     a MineralOverlay with alpha support.
 
     This Overlay colors according to a patterns that are specified as
-    multiple tuples of the form ``(relx, rely, relz, blockid)``. So
+    multiple tuples of the form ``(relx, rely, relz, blockid)`` or ``(relx, rely, relz, blockid, data)``. So
     by specifying ``(0, -1, 0, 4)`` the block below the current one has to
-    be a cobblestone.
+    be a cobblestone. By specifying ``(0, -1, 0, 35, 11)`` the block below has to be Blue wool.
 
     One color is then specified as
     ``((relblockid1, relblockid2, ...), (r, g, b, a))`` where the
     ``relblockid*`` are relative coordinates and the blockid as specified
     above. The ``relblockid*`` must match all at the same time for the
-    color to apply.
+    color to apply. The Alpha (a) is optional and is set to 255 by default.
 
     Example::
 
         StructureOverlay(structures=[(((0, 0, 0, 66), (0, -1, 0, 4)), (255, 0, 0, 255)),
-                                     (((0, 0, 0, 27), (0, -1, 0, 4)), (0, 255, 0, 255))])
+                                     (((0, 0, 0, 27), (0, -1, 0, 4)), (0, 255, 0, 255)),
+                                     (((0, 0, 0, 66), (0, -1, 0, 35, 11)), (0, 0, 255))])
 
     In this example all rails(66) on top of cobblestone are rendered in
-    pure red. And all powerrails(27) are rendered in green.
+    pure red, all powerrails(27) are rendered in green and all rails(66) above blue wool are rendered blue.
 
     If ``structures`` is not provided, a default rail coloring is used.
 

--- a/overviewer_core/rendermodes.py
+++ b/overviewer_core/rendermodes.py
@@ -209,7 +209,7 @@ class SlimeOverlay(Overlay):
 class StructureOverlay(Overlay):
     name = "overlay-structure"
     options = {
-        'structures': ('a list of ((((relx, rely, relz), blockid), ...), (r, g, b, a)) tuples for coloring minerals',
+        'structures': ('a list of (((relx, rely, relz, blockid, data), ...), (r, g, b, a)) tuples for coloring minerals',
                        [(((0, 0, 0, 66),  (0, -1, 0, 4)), (255, 0,   0, 255)),
                         (((0, 0, 0, 27),  (0, -1, 0, 4)), (0,   255, 0, 255)),
                         (((0, 0, 0, 28),  (0, -1, 0, 4)), (255, 255, 0, 255)),


### PR DESCRIPTION
- Add optional data value
- Made the Alpha value optional and default to 255

This allows searching for wool colors in the StructureOverlay (and other things) as requested in #1767

Example Config:
```
StructureOverlay(structures=list([
    (((0, 0, 0, 66), (0, -1, 0, 35, wool_data)), color)
    for wool_data, color in enumerate([
        (255,255,255),      # White
        (255,170,0),        # Orange
        (255,0,255),        # Magenta
        (128,128,255),      # Light Blue
        (255,255,0),        # Yellow
        (192,255,0),        # Lime
        (255,100,162),      # Pink
        (90,90,90),         # Gray
        (160,160,160),      # Light Gray
        (44,171,255),       # Cyan
        (0,0,255),          # Blue
        (255,0,255),        # Purple
        (0,255,0),          # Green
        (160,70,0),         # Brown
        (255,0,0),          # Red
        (0,0,0),            # Black
    ])
]))
```

![2020-07-12_15:17:38](https://user-images.githubusercontent.com/8270201/87247203-9b4b7f00-c452-11ea-9bf5-5d4d065f6e58.png)