### PR TITLE
GenPOI: adds explicit pool close/join in handleEntities to fix possible hang (issue #1817)

### DIFF
--- a/overviewer_core/aux_files/genPOI.py
+++ b/overviewer_core/aux_files/genPOI.py
@@ -217,6 +217,8 @@ def handleEntities(rset, config, config_path, filters, markers):
 
         results = pool.map(parseBucketChunks, ((buck, rset, filters) for buck in buckets))
 
+        pool.close()
+        pool.join()
         logging.info("All the threads completed.")
 
         for marker_dict in results:


### PR DESCRIPTION
Fixes #1817 (rationale in the issue)

I was previously hitting this on at least 10% of all calls to `genPOI`, it's now been nearly a month (~600 runs) without a hang.