### PR TITLE
Fix typos and punctuation in documentation

### DIFF
--- a/docs/building.rst
+++ b/docs/building.rst
@@ -16,7 +16,7 @@ Get The Source
 ==============
 
 First step: download the platform-independent source! Either clone with Git
-(recommended if you know Git) or download the most recent snapshot
+(recommended if you know Git) or download the most recent snapshot:
 
 * Git URL to clone: ``git://github.com/overviewer/Minecraft-Overviewer.git``
 * `Download most recent tar archive <https://github.com/overviewer/Minecraft-Overviewer/tarball/master>`_
@@ -160,7 +160,7 @@ macOS
 
     sudo easy_install pip
 
-#. Install Pillow (overviewer needs PIL, Pillow is a fork of PIL that provides the same funcitonality)::
+#. Install Pillow (overviewer needs PIL, Pillow is a fork of PIL that provides the same functionality)::
 
     pip install Pillow
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -412,7 +412,7 @@ Custom web assets
 .. _customwebassets:
 
 ``customwebassets = "<path to custom web assets>"``
-    This option allows you to speciy a directory containing custom web assets
+    This option allows you to specify a directory containing custom web assets
     to be copied to the output directory. Any files in the custom web assets 
     directory overwrite the default files.
 
@@ -431,7 +431,7 @@ Custom web assets
 
 .. _renderdict:
 
-Render Dictonary Keys
+Render Dictionary Keys
 ---------------------
 
 The render dictionary is a dictionary mapping configuration key strings to

--- a/docs/design/designdoc.rst
+++ b/docs/design/designdoc.rst
@@ -17,7 +17,7 @@ So let's get started!
 
 .. note::
 
-    This page is continually under construction
+    This page is continually under construction.
 
 .. contents::
 
@@ -103,7 +103,7 @@ The first step is rendering the block sprites from the textures. Each block is
 Textures come from files inside of a "textures" folder.  If the file is square (has equal width
 and height dimensions), it is scaled down to 16 x 16 pixels.  Non-square images are used with animated
 textures.  In this case, the first frame of the animated texture is used, and also scaled to a 16 by 16 image.
-In order to draw a cube out of the textuers, an `affine transformation`_ is applied to
+In order to draw a cube out of the textures, an `affine transformation`_ is applied to
 the images for the top and sides of the cube in order to transform it to the
 appropriate perspective.
 
@@ -472,7 +472,7 @@ the upside is that arbitrarily sized maps can be viewed.
 
 The Overviewer uses a tile size of 384 by 384 pixels. This is the same as the
 size of a chunk section and is no coincidence. Just considering the top face of
-a chunk, the 8 chunks directly below itget rendered into a tile in this
+a chunk, the 8 chunks directly below it get rendered into a tile in this
 configuration:
 
 .. image:: tilerendering/chunksintile.png
@@ -679,7 +679,7 @@ corners on a given face, and for all visible faces.
 The `ambient occlusion`_ effect so strongly associated with smooth
 lighting in-game is a side effect of this method. Since solid blocks
 have both light values set to 0, the lighting coefficient is very
-close to 0. For verticies in corners, at least 1 (or more) of the 4
+close to 0. For vertices in corners, at least 1 (or more) of the 4
 averaged lighting values is therefore 0, dragging the average down,
 and creating the "dark corners" effect.
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -24,7 +24,7 @@ now uses Leaflet. All files which Overviewer needs are included in the output,
 so even if you have no internet connection, you will still be able to view the
 map without any issues.
 
-When my map expands, I see remnants of another zoom level
+When my map expands, I see remnants of another zoom level.
 ---------------------------------------------------------
 
 When your map expands ("Your map seems to have expanded beyond its previous
@@ -37,7 +37,7 @@ When you're copying the rendered map, you need to be sure files that *don't*
 exist in the source are *deleted* in the destination.
 
 Explanation: When Overviewer re-arranges tiles to make room for another zoom
-level, it moves some tiles tiles at a particular zoom level and places them at a
+level, it moves some tiles at a particular zoom level and places them at a
 higher zoom level. The tiles that used to be at that zoom level should no longer
 exist there, but if you're copying tiles, there is no mechanism to *delete*
 those files at the copy destination.
@@ -45,10 +45,10 @@ those files at the copy destination.
 If that explanation doesn't make full sense, then just know that you must do one
 of the following:
 
-* Render the tiles directly to the destination
+* Render the tiles directly to the destination.
 
 * Copy the tiles from the render destination in a way that deletes extra files,
-  such as using ``rsync`` with ``--delete``
+  such as using ``rsync`` with ``--delete``.
 
 * Erase and re-copy the files at the final destination when the map expands.
   Map expansions double the width and height of the map, so you will eventually
@@ -118,7 +118,7 @@ you run this command line; to simply append the output to the file, use two grea
 
 .. _cropping_faq:
 
-I've deleted some sections of my world but they still appear in the map
+I've deleted some sections of my world, but they still appear in the map.
 -----------------------------------------------------------------------
 Okay, so making edits to your world in e.g. worldedit has some caveats,
 especially regarding deleting sections of your world.
@@ -175,7 +175,7 @@ two ways.
    people explore near there, because that will force that part of the map to
    update.
 
-My map is zoomed out so far that it looks (almost) blank
+My map is zoomed out so far that it looks (almost) blank.
 --------------------------------------------------------
 
 We see this quite a bit, and seems to stem from a bug in the Minecraft terrain
@@ -201,9 +201,9 @@ to render all of your map, but instead to only render the specified region.
 
 As always, if you need assistance, come chat with us on :ref:`irc<help>`.
 
-.. [*] They could also have been triggered by an accidential teleport where the coordinates were typed in manually.
+.. [*] They could also have been triggered by an accidental teleport where the coordinates were typed in manually.
 
-I want to put manual POI definitions or other parts of my config into a seperate file
+I want to put manual POI definitions or other parts of my config into a separate file.
 -------------------------------------------------------------------------------------
 
 This can be achieved by creating a module and then importing it in

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,7 @@ The Minecraft Overviewer
 ========================
 
 See also the `Github Homepage`_ and the `Updates Blog`_, and follow us on
-our `Twitter account`_
+our `Twitter account`_.
 
 .. _Github Homepage: https://github.com/overviewer/Minecraft-Overviewer
 

--- a/docs/signs.rst
+++ b/docs/signs.rst
@@ -92,7 +92,7 @@ There are currently two special types of POIs.  They each have a special id:
 
 PlayerSpawn
   Used to indicate the spawn location of a player.  The player's name is set
-  in the ``EntityId`` key, and the location is in the x,y,z keys
+  in the ``EntityId`` key, and the location is in the x,y,z keys.
 
 Player
   Used to indicate the last known location of a player.  The player's name is set
@@ -209,7 +209,7 @@ The following keys are accepted in the marker dictionary:
 ``icon``
     Optional.  Specifies the icon to use for POIs in this group.  If omitted, it defaults
     to a signpost icon.  Note that each POI can have different icon by setting the key 'icon'
-    on the POI itself (this can be done by modifying the POI in the filter function.  See the
+    on the POI itself. (this can be done by modifying the POI in the filter function.  See the
     example above)
 
 ``createInfoWindow``

--- a/docs/win_tut/windowsguide.rst
+++ b/docs/win_tut/windowsguide.rst
@@ -68,7 +68,7 @@ We're half way there!
     .. image:: location2.png
     
     Got the location? Good. We're going to *change directory* to that directory
-    with the command prompt. Bring the command prompot window back up. The
+    with the command prompt. Bring the command prompt window back up. The
     command we're going to use is called ``cd``, it stands for ... *change
     directory*!
 
@@ -188,7 +188,7 @@ to use your favorite pastebin site, if you'd like.
     .. image:: gist1.png
 
 * Third, click the 'Create Secret Gist' button.  A secret gist means that
-  only someone with the exact URL can view your gist
+  only someone with the exact URL can view your gist.
 
     .. image:: gist2.png
 


### PR DESCRIPTION
I have fixed some typos and punctuation errors in the documentation.