### PR TITLE
Fixed dead Chorus Flower

### DIFF
--- a/overviewer_core/world.py
+++ b/overviewer_core/world.py
@@ -1215,7 +1215,7 @@ class RegionSet(object):
             if p['half'] == 'top': data |= 0x08
         elif key in ['minecraft:beetroots', 'minecraft:melon_stem', 'minecraft:wheat',
                      'minecraft:pumpkin_stem', 'minecraft:potatoes', 'minecraft:carrots',
-                     'minecraft:sweet_berry_bush']:
+                     'minecraft:sweet_berry_bush', 'minecraft:chorus_flower']:
             data = palette_entry['Properties']['age']
         elif key in ['minecraft:lantern', 'minecraft:soul_lantern']:
             if palette_entry['Properties']['hanging'] == 'true':


### PR DESCRIPTION
The Chorus Flower never got any data/age which makes it always appear alive. The rendering stuff was already all in place.

In Game:
![chorus_flower_ingame](https://user-images.githubusercontent.com/775794/120216921-e8d20580-c237-11eb-8e74-de0717d69a95.png)

Without the fix:
![chorus_flower](https://user-images.githubusercontent.com/775794/120216934-ee2f5000-c237-11eb-899a-7fa06d3970ed.png)

With the fix:
![chorus_flower_fixed](https://user-images.githubusercontent.com/775794/120216941-f2f40400-c237-11eb-83e4-a416e7fa2a94.png)
