### PR TITLE
A little note on the Usage page

### DIFF
--- a/docs/running.rst
+++ b/docs/running.rst
@@ -42,6 +42,11 @@ you want to render).
 
     overviewer.py /home/username/mcserver /home/username/mcmap
 
+A little note: If the world folder is in use by another program at the time of
+rendering, you'll see some unexpected results with chunks being in the wrong
+places. Before you begin, make sure that you aren't using the world, or copy
+the world to a different location.
+
 After you enter one of the commands, The Overviewer should start rendering your
 map. When the render is done, open up *index.html* using your web-browser of
 choice.  Pretty cool, huh? You can even upload this map to a web server to share

--- a/overviewer_core/src/block_class.c
+++ b/overviewer_core/src/block_class.c
@@ -74,6 +74,8 @@ const mc_block_t block_class_stair[] = {
     block_spruce_stairs,
     block_birch_stairs,
     block_jungle_stairs,
+    block_crimson_stairs,
+    block_warped_stairs,
     block_quartz_stairs,
     block_acacia_stairs,
     block_dark_oak_stairs,
@@ -96,7 +98,10 @@ const mc_block_t block_class_stair[] = {
     block_end_stone_brick_stairs,
     block_red_nether_brick_stairs,
     block_mossy_stone_brick_stairs,
-    block_smooth_sandstone_stairs};
+    block_smooth_sandstone_stairs,
+    block_blackstone_stairs,
+    block_polished_blackstone_stairs,
+    block_polished_blackstone_brick_stairs};
 const size_t block_class_stair_len = COUNT_OF(block_class_stair);
 
 const mc_block_t block_class_door[] = {
@@ -106,7 +111,9 @@ const mc_block_t block_class_door[] = {
     block_birch_door,
     block_jungle_door,
     block_acacia_door,
-    block_dark_oak_door};
+    block_dark_oak_door,
+    block_crimson_door,
+    block_warped_door};
 const size_t block_class_door_len = COUNT_OF(block_class_door);
 
 const mc_block_t block_class_fence[] = {
@@ -116,6 +123,8 @@ const mc_block_t block_class_fence[] = {
     block_birch_fence,
     block_jungle_fence,
     block_dark_oak_fence,
+    block_crimson_fence,
+    block_warped_fence,
     block_acacia_fence};
 const size_t block_class_fence_len = COUNT_OF(block_class_fence);
 
@@ -125,7 +134,9 @@ const mc_block_t block_class_fence_gate[] = {
     block_birch_fence_gate,
     block_jungle_fence_gate,
     block_dark_oak_fence_gate,
-    block_acacia_fence_gate};
+    block_acacia_fence_gate,
+    block_crimson_fence_gate,
+    block_warped_fence_gate};
 const size_t block_class_fence_gate_len = COUNT_OF(block_class_fence_gate);
 
 const mc_block_t block_class_ancil[] = {
@@ -136,6 +147,7 @@ const mc_block_t block_class_ancil[] = {
     block_jungle_door,
     block_acacia_door,
     block_dark_oak_door,
+    block_crimson_door,
     block_oak_stairs,
     block_brick_stairs,
     block_stone_brick_stairs,
@@ -147,6 +159,8 @@ const mc_block_t block_class_ancil[] = {
     block_quartz_stairs,
     block_acacia_stairs,
     block_dark_oak_stairs,
+    block_crimson_stairs,
+    block_warped_stairs,
     block_red_sandstone_stairs,
     block_smooth_red_sandstone_stairs,
     block_purpur_stairs,
@@ -167,6 +181,9 @@ const mc_block_t block_class_ancil[] = {
     block_end_stone_brick_stairs,
     block_red_nether_brick_stairs,
     block_smooth_sandstone_stairs,
+    block_blackstone_stairs,
+    block_polished_blackstone_stairs,
+    block_polished_blackstone_brick_stairs,    
     block_grass,
     block_flowing_water,
     block_water,
@@ -193,6 +210,12 @@ const mc_block_t block_class_ancil[] = {
     block_red_sandstone_wall,
     block_sandstone_wall,
     block_stone_brick_wall,
+    block_blackstone_wall,
+    block_polished_blackstone_wall,
+    block_polished_blackstone_brick_wall,
+    block_crying_obsidian,
+    block_lodestone,
+    block_respawn_anchor,
     block_double_plant,
     block_stained_glass_pane,
     block_stained_glass,
@@ -200,6 +223,8 @@ const mc_block_t block_class_ancil[] = {
     block_birch_fence,
     block_jungle_fence,
     block_dark_oak_fence,
+    block_crimson_fence,
+    block_warped_fence,
     block_acacia_fence};
 const size_t block_class_ancil_len = COUNT_OF(block_class_ancil);
 
@@ -214,8 +239,11 @@ const mc_block_t block_class_alt_height[] = {
     block_birch_stairs,
     block_jungle_stairs,
     block_quartz_stairs,
+    block_quartz_stairs,
     block_acacia_stairs,
     block_dark_oak_stairs,
+    block_crimson_stairs,
+    block_warped_stairs,
     block_red_sandstone_stairs,
     block_smooth_red_sandstone_stairs,
     block_prismarine_stairs,
@@ -235,6 +263,9 @@ const mc_block_t block_class_alt_height[] = {
     block_end_stone_brick_stairs,
     block_red_nether_brick_stairs,
     block_smooth_sandstone_stairs,
+    block_blackstone_stairs,
+    block_polished_blackstone_stairs,
+    block_polished_blackstone_brick_stairs,    
     block_prismarine_slab,
     block_dark_prismarine_slab,
     block_prismarine_brick_slab,
@@ -250,6 +281,9 @@ const mc_block_t block_class_alt_height[] = {
     block_smooth_red_sandstone_slab,
     block_cut_red_sandstone_slab,
     block_end_stone_brick_slab,
+    block_blackstone_slab,
+    block_polished_blackstone_slab,
+    block_polished_blackstone_brick_slab,
     block_mossy_cobblestone_slab,
     block_mossy_stone_brick_slab,
     block_smooth_quartz_slab,
@@ -269,5 +303,6 @@ const mc_block_t block_class_nether_roof[] = {
     block_basalt,
     block_blackstone,
     block_soul_soil,
-    block_nether_gold_ore};
+    block_nether_gold_ore,
+    block_ancient_debris};
 const size_t block_class_nether_roof_len = COUNT_OF(block_class_nether_roof);

--- a/overviewer_core/src/iterate.c
+++ b/overviewer_core/src/iterate.c
@@ -280,7 +280,8 @@ generate_pseudo_data(RenderState* state, uint16_t ancilData) {
         /* check for fences AND fence gates */
         return check_adjacent_blocks(state, x, y, z, state->block) | check_adjacent_blocks(state, x, y, z, block_fence_gate) |
                check_adjacent_blocks(state, x, y, z, block_fence_gate) | check_adjacent_blocks(state, x, y, z, block_birch_fence_gate) | check_adjacent_blocks(state, x, y, z, block_jungle_fence_gate) |
-               check_adjacent_blocks(state, x, y, z, block_dark_oak_fence_gate) | check_adjacent_blocks(state, x, y, z, block_acacia_fence_gate);
+               check_adjacent_blocks(state, x, y, z, block_dark_oak_fence_gate) | check_adjacent_blocks(state, x, y, z, block_acacia_fence_gate)
+                | check_adjacent_blocks(state, x, y, z, block_crimson_fence_gate) | check_adjacent_blocks(state, x, y, z, block_warped_fence_gate);
 
     } else if (state->block == block_redstone_wire) { /* redstone */
         /* three addiotional bit are added, one for on/off state, and

--- a/overviewer_core/src/mc_id.h
+++ b/overviewer_core/src/mc_id.h
@@ -168,6 +168,8 @@ enum mc_block_id {
     block_log2 = 162,
     block_acacia_stairs = 163,
     block_dark_oak_stairs = 164,
+    block_crimson_stairs = 509,
+    block_warped_stairs = 510,
     block_slime = 165,
     block_barrier = 166,
     block_iron_trapdoor = 167,
@@ -192,15 +194,21 @@ enum mc_block_id {
     block_jungle_fence_gate = 185,
     block_dark_oak_fence_gate = 186,
     block_acacia_fence_gate = 187,
+    block_crimson_fence_gate = 513,
+    block_warped_fence_gate = 514,
     block_spruce_fence = 188,
     block_birch_fence = 189,
     block_jungle_fence = 190,
     block_dark_oak_fence = 191,
     block_acacia_fence = 192,
+    block_crimson_fence = 511,
+    block_warped_fence = 512,
     block_spruce_door = 193,
     block_birch_door = 194,
     block_jungle_door = 195,
     block_acacia_door = 196,
+    block_crimson_door = 499,
+    block_warped_door = 500,
     block_dark_oak_door = 197,
     block_end_rod = 198,
     block_chorus_plant = 199,
@@ -281,6 +289,29 @@ enum mc_block_id {
     block_crimson_roots = 1019,
     block_soul_soil = 1020,
     block_nether_gold_ore = 1021,
+    // Solid Nether stone blocks
+    block_polished_blackstone = 1022,
+    block_chiseled_polished_blackstone = 1023,
+    block_gilded_blackstone = 1024,
+    block_cracked_polished_blackstone_bricks = 1025,
+    block_polished_blackstone_bricks = 1026,
+    block_quartz_bricks = 1041,
+    // Nether stone stairs
+    block_blackstone_stairs = 1030,
+    block_polished_blackstone_stairs = 1031,
+    block_polished_blackstone_brick_stairs = 1032,
+    // nether redstone blocks
+    block_polished_blackstone_pressure_plate = 1033,
+    block_polished_blackstone_button = 1034,
+    // advanced nether blocks
+    block_crying_obsidian = 1035,
+    block_lodestone = 1036,
+    block_respawn_anchor = 1037,
+    // soul lightning
+    block_soul_lantern = 1038,
+    block_soul_torch = 1039,
+    block_soul_fire = 1040,
+
     // adding a gap in the numbering of walls to keep them all
     // in one numbering block starting at 1792
     // all blocks between 1792 and 2047 are considered walls
@@ -299,6 +330,9 @@ enum mc_block_id {
     block_red_sandstone_wall = 1803,
     block_sandstone_wall = 1804,
     block_stone_brick_wall = 1805,
+    block_blackstone_wall = 1806,
+    block_polished_blackstone_wall = 1807,
+    block_polished_blackstone_brick_wall = 1808,
     // end of walls
 
     block_prismarine_stairs = 11337,
@@ -319,6 +353,9 @@ enum mc_block_id {
     block_smooth_red_sandstone_slab = 11352,
     block_cut_red_sandstone_slab = 11353,
     block_end_stone_brick_slab = 11354,
+    block_blackstone_slab = 1027,
+    block_polished_blackstone_slab = 1028,
+    block_polished_blackstone_brick_slab = 1029,
     block_mossy_cobblestone_slab = 11355,
     block_mossy_stone_brick_slab = 11356,
     block_smooth_quartz_slab = 11357,
@@ -360,12 +397,16 @@ enum mc_block_id {
     block_jungle_sign = 11404,
     block_acacia_sign = 11405,
     block_dark_oak_sign = 11406,
+    block_crimson_sign = 12505,
+    block_warped_sign = 12506,
     block_oak_wall_sign = 11407,
     block_spruce_wall_sign = 11408,
     block_birch_wall_sign = 11409,
     block_jungle_wall_sign = 11410,
     block_acacia_wall_sign = 11411,
     block_dark_oak_wall_sign = 11412,
+    block_crimson_wall_sign = 12507,
+    block_warped_wall_sign = 12508,
     block_bamboo_sapling = 11413,
     block_scaffolding = 11414,
     block_bamboo = 11416,
@@ -559,6 +600,8 @@ enum mc_item_id {
     item_jungle_door = 429,
     item_acacia_door = 430,
     item_dark_oak_door = 431,
+    item_crimson_door = 755,
+    item_warped_door = 756,
     item_chorus_fruit = 432,
     item_popped_chorus_fruit = 433,
     item_beetroot = 434,
@@ -591,7 +634,7 @@ enum mc_item_id {
     item_record_strad = 2264,
     item_record_ward = 2265,
     item_record_11 = 2266,
-    item_record_wait = 2267
+    item_record_wait = 2267,
 };
 
 typedef uint16_t mc_item_t;

--- a/overviewer_core/src/overviewer.h
+++ b/overviewer_core/src/overviewer.h
@@ -31,7 +31,7 @@
 
 // increment this value if you've made a change to the c extension
 // and want to force users to rebuild
-#define OVERVIEWER_EXTENSION_VERSION 91
+#define OVERVIEWER_EXTENSION_VERSION 96
 
 #include <stdbool.h>
 #include <stdint.h>

--- a/overviewer_core/textures.py
+++ b/overviewer_core/textures.py
@@ -396,17 +396,6 @@ class Textures(object):
         self.lavatexture = lavatexture
         return lavatexture
     
-    def load_fire(self):
-        """Special-case function for loading fire."""
-        firetexture = getattr(self, "firetexture", None)
-        if firetexture:
-            return firetexture
-        fireNS = self.load_image_texture("assets/minecraft/textures/block/fire_0.png")
-        fireEW = self.load_image_texture("assets/minecraft/textures/block/fire_1.png")
-        firetexture = (fireNS, fireEW)
-        self.firetexture = firetexture
-        return firetexture
-    
     def load_portal(self):
         """Special-case function for loading portal."""
         portaltexture = getattr(self, "portaltexture", None)
@@ -969,7 +958,7 @@ def dirt_blocks(self, blockid, data):
 block(blockid=4, top_image="assets/minecraft/textures/block/cobblestone.png")
 
 # wooden planks
-@material(blockid=5, data=list(range(6)), solid=True)
+@material(blockid=5, data=list(range(8)), solid=True)
 def wooden_planks(self, blockid, data):
     if data == 0: # normal
         return self.build_block(self.load_image_texture("assets/minecraft/textures/block/oak_planks.png"), self.load_image_texture("assets/minecraft/textures/block/oak_planks.png"))
@@ -983,6 +972,10 @@ def wooden_planks(self, blockid, data):
         return self.build_block(self.load_image_texture("assets/minecraft/textures/block/acacia_planks.png"),self.load_image_texture("assets/minecraft/textures/block/acacia_planks.png"))
     if data == 5: # dark oak
         return self.build_block(self.load_image_texture("assets/minecraft/textures/block/dark_oak_planks.png"),self.load_image_texture("assets/minecraft/textures/block/dark_oak_planks.png"))
+    if data == 6: # crimson
+        return self.build_block(self.load_image_texture("assets/minecraft/textures/block/crimson_planks.png"),self.load_image_texture("assets/minecraft/textures/block/crimson_planks.png"))
+    if data == 7: # warped
+        return self.build_block(self.load_image_texture("assets/minecraft/textures/block/warped_planks.png"),self.load_image_texture("assets/minecraft/textures/block/warped_planks.png"))
 
 @material(blockid=6, data=list(range(16)), transparent=True)
 def saplings(self, blockid, data):
@@ -1681,8 +1674,8 @@ block(blockid=42, top_image="assets/minecraft/textures/block/iron_block.png")
 # double slabs and slabs
 # these wooden slabs are unobtainable without cheating, they are still
 # here because lots of pre-1.3 worlds use this blocks, add prismarine slabs
-@material(blockid=[43, 44, 181, 182, 204, 205] + list(range(11340,11359)), data=list(range(16)),
-          transparent=[44, 182, 205] + list(range(11340,11359)), solid=True)
+@material(blockid=[43, 44, 181, 182, 204, 205] + list(range(11340,11359)) + list(range(1027,1030)), data=list(range(16)),
+          transparent=[44, 182, 205] + list(range(11340,11359)) + list(range(1027,1030)), solid=True)
 def slabs(self, blockid, data):
     if blockid == 44 or blockid == 182: 
         texture = data & 7
@@ -1772,6 +1765,12 @@ def slabs(self, blockid, data):
     elif blockid == 11358: #  smooth_stone_slab
         top  = self.load_image_texture("assets/minecraft/textures/block/smooth_stone.png").copy()
         side = self.load_image_texture("assets/minecraft/textures/block/smooth_stone_slab_side.png").copy()
+    elif blockid == 1027: #  blackstone_slab
+        top = side  = self.load_image_texture("assets/minecraft/textures/block/blackstone.png").copy()
+    elif blockid == 1028: #  polished_blackstone_slab
+        top = side  = self.load_image_texture("assets/minecraft/textures/block/polished_blackstone.png").copy()
+    elif blockid == 1029: #  polished_blackstone_brick_slab
+        top = side  = self.load_image_texture("assets/minecraft/textures/block/polished_blackstone_bricks.png").copy()
 
     if blockid == 43 or blockid == 181 or blockid == 204: # double slab
         return self.build_block(top, side)
@@ -1789,8 +1788,8 @@ block(blockid=48, top_image="assets/minecraft/textures/block/mossy_cobblestone.p
 # obsidian
 block(blockid=49, top_image="assets/minecraft/textures/block/obsidian.png")
 
-# torch, redstone torch (off), redstone torch(on)
-@material(blockid=[50, 75, 76], data=[1, 2, 3, 4, 5], transparent=True)
+# torch, redstone torch (off), redstone torch(on), soul_torch
+@material(blockid=[50, 75, 76, 1039], data=[1, 2, 3, 4, 5], transparent=True)
 def torches(self, blockid, data):
     # first, rotations
     if self.rotation == 1:
@@ -1814,9 +1813,10 @@ def torches(self, blockid, data):
         small = self.load_image_texture("assets/minecraft/textures/block/torch.png")
     elif blockid == 75: # off redstone torch
         small = self.load_image_texture("assets/minecraft/textures/block/redstone_torch_off.png")
-    else: # on redstone torch
+    elif blockid == 76: # on redstone torch
         small = self.load_image_texture("assets/minecraft/textures/block/redstone_torch.png")
-        
+    elif blockid == 1039: # soul torch
+        small= self.load_image_texture("assets/minecraft/textures/block/soul_torch.png")
     # compose a torch bigger than the normal
     # (better for doing transformations)
     torch = Image.new("RGBA", (16,16), self.bgcolor)
@@ -1860,10 +1860,14 @@ def torches(self, blockid, data):
     return img
 
 # lantern
-@material(blockid=11373, data=[0, 1], transparent=True)
+@material(blockid=[11373, 1038], data=[0, 1], transparent=True)
 def lantern(self, blockid, data):
     # get the  multipart texture of the lantern
-    inputtexture = self.load_image_texture("assets/minecraft/textures/block/lantern.png")
+    if blockid == 11373:
+        inputtexture = self.load_image_texture("assets/minecraft/textures/block/lantern.png")
+    if blockid == 1038:
+        inputtexture = self.load_image_texture("assets/minecraft/textures/block/soul_lantern.png")
+
 
     # # now create a textures, using the parts defined in lantern.json
 
@@ -1999,32 +2003,35 @@ def composter(self, blockid, data):
     alpha_over(img, img2, (0, 0), img2)
     return img
 
-# fire
-@material(blockid=51, data=list(range(16)), transparent=True)
+# fire and soul_fire
+@material(blockid=[51, 1040], transparent=True)
 def fire(self, blockid, data):
-    firetextures = self.load_fire()
-    side1 = self.transform_image_side(firetextures[0])
-    side2 = self.transform_image_side(firetextures[1]).transpose(Image.FLIP_LEFT_RIGHT)
-    
+    if blockid == 51:
+        textureNS = self.load_image_texture("assets/minecraft/textures/block/fire_0.png")
+        textureEW = self.load_image_texture("assets/minecraft/textures/block/fire_1.png")
+    elif blockid == 1040:
+        textureNS = self.load_image_texture("assets/minecraft/textures/block/soul_fire_0.png")
+        textureEW = self.load_image_texture("assets/minecraft/textures/block/soul_fire_1.png")
+    side1 = self.transform_image_side(textureNS)
+    side2 = self.transform_image_side(textureEW).transpose(Image.FLIP_LEFT_RIGHT)
     img = Image.new("RGBA", (24,24), self.bgcolor)
-
     alpha_over(img, side1, (12,0), side1)
     alpha_over(img, side2, (0,0), side2)
-
     alpha_over(img, side1, (0,6), side1)
-    alpha_over(img, side2, (12,6), side2)
-    
+    alpha_over(img, side2, (12,6), side2)    
     return img
 
 # monster spawner
 block(blockid=52, top_image="assets/minecraft/textures/block/spawner.png", transparent=True)
 
 # wooden, cobblestone, red brick, stone brick, netherbrick, sandstone, spruce, birch,
-# jungle, quartz, red sandstone, (dark) prismarine, mossy brick and mossy cobblestone, stone smooth_quartz
+# jungle, quartz, red sandstone, purper_stairs, crimson_stairs, warped_stairs, (dark) prismarine,
+# mossy brick and mossy cobblestone, stone smooth_quartz
 # polished_granite polished_andesite polished_diorite granite diorite andesite end_stone_bricks red_nether_brick stairs
-# smooth_red_sandstone_stairs
-@material(blockid=[53, 67, 108, 109, 114, 128, 134, 135, 136, 156, 163, 164, 180, 203, 11337, 11338, 11339,
-          11370, 11371, 11374, 11375, 11376, 11377, 11378, 11379, 11380, 11381, 11382, 11383, 11384, 11415], 
+# smooth_red_sandstone blackstone polished_blackstone polished_blackstone_brick
+@material(blockid=[53, 67, 108, 109, 114, 128, 134, 135, 136, 156, 163, 164, 180, 203, 509, 510, 11337, 11338, 11339,
+          11370, 11371, 11374, 11375, 11376, 11377, 11378, 11379, 11380, 11381, 11382, 11383, 11384, 11415,
+          1030, 1031, 1032],
           data=list(range(128)), transparent=True, solid=True, nospawn=True)
 def stairs(self, blockid, data):
     # preserve the upside-down bit
@@ -2053,6 +2060,8 @@ def stairs(self, blockid, data):
         164: "assets/minecraft/textures/block/dark_oak_planks.png",
         180: "assets/minecraft/textures/block/red_sandstone.png",
         203: "assets/minecraft/textures/block/purpur_block.png",
+        509: "assets/minecraft/textures/block/crimson_planks.png",
+        510: "assets/minecraft/textures/block/warped_planks.png",
         11337: "assets/minecraft/textures/block/prismarine.png",
         11338: "assets/minecraft/textures/block/dark_prismarine.png",
         11339: "assets/minecraft/textures/block/prismarine_bricks.png",
@@ -2070,6 +2079,9 @@ def stairs(self, blockid, data):
         11383: "assets/minecraft/textures/block/end_stone_bricks.png",
         11384: "assets/minecraft/textures/block/red_nether_bricks.png",
         11415: "assets/minecraft/textures/block/red_sandstone_top.png",
+        1030: "assets/minecraft/textures/block/blackstone.png",
+        1031: "assets/minecraft/textures/block/polished_blackstone.png",
+        1032: "assets/minecraft/textures/block/polished_blackstone_bricks.png",
     }
 
     texture = self.load_image_texture(stair_id_to_tex[blockid]).copy()
@@ -2817,7 +2829,7 @@ def farmland(self, blockid, data):
 
 
 # signposts
-@material(blockid=[63,11401,11402,11403,11404,11405,11406], data=list(range(16)), transparent=True)
+@material(blockid=[63,11401,11402,11403,11404,11405,11406,12505,12506], data=list(range(16)), transparent=True)
 def signpost(self, blockid, data):
 
     # first rotations
@@ -2837,6 +2849,8 @@ def signpost(self, blockid, data):
         11404: ("jungle_planks.png", "jungle_log.png"),
         11405: ("acacia_planks.png", "acacia_log.png"),
         11406: ("dark_oak_planks.png", "dark_oak_log.png"),
+        12505: ("crimson_planks.png", "crimson_stem.png"),
+        12506: ("warped_planks.png", "warped_stem.png"),
     }
     texture_path, texture_stick_path = ["assets/minecraft/textures/block/" + x for x in sign_texture[blockid]]
     
@@ -2884,7 +2898,7 @@ def signpost(self, blockid, data):
 
 # wooden and iron door
 # uses pseudo-ancildata found in iterate.c
-@material(blockid=[64,71,193,194,195,196,197], data=list(range(32)), transparent=True)
+@material(blockid=[64,71,193,194,195,196,197, 499, 500], data=list(range(32)), transparent=True)
 def door(self, blockid, data):
     #Masked to not clobber block top/bottom & swung info
     if self.rotation == 1:
@@ -2918,6 +2932,10 @@ def door(self, blockid, data):
             raw_door = self.load_image_texture("assets/minecraft/textures/block/acacia_door_top.png")
         elif blockid == 197: # dark_oak door
             raw_door = self.load_image_texture("assets/minecraft/textures/block/dark_oak_door_top.png")
+        elif blockid == 499: # crimson door
+            raw_door = self.load_image_texture("assets/minecraft/textures/block/crimson_door_top.png")
+        elif blockid == 500: # warped door
+            raw_door = self.load_image_texture("assets/minecraft/textures/block/warped_door_top.png")
     else: # bottom of the door
         if blockid == 64:
             raw_door = self.load_image_texture("assets/minecraft/textures/block/oak_door_bottom.png")
@@ -2933,7 +2951,11 @@ def door(self, blockid, data):
             raw_door = self.load_image_texture("assets/minecraft/textures/block/acacia_door_bottom.png")
         elif blockid == 197: # dark_oak door
             raw_door = self.load_image_texture("assets/minecraft/textures/block/dark_oak_door_bottom.png")
-    
+        elif blockid == 499: # crimson door
+            raw_door = self.load_image_texture("assets/minecraft/textures/block/crimson_door_bottom.png")
+        elif blockid == 500: # warped door
+            raw_door = self.load_image_texture("assets/minecraft/textures/block/warped_door_bottom.png")
+
     # if you want to render all doors as closed, then force
     # force closed to be True
     if data & 0x4 == 0x4:
@@ -3076,7 +3098,7 @@ def ladder(self, blockid, data):
 
 
 # wall signs
-@material(blockid=[68,11407,11408,11409,11410,11411,11412], data=[2, 3, 4, 5], transparent=True)
+@material(blockid=[68,11407,11408,11409,11410,11411,11412,12507,12508], data=[2, 3, 4, 5], transparent=True)
 def wall_sign(self, blockid, data): # wall sign
 
     # first rotations
@@ -3104,6 +3126,8 @@ def wall_sign(self, blockid, data): # wall sign
         11410: "jungle_planks.png",
         11411: "acacia_planks.png",
         11412: "dark_oak_planks.png",
+        12507: "crimson_planks.png",
+        12508: "warped_planks.png",
     }
     texture_path = "assets/minecraft/textures/block/" + sign_texture[blockid]
     texture = self.load_image_texture(texture_path).copy()
@@ -3286,7 +3310,7 @@ def levers(self, blockid, data):
     return img
 
 # wooden and stone pressure plates, and weighted pressure plates
-@material(blockid=[70, 72,147,148,11301,11302,11303,11304,11305], data=[0,1], transparent=True)
+@material(blockid=[70, 72,147,148,11301,11302,11303,11304,11305, 1033,11517,11518], data=[0,1], transparent=True)
 def pressure_plate(self, blockid, data):
     texture_name = {70:"assets/minecraft/textures/block/stone.png",              # stone
                     72:"assets/minecraft/textures/block/oak_planks.png",         # oak
@@ -3295,8 +3319,11 @@ def pressure_plate(self, blockid, data):
                     11303:"assets/minecraft/textures/block/jungle_planks.png",   # jungle
                     11304:"assets/minecraft/textures/block/acacia_planks.png",   # acacia
                     11305:"assets/minecraft/textures/block/dark_oak_planks.png", # dark oak
+                    11517:"assets/minecraft/textures/block/crimson_planks.png",  # crimson
+                    11518:"assets/minecraft/textures/block/warped_planks.png",   # warped
                     147:"assets/minecraft/textures/block/gold_block.png",        # light golden
                     148:"assets/minecraft/textures/block/iron_block.png",        # heavy iron
+                    1033:"assets/minecraft/textures/block/polished_blackstone.png"
                    }[blockid]
     t = self.load_image_texture(texture_name).copy()
     
@@ -3326,8 +3353,8 @@ def pressure_plate(self, blockid, data):
 # normal and glowing redstone ore
 block(blockid=[73, 74], top_image="assets/minecraft/textures/block/redstone_ore.png")
 
-# stone a wood buttons
-@material(blockid=(77,143,11326,11327,11328,11329,11330), data=list(range(16)), transparent=True)
+# stone and wood buttons
+@material(blockid=(77,143,11326,11327,11328,11329,11330,1034,11515,11516), data=list(range(16)), transparent=True)
 def buttons(self, blockid, data):
 
     # 0x8 is set if the button is pressed mask this info and render
@@ -3360,7 +3387,10 @@ def buttons(self, blockid, data):
                    11327:"assets/minecraft/textures/block/birch_planks.png",
                    11328:"assets/minecraft/textures/block/jungle_planks.png",
                    11329:"assets/minecraft/textures/block/acacia_planks.png",
-                   11330:"assets/minecraft/textures/block/dark_oak_planks.png"
+                   11330:"assets/minecraft/textures/block/dark_oak_planks.png",
+                   1034:"assets/minecraft/textures/block/polished_blackstone.png",
+                   11515:"assets/minecraft/textures/block/crimson_planks.png",
+                   11516:"assets/minecraft/textures/block/warped_planks.png"
                   }[blockid]
     t = self.load_image_texture(texturepath).copy()
 
@@ -3491,7 +3521,7 @@ def jukebox(self, blockid, data):
 
 # nether and normal fences
 # uses pseudo-ancildata found in iterate.c
-@material(blockid=[85, 188, 189, 190, 191, 192, 113], data=list(range(16)), transparent=True, nospawn=True)
+@material(blockid=[85, 188, 189, 190, 191, 192, 113, 511, 512], data=list(range(16)), transparent=True, nospawn=True)
 def fence(self, blockid, data):
     # no need for rotations, it uses pseudo data.
     # create needed images for Big stick fence
@@ -3515,10 +3545,18 @@ def fence(self, blockid, data):
         fence_top = self.load_image_texture("assets/minecraft/textures/block/dark_oak_planks.png").copy()
         fence_side = self.load_image_texture("assets/minecraft/textures/block/dark_oak_planks.png").copy()
         fence_small_side = self.load_image_texture("assets/minecraft/textures/block/dark_oak_planks.png").copy()
-    elif blockid == 192: # acacia oak fence
+    elif blockid == 192: # acacia fence
         fence_top = self.load_image_texture("assets/minecraft/textures/block/acacia_planks.png").copy()
         fence_side = self.load_image_texture("assets/minecraft/textures/block/acacia_planks.png").copy()
         fence_small_side = self.load_image_texture("assets/minecraft/textures/block/acacia_planks.png").copy()
+    elif blockid == 511: # crimson_fence
+        fence_top = self.load_image_texture("assets/minecraft/textures/block/crimson_planks.png").copy()
+        fence_side = self.load_image_texture("assets/minecraft/textures/block/crimson_planks.png").copy()
+        fence_small_side = self.load_image_texture("assets/minecraft/textures/block/crimson_planks.png").copy()
+    elif blockid == 512: # warped fence
+        fence_top = self.load_image_texture("assets/minecraft/textures/block/warped_planks.png").copy()
+        fence_side = self.load_image_texture("assets/minecraft/textures/block/warped_planks.png").copy()
+        fence_small_side = self.load_image_texture("assets/minecraft/textures/block/warped_planks.png").copy()
     else: # netherbrick fence
         fence_top = self.load_image_texture("assets/minecraft/textures/block/nether_bricks.png").copy()
         fence_side = self.load_image_texture("assets/minecraft/textures/block/nether_bricks.png").copy()
@@ -4017,7 +4055,7 @@ def comparator(self, blockid, data):
     
 # trapdoor
 # the trapdoor is looks like a sprite when opened, that's not good
-@material(blockid=[96,167,11332,11333,11334,11335,11336], data=list(range(16)), transparent=True, nospawn=True)
+@material(blockid=[96,167,11332,11333,11334,11335,11336,12501,12502], data=list(range(16)), transparent=True, nospawn=True)
 def trapdoor(self, blockid, data):
 
     # rotation
@@ -4045,7 +4083,9 @@ def trapdoor(self, blockid, data):
                    11333:"assets/minecraft/textures/block/birch_trapdoor.png",
                    11334:"assets/minecraft/textures/block/jungle_trapdoor.png",
                    11335:"assets/minecraft/textures/block/acacia_trapdoor.png",
-                   11336:"assets/minecraft/textures/block/dark_oak_trapdoor.png"
+                   11336:"assets/minecraft/textures/block/dark_oak_trapdoor.png",
+                   12501:"assets/minecraft/textures/block/crimson_trapdoor.png",
+                   12502:"assets/minecraft/textures/block/warped_trapdoor.png",
                   }[blockid]
 
     if data & 0x4 == 0x4: # opened trapdoor
@@ -4256,7 +4296,7 @@ def vines(self, blockid, data):
 
 
 # fence gates
-@material(blockid=[107, 183, 184, 185, 186, 187], data=list(range(8)), transparent=True, nospawn=True)
+@material(blockid=[107, 183, 184, 185, 186, 187, 513, 514], data=list(range(8)), transparent=True, nospawn=True)
 def fence_gate(self, blockid, data):
 
     # rotation
@@ -4295,6 +4335,10 @@ def fence_gate(self, blockid, data):
         gate_side = self.load_image_texture("assets/minecraft/textures/block/dark_oak_planks.png").copy()
     elif blockid == 187: # Acacia
         gate_side = self.load_image_texture("assets/minecraft/textures/block/acacia_planks.png").copy()
+    elif blockid == 513: # Crimson
+        gate_side = self.load_image_texture("assets/minecraft/textures/block/crimson_planks.png").copy()
+    elif blockid == 514: # Warped
+        gate_side = self.load_image_texture("assets/minecraft/textures/block/warped_planks.png").copy()
     else:
         return None
 
@@ -4358,10 +4402,7 @@ block(blockid=110, top_image="assets/minecraft/textures/block/mycelium_top.png",
 # warped_nylium & crimson_nylium
 block(blockid=1006, top_image="assets/minecraft/textures/block/warped_nylium.png", side_image="assets/minecraft/textures/block/warped_nylium_side.png")
 block(blockid=1007, top_image="assets/minecraft/textures/block/crimson_nylium.png", side_image="assets/minecraft/textures/block/crimson_nylium_side.png")
-# soul soil
-block(blockid=1020, top_image="assets/minecraft/textures/block/soul_soil.png")
-# nether gold ore
-block(blockid=1021, top_image="assets/minecraft/textures/block/nether_gold_ore.png")
+
 
 # lilypad
 # At the moment of writing this lilypads has no ancil data and their
@@ -4557,6 +4598,10 @@ def wooden_slabs(self, blockid, data):
         top = side = self.load_image_texture("assets/minecraft/textures/block/acacia_planks.png")
     elif texture== 5: # dark wood
         top = side = self.load_image_texture("assets/minecraft/textures/block/dark_oak_planks.png")
+    elif texture== 6: # crimson
+        top = side = self.load_image_texture("assets/minecraft/textures/block/crimson_planks.png")
+    elif texture== 7: # warped
+        top = side = self.load_image_texture("assets/minecraft/textures/block/warped_planks.png")
     else:
         return None
     
@@ -4694,7 +4739,7 @@ def beacon(self, blockid, data):
 
 # cobblestone and mossy cobblestone walls, chorus plants, mossy stone brick walls
 # one additional bit of data value added for mossy and cobblestone
-@material(blockid=[199]+list(range(1792, 1805 + 1)), data=list(range(32)), transparent=True, nospawn=True)
+@material(blockid=[199]+list(range(1792, 1808 + 1)), data=list(range(32)), transparent=True, nospawn=True)
 def cobblestone_wall(self, blockid, data):
     walls_id_to_tex = {
           199: "assets/minecraft/textures/block/chorus_plant.png", # chorus plants
@@ -4711,7 +4756,10 @@ def cobblestone_wall(self, blockid, data):
         1802: "assets/minecraft/textures/block/red_nether_bricks.png",
         1803: "assets/minecraft/textures/block/red_sandstone.png",
         1804: "assets/minecraft/textures/block/sandstone.png",
-        1805: "assets/minecraft/textures/block/stone_bricks.png"
+        1805: "assets/minecraft/textures/block/stone_bricks.png",
+        1806: "assets/minecraft/textures/block/blackstone.png",
+        1807: "assets/minecraft/textures/block/polished_blackstone.png",
+        1808: "assets/minecraft/textures/block/polished_blackstone_bricks.png"
     }
     t = self.load_image_texture(walls_id_to_tex[blockid]).copy()
 
@@ -5718,3 +5766,18 @@ block(blockid=[1004], top_image="assets/minecraft/textures/block/blackstone_top.
 
 # Netherite
 block(blockid=[1005], top_image="assets/minecraft/textures/block/netherite_block.png")
+# soul soil
+block(blockid=1020, top_image="assets/minecraft/textures/block/soul_soil.png")
+# nether gold ore
+block(blockid=1021, top_image="assets/minecraft/textures/block/nether_gold_ore.png")
+# Solid Nether stone blocks
+block(blockid=1022, top_image="assets/minecraft/textures/block/polished_blackstone.png")
+block(blockid=1023, top_image="assets/minecraft/textures/block/chiseled_polished_blackstone.png")
+block(blockid=1024, top_image="assets/minecraft/textures/block/gilded_blackstone.png")
+block(blockid=1025, top_image="assets/minecraft/textures/block/cracked_polished_blackstone_bricks.png")
+block(blockid=1026, top_image="assets/minecraft/textures/block/polished_blackstone_bricks.png")
+
+block(blockid=1035, top_image="assets/minecraft/textures/block/crying_obsidian.png")
+block(blockid=1036, top_image="assets/minecraft/textures/block/lodestone_top.png", side_image="assets/minecraft/textures/block/lodestone_side.png")
+block(blockid=1037, top_image="assets/minecraft/textures/block/respawn_anchor_top.png", side_image="assets/minecraft/textures/block/respawn_anchor_side1.png")
+block(blockid=1041, top_image="assets/minecraft/textures/block/quartz_bricks.png")

--- a/overviewer_core/world.py
+++ b/overviewer_core/world.py
@@ -319,6 +319,8 @@ class RegionSet(object):
             'minecraft:jungle_planks': (5, 3),
             'minecraft:acacia_planks': (5, 4),
             'minecraft:dark_oak_planks': (5, 5),
+            'minecraft:crimson_planks': (5, 6),
+            'minecraft:warped_planks': (5, 7),
             'minecraft:sapling': (6, 0),
             'minecraft:bedrock': (7, 0),
             'minecraft:water': (8, 0),
@@ -411,6 +413,8 @@ class RegionSet(object):
             'minecraft:fire': (51, 0),
             'minecraft:spawner': (52, 0),
             'minecraft:oak_stairs': (53, 0),
+            'minecraft:crimson_stairs': (509, 0),
+            'minecraft:warped_stairs': (510, 0),
             'minecraft:chest': (54, 0),
             'minecraft:redstone_wire': (55, 0),
             'minecraft:diamond_ore': (56, 0),
@@ -426,6 +430,8 @@ class RegionSet(object):
             'minecraft:jungle_sign': (11404, 0),
             'minecraft:acacia_sign': (11405, 0),
             'minecraft:dark_oak_sign': (11406, 0),
+            'minecraft:crimson_sign': (12505, 0),
+            'minecraft:warped_sign': (12506, 0),
             'minecraft:oak_door': (64, 0),
             'minecraft:ladder': (65, 0),
             'minecraft:rail': (66, 0),
@@ -437,6 +443,8 @@ class RegionSet(object):
             'minecraft:jungle_wall_sign': (11410, 0),
             'minecraft:acacia_wall_sign': (11411, 0),
             'minecraft:dark_oak_wall_sign': (11412, 0),
+            'minecraft:crimson_wall_sign': (12507, 0),
+            'minecraft:warped_wall_sign': (12508, 0),
             'minecraft:lever': (69, 0),
             'minecraft:stone_pressure_plate': (70, 0),
             'minecraft:iron_door': (71, 0),
@@ -504,6 +512,8 @@ class RegionSet(object):
             'minecraft:jungle_slab': (126, 3),
             'minecraft:acacia_slab': (126, 4),
             'minecraft:dark_oak_slab': (126, 5),
+            'minecraft:crimson_slab': (126, 6),
+            'minecraft:warped_slab': (126, 7),
             'minecraft:cocoa': (127, 0),
             'minecraft:sandstone_stairs': (128, 0),
             'minecraft:emerald_ore': (129, 0),
@@ -630,16 +640,22 @@ class RegionSet(object):
             'minecraft:jungle_fence_gate': (185, 0),
             'minecraft:dark_oak_fence_gate': (186, 0),
             'minecraft:acacia_fence_gate': (187, 0),
+            'minecraft:crimson_fence_gate': (513, 0),
+            'minecraft:warped_fence_gate': (514, 0),
             'minecraft:spruce_fence': (188, 0),
             'minecraft:birch_fence': (189, 0),
             'minecraft:jungle_fence': (190, 0),
             'minecraft:dark_oak_fence': (191, 0),
             'minecraft:acacia_fence': (192, 0),
+            'minecraft:crimson_fence': (511, 0),
+            'minecraft:warped_fence': (512, 0),
             'minecraft:spruce_door': (193, 0),
             'minecraft:birch_door': (194, 0),
             'minecraft:jungle_door': (195, 0),
             'minecraft:acacia_door': (196, 0),
             'minecraft:dark_oak_door': (197, 0),
+            'minecraft:crimson_door': (499, 0),
+            'minecraft:warped_door': (500, 0),
             'minecraft:end_rod': (198, 0),  # not rendering
             'minecraft:chorus_plant': (199, 0),
             'minecraft:chorus_flower': (200, 0),
@@ -721,6 +737,34 @@ class RegionSet(object):
             'minecraft:crimson_roots': (1019, 0),
             'minecraft:soul_soil': (1020, 0),
             'minecraft:nether_gold_ore': (1021, 0),
+            # Solid Nether stone blocks
+            'minecraft:polished_blackstone': (1022, 0),
+            'minecraft:chiseled_polished_blackstone': (1023, 0),
+            'minecraft:gilded_blackstone': (1024, 0),
+            'minecraft:cracked_polished_blackstone_bricks': (1025, 0),
+            'minecraft:polished_blackstone_bricks': (1026, 0),
+            # Nether slabs
+            'minecraft:blackstone_slab': (1027, 0),
+            'minecraft:polished_blackstone_slab': (1028, 0),
+            'minecraft:polished_blackstone_brick_slab': (1029, 0),
+            # Nether stairs
+            'minecraft:blackstone_stairs': (1030, 0),
+            'minecraft:polished_blackstone_stairs': (1031, 0),
+            'minecraft:polished_blackstone_brick_stairs': (1032, 0),
+            # nether redstone blocks
+            'minecraft:polished_blackstone_pressure_plate': (1033, 0),
+            'minecraft:polished_blackstone_button': (1034, 0),
+            # advanced nether blocks
+            'minecraft:crying_obsidian': (1035, 0),
+            'minecraft:lodestone': (1036, 0),
+            'minecraft:respawn_anchor': (1037, 0),
+            # soul lightning
+            'minecraft:soul_lantern': (1038, 0),
+            'minecraft:soul_wall_torch': (1039, 0),
+            'minecraft:soul_torch': (1039, 5),
+            'minecraft:soul_fire': (1040, 0),
+            # quartz bricks
+            'minecraft:quartz_bricks': (1041, 0),
 
             # New blocks
             'minecraft:carved_pumpkin': (11300, 0),
@@ -729,6 +773,8 @@ class RegionSet(object):
             'minecraft:jungle_pressure_plate': (11303, 0),
             'minecraft:acacia_pressure_plate': (11304, 0),
             'minecraft:dark_oak_pressure_plate': (11305, 0),
+            'minecraft:crimson_pressure_plate': (11517, 0),
+            'minecraft:warped_pressure_plate': (11518, 0),
             'minecraft:stripped_oak_log': (11306, 0),
             'minecraft:stripped_spruce_log': (11306, 1),
             'minecraft:stripped_birch_log': (11306, 2),
@@ -766,12 +812,16 @@ class RegionSet(object):
             'minecraft:jungle_button': (11328,0),
             'minecraft:acacia_button': (11329,0),
             'minecraft:dark_oak_button': (11330,0),
+            'minecraft:crimson_button': (11515,0),
+            'minecraft:warped_button': (11516,0),
             'minecraft:dried_kelp_block': (11331,0),
             'minecraft:spruce_trapdoor': (11332, 0),
             'minecraft:birch_trapdoor': (11333, 0),
             'minecraft:jungle_trapdoor': (11334, 0),
             'minecraft:acacia_trapdoor': (11335, 0),
             'minecraft:dark_oak_trapdoor': (11336, 0),
+            'minecraft:crimson_trapdoor': (12501, 0),
+            'minecraft:warped_trapdoor': (12502, 0),
             'minecraft:petrified_oak_slab': (126, 0),
             'minecraft:prismarine_stairs': (11337, 0),
             'minecraft:dark_prismarine_stairs': (11338, 0),
@@ -839,6 +889,7 @@ class RegionSet(object):
             'minecraft:campfire': (11506, 0),
             'minecraft:bell': (11507, 0),
             # adding a gap in the numbering of walls to keep them all
+            # blocks >= 1792 and <= 2047 are considered walls
             'minecraft:andesite_wall': (1792, 0),
             'minecraft:brick_wall': (1793, 0),
             'minecraft:cobblestone_wall': (1794, 0),
@@ -853,6 +904,9 @@ class RegionSet(object):
             'minecraft:red_sandstone_wall': (1803, 0),
             'minecraft:sandstone_wall': (1804, 0),
             'minecraft:stone_brick_wall': (1805, 0),
+            'minecraft:blackstone_wall': (1806, 0),
+            'minecraft:polished_blackstone_wall': (1807, 0),
+            'minecraft:polished_blackstone_brick_wall': (1808, 0),
         }
 
         colors = [   'white', 'orange', 'magenta', 'light_blue',
@@ -882,7 +936,7 @@ class RegionSet(object):
 
     def _get_block(self, palette_entry):
         wood_slabs = ('minecraft:oak_slab','minecraft:spruce_slab','minecraft:birch_slab','minecraft:jungle_slab',
-                        'minecraft:acacia_slab','minecraft:dark_oak_slab','minecraft:petrified_oak_slab')
+                        'minecraft:acacia_slab','minecraft:dark_oak_slab','minecraft:petrified_oak_slab', 'minecraft:crimson_slab', 'minecraft:warped_slab')
         stone_slabs = ('minecraft:stone_slab', 'minecraft:sandstone_slab','minecraft:red_sandstone_slab',
                         'minecraft:cobblestone_slab', 'minecraft:brick_slab','minecraft:purpur_slab',
                         'minecraft:stone_brick_slab', 'minecraft:nether_brick_slab',
@@ -893,8 +947,11 @@ class RegionSet(object):
                         'minecraft:cut_sandstone_slab','minecraft:smooth_red_sandstone_slab',
                         'minecraft:cut_red_sandstone_slab','minecraft:end_stone_brick_slab',
                         'minecraft:mossy_cobblestone_slab','minecraft:mossy_stone_brick_slab',
-                        'minecraft:smooth_quartz_slab','minecraft:smooth_stone_slab'
+                        'minecraft:smooth_quartz_slab','minecraft:smooth_stone_slab',
+                        'minecraft:blackstone_slab','minecraft:polished_blackstone_slab',
+                        'minecraft:polished_blackstone_brick_slab'
                          )
+
         prismarine_slabs = ('minecraft:prismarine_slab','minecraft:dark_prismarine_slab','minecraft:prismarine_brick_slab')
 
         key = palette_entry['Name']
@@ -1004,6 +1061,15 @@ class RegionSet(object):
                     elif key == 'minecraft:smooth_stone_slab':
                         block = 11313   # minecraft:smooth_stone
                         data  = 0
+                    elif key == 'minecraft:blackstone_slab':
+                        block = 1004   # blackstone
+                        data = 0
+                    elif key == 'minecraft:polished_blackstone_slab':
+                        block = 1022   # polished_blackstone
+                        data = 0
+                    elif key == 'minecraft:polished_blackstone_brick_slab':
+                        block = 1026   # polished_blackstone_bricks
+                        data = 0
 
                 elif key in  prismarine_slabs:
                     block = 168         # minecraft:prismarine variants
@@ -1070,7 +1136,8 @@ class RegionSet(object):
         elif key == 'minecraft:basalt' or key == 'minecraft:polished_basalt':
             axis = palette_entry['Properties']['axis']
             data = {'y': 0, 'x': 1, 'z': 2}[axis]
-        elif key in ['minecraft:redstone_torch','minecraft:redstone_wall_torch','minecraft:wall_torch']:
+        elif key in ['minecraft:redstone_torch','minecraft:redstone_wall_torch','minecraft:wall_torch',
+                    'minecraft:soul_torch', 'minecraft:soul_wall_torch']:
             if key.startswith('minecraft:redstone_') and palette_entry['Properties']['lit'] == 'true':
                 block += 1
             if key.endswith('wall_torch'):
@@ -1148,7 +1215,7 @@ class RegionSet(object):
                      'minecraft:pumpkin_stem', 'minecraft:potatoes', 'minecraft:carrots',
                      'minecraft:sweet_berry_bush']:
             data = palette_entry['Properties']['age']
-        elif key == 'minecraft:lantern':
+        elif key in ['minecraft:lantern', 'minecraft:soul_lantern']:
             if palette_entry['Properties']['hanging'] == 'true':
                 data = 1
             else:


### PR DESCRIPTION
I noticed when I was rendering with my Minecraft server online, certain chunks would fly around the map and sit in the wrong location. I do not have a screenshot but this is just like issue #1676, and the suggestion made to add a note was not accompanied by a pull request or commit with one. 

This pull request adds a note on "docs/using.rst" saying that:

* The world should not be in use.
* Any programs that are using it should be closed.
* If the world is not able to be closed (like with a server), copy the world to a new location.
