### PR TITLE
Fixes snow height rendering

### DIFF
--- a/overviewer_core/textures.py
+++ b/overviewer_core/textures.py
@@ -3424,27 +3424,27 @@ def buttons(self, blockid, data):
     return img
 
 # snow
-@material(blockid=78, data=list(range(16)), transparent=True, solid=True)
+@material(blockid=78, data=list(range(1, 9)), transparent=True, solid=True)
 def snow(self, blockid, data):
     # still not rendered correctly: data other than 0
-    
+
     tex = self.load_image_texture("assets/minecraft/textures/block/snow.png")
-    
-    # make the side image, top 3/4 transparent
-    mask = tex.crop((0,12,16,16))
+
+    y = 16 - (data * 2)
+    mask = tex.crop((0, y, 16, 16))
     sidetex = Image.new(tex.mode, tex.size, self.bgcolor)
-    alpha_over(sidetex, mask, (0,12,16,16), mask)
-    
+    alpha_over(sidetex, mask, (0,y,16,16), mask)
+
     img = Image.new("RGBA", (24,24), self.bgcolor)
-    
+
     top = self.transform_image_top(tex)
     side = self.transform_image_side(sidetex)
     otherside = side.transpose(Image.FLIP_LEFT_RIGHT)
-    
-    alpha_over(img, side, (0,6), side)
-    alpha_over(img, otherside, (12,6), otherside)
-    alpha_over(img, top, (0,9), top)
-    
+
+    alpha_over(img, side, (0, 6), side)
+    alpha_over(img, otherside, (12, 6), otherside)
+    alpha_over(img, top, (0, 12 - int(12 / 8 * data)), top)
+
     return img
 
 # snow block

--- a/overviewer_core/world.py
+++ b/overviewer_core/world.py
@@ -927,6 +927,8 @@ class RegionSet(object):
         elif key == 'minecraft:grass_block':
             if palette_entry['Properties']['snowy'] == 'true':
                 data |= 0x10
+        elif key == 'minecraft:snow':
+            data = palette_entry['Properties']['layers']
         elif key in ('minecraft:sunflower', 'minecraft:lilac', 'minecraft:tall_grass', 'minecraft:large_fern', 'minecraft:rose_bush', 'minecraft:peony'):
             if palette_entry['Properties']['half'] == 'upper':
                 data |= 0x08


### PR DESCRIPTION
The snow height is not rendered correctly, it just has 1 fixed size.
NOTE: I am not yet sure why the full height is rendered black, but let's fix 1 bug at a time. :)

In game:
![2021-05-15_17 28 39](https://user-images.githubusercontent.com/775794/118369752-de134180-b5a4-11eb-81ae-58425ec373d6.png)

Without the fix (broken):
![snow-broken](https://user-images.githubusercontent.com/775794/118369757-e9666d00-b5a4-11eb-9ef8-313020b518de.png)

With the fix:
![snow-fixed](https://user-images.githubusercontent.com/775794/118369761-ed928a80-b5a4-11eb-8687-4624d9145476.png)
