### PR TITLE
Fixed edge-lines and side rendering for snow layers

### DIFF
--- a/overviewer_core/src/primitives/edge-lines.c
+++ b/overviewer_core/src/primitives/edge-lines.c
@@ -45,8 +45,13 @@ edge_lines_draw(void* data, RenderState* state, PyObject* src, PyObject* mask, P
         int32_t increment = 0;
         if (block_class_is_subset(state->block, (mc_block_t[]){block_wooden_slab, block_stone_slab}, 2) && ((state->block_data & 0x8) == 0)) // half-steps BUT no upsidown half-steps
             increment = 6;
-        else if (block_class_is_subset(state->block, (mc_block_t[]){block_snow_layer, block_unpowered_repeater, block_powered_repeater}, 3)) // snow, redstone repeaters (on and off)
+        else if (block_class_is_subset(state->block, (mc_block_t[]){block_unpowered_repeater, block_powered_repeater}, 2)) // redstone repeaters (on and off)
             increment = 9;
+        else if (state->block == block_snow_layer) {
+            uint32_t block_data = get_data(state, DATA, x, y, z);
+            // height calculation from textures.py -> def snow
+            increment = (int)((12.0f - (12.0f / 8.0f * (float)block_data)));
+        }
 
         /* +X side */
         side_block = get_data(state, BLOCKS, x + 1, y, z);

--- a/overviewer_core/textures.py
+++ b/overviewer_core/textures.py
@@ -3601,8 +3601,6 @@ def end_rod(self, blockid, data):
 # snow
 @material(blockid=78, data=list(range(1, 9)), transparent=True, solid=True)
 def snow(self, blockid, data):
-    # still not rendered correctly: data other than 0
-
     tex = self.load_image_texture("assets/minecraft/textures/block/snow.png")
 
     y = 16 - (data * 2)
@@ -3615,6 +3613,13 @@ def snow(self, blockid, data):
     top = self.transform_image_top(tex)
     side = self.transform_image_side(sidetex)
     otherside = side.transpose(Image.FLIP_LEFT_RIGHT)
+
+    sidealpha = side.split()[3]
+    side = ImageEnhance.Brightness(side).enhance(0.9)
+    side.putalpha(sidealpha)
+    othersidealpha = otherside.split()[3]
+    otherside = ImageEnhance.Brightness(otherside).enhance(0.8)
+    otherside.putalpha(othersidealpha)
 
     alpha_over(img, side, (0, 6), side)
     alpha_over(img, otherside, (12, 6), otherside)


### PR DESCRIPTION
Fix "dirty" snow, because of wrong edge-lines and missing texture side darkening.

Pretty hard so see in game, but for comparison, In-Game:
![dirty_snow_ingame](https://user-images.githubusercontent.com/775794/125800237-8a6e6f5d-fabf-478b-a1eb-2a0660fad6ee.png)

Current master (without the fix):
![dirty_snow](https://user-images.githubusercontent.com/775794/125800257-1a92e974-df94-47fe-9035-edc6f17289f5.png)

With the fix:
![dirty_snow_fixed](https://user-images.githubusercontent.com/775794/125800277-f03f9e53-74d9-4f35-8ff1-b6c29740b8bc.png)
