### PR TITLE
Resolve stair & stem rendering issues

### DIFF
--- a/overviewer_core/src/block_class.c
+++ b/overviewer_core/src/block_class.c
@@ -62,7 +62,7 @@ bool block_class_is_wall(mc_block_t block) {
     mc_block_t mask = 0b11111111;
     mc_block_t prefix = 0b111 << 8;     // 1792 is the starting offset
     // if the xor zeroes all bits, the prefix must've matched.
-    return (block & ~mask) ^ prefix == 0;
+    return ((block & ~mask) ^ prefix) == 0;
 }
 
 const mc_block_t block_class_stair[] = {

--- a/overviewer_core/src/overviewer.h
+++ b/overviewer_core/src/overviewer.h
@@ -31,7 +31,7 @@
 
 // increment this value if you've made a change to the c extension
 // and want to force users to rebuild
-#define OVERVIEWER_EXTENSION_VERSION 90
+#define OVERVIEWER_EXTENSION_VERSION 91
 
 #include <stdbool.h>
 #include <stdint.h>

--- a/overviewer_core/world.py
+++ b/overviewer_core/world.py
@@ -1053,7 +1053,9 @@ class RegionSet(object):
                 (key == 'minecraft:observer' and p.get('powered', 'false') == 'true')):
                 data |= 0x08
         elif (key.endswith('_log') or key.endswith('_wood') or
-              key == 'minecraft:bone_block' or key.endswith('_stem')):
+              key in ['minecraft:bone_block', 'minecraft:warped_stem',
+                      'minecraft:stripped_warped_stem', 'minecraft:crimson_stem',
+                      'minecraft:stripped_crimson_stem']):
             axis = palette_entry['Properties']['axis']
             if axis == 'x':
                 data |= 4


### PR DESCRIPTION
This resolves a couple of issues with some of the recent 1.16 commits:
- Some stairs were incorrectly being identified as walls, causing incorrect pseudo data to be assigned & resulting in rendering issues
- A check for warped & crimson stem blocks was too inclusive, resulting in stems for melons, pumpkins, and mushrooms to no longer render at all

Fixes: #1825 