### PR TITLE
Added all new 1.16 wood blocks

### DIFF
--- a/overviewer_core/src/block_class.c
+++ b/overviewer_core/src/block_class.c
@@ -249,6 +249,8 @@ const mc_block_t block_class_alt_height[] = {
     block_cut_sandstone_slab,
     block_smooth_red_sandstone_slab,
     block_cut_red_sandstone_slab,
+    block_crimson_slab,
+    block_warped_slab,
     block_end_stone_brick_slab,
     block_mossy_cobblestone_slab,
     block_mossy_stone_brick_slab,

--- a/overviewer_core/src/mc_id.h
+++ b/overviewer_core/src/mc_id.h
@@ -281,6 +281,8 @@ enum mc_block_id {
     block_crimson_roots = 1019,
     block_soul_soil = 1020,
     block_nether_gold_ore = 1021,
+    block_crimson_slab = 1022,
+    block_warped_slab = 1023,
     // adding a gap in the numbering of walls to keep them all
     // in one numbering block starting at 1792
     // all blocks between 1792 and 2047 are considered walls
@@ -377,10 +379,7 @@ enum mc_block_id {
     block_honey_block = 11504,
     block_sweet_berry_bush = 11505,
     block_campfire = 11506,
-    block_bell = 11507,
-    // 1.16 blocks below
-    block_crimson_slab = 11508,
-    block_warped_slab = 11509
+    block_bell = 11507
 };
 
 typedef uint16_t mc_block_t;

--- a/overviewer_core/src/mc_id.h
+++ b/overviewer_core/src/mc_id.h
@@ -377,7 +377,10 @@ enum mc_block_id {
     block_honey_block = 11504,
     block_sweet_berry_bush = 11505,
     block_campfire = 11506,
-    block_bell = 11507
+    block_bell = 11507,
+    // 1.16 blocks below
+    block_crimson_slab = 11508,
+    block_warped_slab = 11509
 };
 
 typedef uint16_t mc_block_t;

--- a/overviewer_core/src/overviewer.h
+++ b/overviewer_core/src/overviewer.h
@@ -31,7 +31,7 @@
 
 // increment this value if you've made a change to the c extension
 // and want to force users to rebuild
-#define OVERVIEWER_EXTENSION_VERSION 91
+#define OVERVIEWER_EXTENSION_VERSION 92
 
 #include <stdbool.h>
 #include <stdint.h>

--- a/overviewer_core/textures.py
+++ b/overviewer_core/textures.py
@@ -1685,8 +1685,8 @@ block(blockid=42, top_image="assets/minecraft/textures/block/iron_block.png")
 # double slabs and slabs
 # these wooden slabs are unobtainable without cheating, they are still
 # here because lots of pre-1.3 worlds use this blocks, add prismarine slabs
-@material(blockid=[43, 44, 181, 182, 204, 205] + list(range(11340,11359)) + [11508, 11509], data=list(range(16)),
-          transparent=[44, 182, 205] + list(range(11340,11359)) + [11508, 11509], solid=True)
+@material(blockid=[43, 44, 181, 182, 204, 205] + list(range(11340,11359)) + [1022, 1023], data=list(range(16)),
+          transparent=[44, 182, 205] + list(range(11340,11359)) + [1022, 1023], solid=True)
 def slabs(self, blockid, data):
     if blockid == 44 or blockid == 182: 
         texture = data & 7
@@ -1777,9 +1777,9 @@ def slabs(self, blockid, data):
         top  = self.load_image_texture("assets/minecraft/textures/block/smooth_stone.png").copy()
         side = self.load_image_texture("assets/minecraft/textures/block/smooth_stone_slab_side.png").copy()
 
-    elif blockid == 11508: #  crimson_slab
+    elif blockid == 1022: #  crimson_slab
         top = side  = self.load_image_texture("assets/minecraft/textures/block/crimson_planks.png").copy()
-    elif blockid == 11509: #  warped_slab
+    elif blockid == 1023: #  warped_slab
         top = side  = self.load_image_texture("assets/minecraft/textures/block/warped_planks.png").copy()
 
     if blockid == 43 or blockid == 181 or blockid == 204: # double slab

--- a/overviewer_core/textures.py
+++ b/overviewer_core/textures.py
@@ -969,7 +969,7 @@ def dirt_blocks(self, blockid, data):
 block(blockid=4, top_image="assets/minecraft/textures/block/cobblestone.png")
 
 # wooden planks
-@material(blockid=5, data=list(range(6)), solid=True)
+@material(blockid=5, data=list(range(8)), solid=True)
 def wooden_planks(self, blockid, data):
     if data == 0: # normal
         return self.build_block(self.load_image_texture("assets/minecraft/textures/block/oak_planks.png"), self.load_image_texture("assets/minecraft/textures/block/oak_planks.png"))
@@ -983,6 +983,10 @@ def wooden_planks(self, blockid, data):
         return self.build_block(self.load_image_texture("assets/minecraft/textures/block/acacia_planks.png"),self.load_image_texture("assets/minecraft/textures/block/acacia_planks.png"))
     if data == 5: # dark oak
         return self.build_block(self.load_image_texture("assets/minecraft/textures/block/dark_oak_planks.png"),self.load_image_texture("assets/minecraft/textures/block/dark_oak_planks.png"))
+    if data == 6: # crimson
+        return self.build_block(self.load_image_texture("assets/minecraft/textures/block/crimson_planks.png"),self.load_image_texture("assets/minecraft/textures/block/crimson_planks.png"))
+    if data == 7: # warped
+        return self.build_block(self.load_image_texture("assets/minecraft/textures/block/warped_planks.png"),self.load_image_texture("assets/minecraft/textures/block/warped_planks.png"))
 
 @material(blockid=6, data=list(range(16)), transparent=True)
 def saplings(self, blockid, data):
@@ -1681,8 +1685,8 @@ block(blockid=42, top_image="assets/minecraft/textures/block/iron_block.png")
 # double slabs and slabs
 # these wooden slabs are unobtainable without cheating, they are still
 # here because lots of pre-1.3 worlds use this blocks, add prismarine slabs
-@material(blockid=[43, 44, 181, 182, 204, 205] + list(range(11340,11359)), data=list(range(16)),
-          transparent=[44, 182, 205] + list(range(11340,11359)), solid=True)
+@material(blockid=[43, 44, 181, 182, 204, 205] + list(range(11340,11359)) + [11508, 11509], data=list(range(16)),
+          transparent=[44, 182, 205] + list(range(11340,11359)) + [11508, 11509], solid=True)
 def slabs(self, blockid, data):
     if blockid == 44 or blockid == 182: 
         texture = data & 7
@@ -1700,13 +1704,13 @@ def slabs(self, blockid, data):
             top = side = self.load_image_texture("assets/minecraft/textures/block/oak_planks.png")
         elif texture== 3: # cobblestone slab
             top = side = self.load_image_texture("assets/minecraft/textures/block/cobblestone.png")
-        elif texture== 4: # brick
+        elif texture== 4: # brick slab
             top = side = self.load_image_texture("assets/minecraft/textures/block/bricks.png")
-        elif texture== 5: # stone brick
+        elif texture== 5: # stone brick slab
             top = side = self.load_image_texture("assets/minecraft/textures/block/stone_bricks.png")
         elif texture== 6: # nether brick slab
             top = side = self.load_image_texture("assets/minecraft/textures/block/nether_bricks.png")
-        elif texture== 7: #quartz        
+        elif texture== 7: # quartz slab
             top = side = self.load_image_texture("assets/minecraft/textures/block/quartz_block_side.png")
         elif texture== 8: # special stone double slab with top texture only
             top = side = self.load_image_texture("assets/minecraft/textures/block/smooth_stone.png")
@@ -1772,6 +1776,11 @@ def slabs(self, blockid, data):
     elif blockid == 11358: #  smooth_stone_slab
         top  = self.load_image_texture("assets/minecraft/textures/block/smooth_stone.png").copy()
         side = self.load_image_texture("assets/minecraft/textures/block/smooth_stone_slab_side.png").copy()
+
+    elif blockid == 11508: #  crimson_slab
+        top = side  = self.load_image_texture("assets/minecraft/textures/block/crimson_planks.png").copy()
+    elif blockid == 11509: #  warped_slab
+        top = side  = self.load_image_texture("assets/minecraft/textures/block/warped_planks.png").copy()
 
     if blockid == 43 or blockid == 181 or blockid == 204: # double slab
         return self.build_block(top, side)
@@ -4557,6 +4566,11 @@ def wooden_slabs(self, blockid, data):
         top = side = self.load_image_texture("assets/minecraft/textures/block/acacia_planks.png")
     elif texture== 5: # dark wood
         top = side = self.load_image_texture("assets/minecraft/textures/block/dark_oak_planks.png")
+    elif texture== 6: # crimson
+        top = side = self.load_image_texture("assets/minecraft/textures/block/crimson_planks.png")
+    elif texture== 7: # warped
+        top = side = self.load_image_texture("assets/minecraft/textures/block/warped_planks.png")
+
     else:
         return None
     

--- a/overviewer_core/textures.py
+++ b/overviewer_core/textures.py
@@ -2033,7 +2033,7 @@ block(blockid=52, top_image="assets/minecraft/textures/block/spawner.png", trans
 # polished_granite polished_andesite polished_diorite granite diorite andesite end_stone_bricks red_nether_brick stairs
 # smooth_red_sandstone_stairs
 @material(blockid=[53, 67, 108, 109, 114, 128, 134, 135, 136, 156, 163, 164, 180, 203, 11337, 11338, 11339,
-          11370, 11371, 11374, 11375, 11376, 11377, 11378, 11379, 11380, 11381, 11382, 11383, 11384, 11415], 
+          11370, 11371, 11374, 11375, 11376, 11377, 11378, 11379, 11380, 11381, 11382, 11383, 11384, 11415, 11518, 11519], 
           data=list(range(128)), transparent=True, solid=True, nospawn=True)
 def stairs(self, blockid, data):
     # preserve the upside-down bit
@@ -2079,6 +2079,8 @@ def stairs(self, blockid, data):
         11383: "assets/minecraft/textures/block/end_stone_bricks.png",
         11384: "assets/minecraft/textures/block/red_nether_bricks.png",
         11415: "assets/minecraft/textures/block/red_sandstone_top.png",
+        11518: "assets/minecraft/textures/block/crimson_planks.png",
+        11519: "assets/minecraft/textures/block/warped_planks.png"
     }
 
     texture = self.load_image_texture(stair_id_to_tex[blockid]).copy()
@@ -3295,7 +3297,7 @@ def levers(self, blockid, data):
     return img
 
 # wooden and stone pressure plates, and weighted pressure plates
-@material(blockid=[70, 72,147,148,11301,11302,11303,11304,11305], data=[0,1], transparent=True)
+@material(blockid=[70,72,147,148,11301,11302,11303,11304,11305,11510,11511], data=[0,1], transparent=True)
 def pressure_plate(self, blockid, data):
     texture_name = {70:"assets/minecraft/textures/block/stone.png",              # stone
                     72:"assets/minecraft/textures/block/oak_planks.png",         # oak
@@ -3304,8 +3306,10 @@ def pressure_plate(self, blockid, data):
                     11303:"assets/minecraft/textures/block/jungle_planks.png",   # jungle
                     11304:"assets/minecraft/textures/block/acacia_planks.png",   # acacia
                     11305:"assets/minecraft/textures/block/dark_oak_planks.png", # dark oak
+                    11510:"assets/minecraft/textures/block/crimson_planks.png",  # crimson
+                    11511:"assets/minecraft/textures/block/warped_planks.png",   # warped
                     147:"assets/minecraft/textures/block/gold_block.png",        # light golden
-                    148:"assets/minecraft/textures/block/iron_block.png",        # heavy iron
+                    148:"assets/minecraft/textures/block/iron_block.png"         # heavy iron
                    }[blockid]
     t = self.load_image_texture(texture_name).copy()
     
@@ -3336,7 +3340,7 @@ def pressure_plate(self, blockid, data):
 block(blockid=[73, 74], top_image="assets/minecraft/textures/block/redstone_ore.png")
 
 # stone a wood buttons
-@material(blockid=(77,143,11326,11327,11328,11329,11330), data=list(range(16)), transparent=True)
+@material(blockid=(77,143,11326,11327,11328,11329,11330,11512,11513), data=list(range(16)), transparent=True)
 def buttons(self, blockid, data):
 
     # 0x8 is set if the button is pressed mask this info and render
@@ -3369,7 +3373,9 @@ def buttons(self, blockid, data):
                    11327:"assets/minecraft/textures/block/birch_planks.png",
                    11328:"assets/minecraft/textures/block/jungle_planks.png",
                    11329:"assets/minecraft/textures/block/acacia_planks.png",
-                   11330:"assets/minecraft/textures/block/dark_oak_planks.png"
+                   11330:"assets/minecraft/textures/block/dark_oak_planks.png",
+                   11512:"assets/minecraft/textures/block/crimson_planks.png",
+                   11513:"assets/minecraft/textures/block/warped_planks.png"
                   }[blockid]
     t = self.load_image_texture(texturepath).copy()
 
@@ -3500,7 +3506,7 @@ def jukebox(self, blockid, data):
 
 # nether and normal fences
 # uses pseudo-ancildata found in iterate.c
-@material(blockid=[85, 188, 189, 190, 191, 192, 113], data=list(range(16)), transparent=True, nospawn=True)
+@material(blockid=[85, 188, 189, 190, 191, 192, 113, 11514, 11515], data=list(range(16)), transparent=True, nospawn=True)
 def fence(self, blockid, data):
     # no need for rotations, it uses pseudo data.
     # create needed images for Big stick fence
@@ -3528,6 +3534,14 @@ def fence(self, blockid, data):
         fence_top = self.load_image_texture("assets/minecraft/textures/block/acacia_planks.png").copy()
         fence_side = self.load_image_texture("assets/minecraft/textures/block/acacia_planks.png").copy()
         fence_small_side = self.load_image_texture("assets/minecraft/textures/block/acacia_planks.png").copy()
+    elif blockid == 11514: # crimson fence
+        fence_top = self.load_image_texture("assets/minecraft/textures/block/crimson_planks.png").copy()
+        fence_side = self.load_image_texture("assets/minecraft/textures/block/crimson_planks.png").copy()
+        fence_small_side = self.load_image_texture("assets/minecraft/textures/block/crimson_planks.png").copy()
+    elif blockid == 11515: # warped fence
+        fence_top = self.load_image_texture("assets/minecraft/textures/block/warped_planks.png").copy()
+        fence_side = self.load_image_texture("assets/minecraft/textures/block/warped_planks.png").copy()
+        fence_small_side = self.load_image_texture("assets/minecraft/textures/block/warped_planks.png").copy()
     else: # netherbrick fence
         fence_top = self.load_image_texture("assets/minecraft/textures/block/nether_bricks.png").copy()
         fence_side = self.load_image_texture("assets/minecraft/textures/block/nether_bricks.png").copy()
@@ -4265,7 +4279,7 @@ def vines(self, blockid, data):
 
 
 # fence gates
-@material(blockid=[107, 183, 184, 185, 186, 187], data=list(range(8)), transparent=True, nospawn=True)
+@material(blockid=[107, 183, 184, 185, 186, 187, 11516, 11517], data=list(range(8)), transparent=True, nospawn=True)
 def fence_gate(self, blockid, data):
 
     # rotation
@@ -4304,6 +4318,10 @@ def fence_gate(self, blockid, data):
         gate_side = self.load_image_texture("assets/minecraft/textures/block/dark_oak_planks.png").copy()
     elif blockid == 187: # Acacia
         gate_side = self.load_image_texture("assets/minecraft/textures/block/acacia_planks.png").copy()
+    elif blockid == 11516: # Crimson
+        gate_side = self.load_image_texture("assets/minecraft/textures/block/crimson_planks.png").copy()
+    elif blockid == 11517: # Warped
+        gate_side = self.load_image_texture("assets/minecraft/textures/block/warped_planks.png").copy()
     else:
         return None
 

--- a/overviewer_core/world.py
+++ b/overviewer_core/world.py
@@ -855,8 +855,19 @@ class RegionSet(object):
             'minecraft:red_sandstone_wall': (1803, 0),
             'minecraft:sandstone_wall': (1804, 0),
             'minecraft:stone_brick_wall': (1805, 0),
+            # 1.16 extra
             'minecraft:crimson_slab': (11508, 0),
             'minecraft:warped_slab': (11509, 0),
+            'minecraft:crimson_pressure_plate': (11510, 0),
+            'minecraft:warped_pressure_plate': (11511, 0),
+            'minecraft:crimson_button': (11512, 0),
+            'minecraft:warped_button': (11513, 0),
+            'minecraft:crimson_fence': (11514, 0),
+            'minecraft:warped_fence': (11515, 0),
+            'minecraft:crimson_fence_gate': (11516, 0),
+            'minecraft:warped_fence_gate': (11517, 0),
+            'minecraft:crimson_stairs': (11518, 0),
+            'minecraft:warped_stairs': (11519, 0)
         }
 
         colors = [   'white', 'orange', 'magenta', 'light_blue',

--- a/overviewer_core/world.py
+++ b/overviewer_core/world.py
@@ -723,6 +723,8 @@ class RegionSet(object):
             'minecraft:crimson_roots': (1019, 0),
             'minecraft:soul_soil': (1020, 0),
             'minecraft:nether_gold_ore': (1021, 0),
+            'minecraft:crimson_slab': (1022, 0),
+            'minecraft:warped_slab': (1023, 0),
 
             # New blocks
             'minecraft:carved_pumpkin': (11300, 0),
@@ -856,8 +858,6 @@ class RegionSet(object):
             'minecraft:sandstone_wall': (1804, 0),
             'minecraft:stone_brick_wall': (1805, 0),
             # 1.16 extra
-            'minecraft:crimson_slab': (11508, 0),
-            'minecraft:warped_slab': (11509, 0),
             'minecraft:crimson_pressure_plate': (11510, 0),
             'minecraft:warped_pressure_plate': (11511, 0),
             'minecraft:crimson_button': (11512, 0),

--- a/overviewer_core/world.py
+++ b/overviewer_core/world.py
@@ -319,6 +319,8 @@ class RegionSet(object):
             'minecraft:jungle_planks': (5, 3),
             'minecraft:acacia_planks': (5, 4),
             'minecraft:dark_oak_planks': (5, 5),
+            'minecraft:crimson_planks': (5, 6),
+            'minecraft:warped_planks': (5, 7),
             'minecraft:sapling': (6, 0),
             'minecraft:bedrock': (7, 0),
             'minecraft:water': (8, 0),
@@ -853,6 +855,8 @@ class RegionSet(object):
             'minecraft:red_sandstone_wall': (1803, 0),
             'minecraft:sandstone_wall': (1804, 0),
             'minecraft:stone_brick_wall': (1805, 0),
+            'minecraft:crimson_slab': (11508, 0),
+            'minecraft:warped_slab': (11509, 0),
         }
 
         colors = [   'white', 'orange', 'magenta', 'light_blue',
@@ -882,7 +886,8 @@ class RegionSet(object):
 
     def _get_block(self, palette_entry):
         wood_slabs = ('minecraft:oak_slab','minecraft:spruce_slab','minecraft:birch_slab','minecraft:jungle_slab',
-                        'minecraft:acacia_slab','minecraft:dark_oak_slab','minecraft:petrified_oak_slab')
+                        'minecraft:acacia_slab','minecraft:dark_oak_slab','minecraft:petrified_oak_slab',
+                        'minecraft:crimson_slab','minecraft:warped_slab')
         stone_slabs = ('minecraft:stone_slab', 'minecraft:sandstone_slab','minecraft:red_sandstone_slab',
                         'minecraft:cobblestone_slab', 'minecraft:brick_slab','minecraft:purpur_slab',
                         'minecraft:stone_brick_slab', 'minecraft:nether_brick_slab',
@@ -937,6 +942,12 @@ class RegionSet(object):
             elif palette_entry['Properties']['type'] == 'double':
                 if key in wood_slabs:
                     block = 125         # block_double_wooden_slab
+                    if key == 'minecraft:crimson_slab':
+                        block = 5   # minecraft:crimson_planks
+                        data  = 6
+                    elif key == 'minecraft:warped_slab':
+                        block = 5   # minecraft:warped_planks
+                        data  = 7
                 elif key in stone_slabs:
                     if key == 'minecraft:stone_brick_slab':
                         block = 98


### PR DESCRIPTION
I've added 1.16 blocks using crimson and warped wood

This includes planks, slabs, stairs, plates, buttons, fences and gates

- [x] Tested compilation
- [X] Ran on a world with all blocks

(Ran on Debian Buster 10 with 1.16.4 world and 1.16.4 textures)