### PR TITLE
Remove inaccurate/useless ETAs for check tiles renders

### DIFF
--- a/overviewer_core/dispatcher.py
+++ b/overviewer_core/dispatcher.py
@@ -65,6 +65,13 @@ class Dispatcher:
             # keep track of total jobs, and how many jobs are done
             total_jobs = 0
             for tileset, phases in zip(tilesetlist, num_phases):
+
+                # the tileset is rendering in check-tiles mode,
+                # so we don't know exactly how many jobs will be run
+                if tileset.config.get("render_in_progress", False):
+                    total_jobs = None
+                    break
+
                 if phase < phases:
                     jobs_for_tileset = tileset.get_phase_length(phase)
                     # if one is unknown, the total is unknown

--- a/overviewer_core/tileset.py
+++ b/overviewer_core/tileset.py
@@ -345,14 +345,11 @@ class TileSet(object):
                 # The last render must have been interrupted. The default should be
                 # a check-tiles render then
                 logging.warning(
-                    "The last render for '%s' didn't finish. I'll be "
-                    "scanning all the tiles to make sure everything's up "
-                    "to date.",
+                    "The last render for %s didn't finish. All tiles will"
+                    "be checked to make sure everything's up to date. The "
+                    "total tile render count cannot be determined because"
+                    " of this. No ETA will be available as a result.",
                     self.options['name'])
-                logging.warning(
-                    "The total tile count will be (possibly "
-                    "wildly) inaccurate, because I don't know how many "
-                    "tiles need rendering. I'll be checking them as I go.")
                 if self.forcerendertime != 0:
                     logging.info(
                         "The unfinished render was a --forcerender. "


### PR DESCRIPTION
Removes messages about "wildly inaccurate" render estimates in observers, instead replacing with indeterminate messages and explainers. Implements #1944, at least partially - see there for more details.

Still need to do some more testing and refinement (especially progress bar), and update documentation.