### PR TITLE
Fixed black full height snow layers

### DIFF
--- a/overviewer_core/src/overviewer.h
+++ b/overviewer_core/src/overviewer.h
@@ -31,7 +31,7 @@
 
 // increment this value if you've made a change to the c extension
 // and want to force users to rebuild
-#define OVERVIEWER_EXTENSION_VERSION 96
+#define OVERVIEWER_EXTENSION_VERSION 97
 
 #include <stdbool.h>
 #include <stdint.h>

--- a/overviewer_core/src/primitives/lighting.c
+++ b/overviewer_core/src/primitives/lighting.c
@@ -155,15 +155,18 @@ get_lighting_color(RenderPrimitiveLighting* self, RenderState* state,
 
     /* placeholders for later data arrays, coordinates */
     mc_block_t block;
-    uint8_t skylevel, blocklevel;
+    uint8_t skylevel, blocklevel, blockdata;
 
     block = get_data(state, BLOCKS, x, y, z);
     skylevel = get_data(state, SKYLIGHT, x, y, z);
     blocklevel = get_data(state, BLOCKLIGHT, x, y, z);
+    blockdata = get_data(state, DATA, x, y, z);
 
     /* special half-step handling, stairs handling */
     /* Anvil also needs to be here, blockid 145 */
-    if (block_class_is_subset(block, block_class_alt_height, block_class_alt_height_len) || block == block_anvil) {
+    /* Full height snow layers have skylevel=0 and blocklightlevel=0, fix them too */
+    if (block_class_is_subset(block, block_class_alt_height, block_class_alt_height_len) || block == block_anvil ||
+        (block == block_snow_layer && blockdata == 8)) {
         uint32_t upper_block;
 
         /* stairs and half-blocks take the skylevel from the upper block if it's transparent */


### PR DESCRIPTION
Full height (8layers) snow layers are rendered black, they have skylevel and blocklight level 0 (ingame), all other layer levels work fine.

In-Game:
![snowlayers8_ingame](https://user-images.githubusercontent.com/775794/120369104-2061b000-c313-11eb-94be-245e91b09c76.png)

Without the fix:
![snowlayers8](https://user-images.githubusercontent.com/775794/120369132-25befa80-c313-11eb-96b3-f4a28618cde2.png)

With the fix:
![snowlayers8_fixed](https://user-images.githubusercontent.com/775794/120369152-2bb4db80-c313-11eb-81d0-3d167e11693b.png)
