### PR TITLE
Fixes rendering with slabs&stair in occlusion check

### DIFF
--- a/overviewer_core/src/primitives/base.c
+++ b/overviewer_core/src/primitives/base.c
@@ -61,11 +61,20 @@ base_occluded(void* data, RenderState* state, int32_t x, int32_t y, int32_t z) {
     if ((x != 0) && (y != 15) && (z != 15) &&
         !render_mode_hidden(state->rendermode, x - 1, y, z) &&
         !render_mode_hidden(state->rendermode, x, y, z + 1) &&
-        !render_mode_hidden(state->rendermode, x, y + 1, z) &&
-        !is_transparent(getArrayShort3D(state->blocks, x - 1, y, z)) &&
-        !is_transparent(getArrayShort3D(state->blocks, x, y, z + 1)) &&
-        !is_transparent(getArrayShort3D(state->blocks, x, y + 1, z))) {
-        return true;
+        !render_mode_hidden(state->rendermode, x, y + 1, z)) {
+
+        mc_block_t block1 = getArrayShort3D(state->blocks, x - 1, y, z);
+        mc_block_t block2 = getArrayShort3D(state->blocks, x, y, z + 1);
+        mc_block_t block3 = getArrayShort3D(state->blocks, x, y + 1, z);
+
+        if (!is_transparent(block1) &&
+            !is_transparent(block2) &&
+            !is_transparent(block3) &&
+            !block_class_is_subset(block1, block_class_alt_height, block_class_alt_height_len) &&
+            !block_class_is_subset(block2, block_class_alt_height, block_class_alt_height_len) &&
+            !block_class_is_subset(block3, block_class_alt_height, block_class_alt_height_len)) {
+            return true;
+        }
     }
 
     return false;


### PR DESCRIPTION
The occlusion check does not check for slabs/stairs with are not of full height and hides them from the render.

See the following screenshots:

In game:
![2021-05-01_13 11 20](https://user-images.githubusercontent.com/775794/116780873-78409900-aa7f-11eb-83dc-1eb09d83d877.png)

broken (without the fix)
![minecraft-overview-broken](https://user-images.githubusercontent.com/775794/116780886-87274b80-aa7f-11eb-967c-5dedbe5bf6c9.png)


With the fix:
![minecraft-overview-fixed](https://user-images.githubusercontent.com/775794/116780891-8bebff80-aa7f-11eb-9d46-9be095a93185.png)
