### PR TITLE
Add name of world to some errors

### DIFF
--- a/overviewer.py
+++ b/overviewer.py
@@ -513,7 +513,7 @@ def main():
             rset = w.get_regionset(render['dimension'][1])
         except IndexError:
             logging.error("Sorry, I can't find anything to render!  Are you sure there are .mca "
-                          "files in the world directory?")
+                          "files in the world directory of %s?" % render['world'])
             return 1
         if rset is None:    # indicates no such dimension was found
             logging.warning("Sorry, you requested dimension '%s' for %s, but I couldn't find it.",

--- a/overviewer_core/world.py
+++ b/overviewer_core/world.py
@@ -1600,7 +1600,7 @@ class RegionSet(object):
                 x = int(p[1])
                 y = int(p[2])
                 if abs(x) > 500000 or abs(y) > 500000:
-                    logging.warning("Holy shit what is up with region file %s !?" % f)
+                    logging.warning("Holy shit what is up with region file %s in %s !?" % (f, self.regiondir))
                 yield (x, y, os.path.join(self.regiondir, f))
 
 class RegionSetWrapper(object):


### PR DESCRIPTION
This adds the name of the world which was causing certain errors to the error messages so that one can figure out what went wrong there. This helps a lot when you have tons of worlds in one config.