### PR TITLE
Improve multiple crop zone support

### DIFF
--- a/overviewer.py
+++ b/overviewer.py
@@ -531,20 +531,12 @@ def main():
 
         # If a crop is requested, wrap the regionset here
         if "crop" in render:
-            rsets = []
-            for zone in render['crop']:
-                rsets.append(world.CroppedRegionSet(rset, *zone))
-        else:
-            rsets = [rset]
+            rset = world.CroppedRegionSet(rset, render['crop'])
 
         # If this is to be a rotated regionset, wrap it in a RotatedRegionSet
         # object
         if (render['northdirection'] > 0):
-            newrsets = []
-            for r in rsets:
-                r = world.RotatedRegionSet(r, render['northdirection'])
-                newrsets.append(r)
-            rsets = newrsets
+            rset = world.RotatedRegionSet(rset, render['northdirection'])
 
         ###############################
         # Do the final prep and create the TileSet object
@@ -560,9 +552,8 @@ def main():
             "dimension", "changelist", "showspawn", "overlay", "base", "poititle", "maxzoom",
             "showlocationmarker", "minzoom", "center"])
         tileSetOpts.update({"spawn": w.find_true_spawn()})  # TODO find a better way to do this
-        for rset in rsets:
-            tset = tileset.TileSet(w, rset, assetMrg, tex, tileSetOpts, tileset_dir)
-            tilesets.append(tset)
+        tset = tileset.TileSet(w, rset, assetMrg, tex, tileSetOpts, tileset_dir)
+        tilesets.append(tset)
 
     # If none of the requested dimenstions exist, tilesets will be empty
     if not tilesets:

--- a/overviewer_core/world.py
+++ b/overviewer_core/world.py
@@ -1743,42 +1743,38 @@ class RotatedRegionSet(RegionSetWrapper):
             yield x,z,mtime
 
 class CroppedRegionSet(RegionSetWrapper):
-    def __init__(self, rsetobj, xmin, zmin, xmax, zmax):
+    def __init__(self, rsetobj, cropzones):
         super(CroppedRegionSet, self).__init__(rsetobj)
-        self.xmin = xmin//16
-        self.xmax = xmax//16
-        self.zmin = zmin//16
-        self.zmax = zmax//16
+        newcropzones = []
+        for cz in cropzones:
+            # Crop zone format: (xmin, zmin, xmax, zmax)
+            newcropzones.append(tuple([x // 16 for x in cz]))
+        self.cropzones = newcropzones
+    
+    def chunk_in_cropzone(self, x, z):
+        # Determines if chunk at (x, z) is within one of the defined crop zones
+        for cz in self.cropzones:
+            if cz[0] <= x <= cz[2] and cz[1] <= z <= cz[3]:
+                return True
+        return False
 
-    def get_chunk(self,x,z):
-        if (
-                self.xmin <= x <= self.xmax and
-                self.zmin <= z <= self.zmax
-                ):
-            return super(CroppedRegionSet, self).get_chunk(x,z)
+    def get_chunk(self, x, z):
+        if self.chunk_in_cropzone(x, z):
+            return super(CroppedRegionSet, self).get_chunk(x, z)
         else:
             raise ChunkDoesntExist("This chunk is out of the requested bounds")
 
     def iterate_chunks(self):
-        return ((x,z,mtime) for (x,z,mtime) in super(CroppedRegionSet,self).iterate_chunks()
-                if
-                    self.xmin <= x <= self.xmax and
-                    self.zmin <= z <= self.zmax
-                )
+        return ((x, z, mtime) for (x, z ,mtime) in super(CroppedRegionSet,self).iterate_chunks()
+                if self.chunk_in_cropzone(x, z))
 
     def iterate_newer_chunks(self, filemtime):
-        return ((x,z,mtime) for (x,z,mtime) in super(CroppedRegionSet,self).iterate_newer_chunks(filemtime)
-                if
-                    self.xmin <= x <= self.xmax and
-                    self.zmin <= z <= self.zmax
-                )
+        return ((x, z, mtime) for (x, z, mtime) in super(CroppedRegionSet,self).iterate_newer_chunks(filemtime)
+                if self.chunk_in_cropzone(x, z))
 
     def get_chunk_mtime(self,x,z):
-        if (
-                self.xmin <= x <= self.xmax and
-                self.zmin <= z <= self.zmax
-                ):
-            return super(CroppedRegionSet, self).get_chunk_mtime(x,z)
+        if self.chunk_in_cropzone(x, z):
+            return super(CroppedRegionSet, self).get_chunk_mtime(x, z)
         else:
             return None
 


### PR DESCRIPTION
Changes how multiple crop zones within a single render definition are handled, resolving an issue where output would be corrupted when crop zones overlapped or were in close proximity to each other (potentially fixes #1848).

See below a comparison of the same render on master at 91ea87447a1b73aa596a0a7919910b8556f24283 (top) and this PR (bottom) with two crop zones defined as `[(-1264, -112, -1249, -65), (-1328, -144, -1265, -113)]`:
![ovr-crop-change](https://user-images.githubusercontent.com/2823982/92979876-f0743300-f48b-11ea-9d18-4dada3f325c2.png)
