### PR TITLE
Minor spelling fixes

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,7 +53,7 @@ Documentation Contents
 Features
 ========
 
-* Renders high resolution images of your world, let's you "deep zoom" and see
+* Renders high resolution images of your world, lets you "deep zoom" and see
   details!
 
 * Gloriously awesome smooth lighting is here!


### PR DESCRIPTION
Fixes two minor spelling mistakes in the `index.rst` of the documentation.