### PR TITLE
fix marker center

### DIFF
--- a/overviewer_core/data/web_assets/overviewer.css
+++ b/overviewer_core/data/web_assets/overviewer.css
@@ -176,8 +176,7 @@ div.worldcontrol select {
 
 .ov-marker {
     position:relative;
-    margin-left:-50%;
-    margin-top:-50%;
+    transform: translate(-50%, -50%);
 }
 
 .ov-marker-legend {


### PR DESCRIPTION
For some reason, the margin -50% doesn't work and the markers are offset just by something like -10%. I have no idea why but switching to translate fixes the issue.