### PR TITLE
Added chiseled and cracked nether bricks

### DIFF
--- a/overviewer_core/textures.py
+++ b/overviewer_core/textures.py
@@ -4509,8 +4509,19 @@ def lilypad(self, blockid, data):
 
     return self.build_full_block(None, None, None, None, None, t)
 
-# nether brick
-block(blockid=112, top_image="assets/minecraft/textures/block/nether_bricks.png")
+# nether bricks
+@material(blockid=112, data=list(range(3)), solid=True)
+def nether_bricks(self, blockid, data):
+    if data == 0: # normal
+        t = self.load_image_texture("assets/minecraft/textures/block/nether_bricks.png")
+    elif data == 1: # cracked
+        t = self.load_image_texture("assets/minecraft/textures/block/cracked_nether_bricks.png")
+    elif data == 2: # chiseled
+        t = self.load_image_texture("assets/minecraft/textures/block/chiseled_nether_bricks.png")
+
+    img = self.build_full_block(t, None, None, t, t)
+
+    return img
 
 # nether wart
 @material(blockid=115, data=list(range(4)), transparent=True)

--- a/overviewer_core/world.py
+++ b/overviewer_core/world.py
@@ -495,6 +495,8 @@ class RegionSet(object):
             'minecraft:mycelium': (110, 0),
             'minecraft:lily_pad': (111, 0),
             'minecraft:nether_bricks': (112, 0),
+            'minecraft:cracked_nether_bricks': (112, 1),
+            'minecraft:chiseled_nether_bricks': (112, 2),
             'minecraft:nether_brick_fence': (113, 0),
             'minecraft:nether_brick_stairs': (114, 0),
             'minecraft:nether_wart': (115, 0),


### PR DESCRIPTION
Chiseled and Cracked Nether Bricks are not rendering.

In-Game:
![netherbricks_ingame](https://user-images.githubusercontent.com/775794/120367803-9bc26200-c311-11eb-8155-13a0378549f7.png)

Without the Patch:
![netherbricks](https://user-images.githubusercontent.com/775794/120367838-a41a9d00-c311-11eb-8d4b-e1611a9fd6f5.png)

With the Patch:
![netherbricks_fixed](https://user-images.githubusercontent.com/775794/120367861-aa107e00-c311-11eb-8211-09e7ab1254c1.png)
