### PR TITLE
Fix cauldrons on 1.17.1

### DIFF
--- a/overviewer_core/textures.py
+++ b/overviewer_core/textures.py
@@ -4654,21 +4654,24 @@ def brewing_stand(self, blockid, data):
 
 
 # cauldron
-@material(blockid=118, data=list(range(4)), transparent=True, solid=True, nospawn=True)
+@material(blockid=[118, 11701, 11702, 11703], data=list(range(4)), transparent=True, solid=True, nospawn=True)
 def cauldron(self, blockid, data):
     side = self.load_image_texture("assets/minecraft/textures/block/cauldron_side.png").copy()
     top = self.load_image_texture("assets/minecraft/textures/block/cauldron_top.png")
     bottom = self.load_image_texture("assets/minecraft/textures/block/cauldron_inner.png")
-    water = self.transform_image_top(self.load_image_texture("water.png"))
-    # Side texture isn't transparent between the feet, so adjust the texture
-    ImageDraw.Draw(side).rectangle((5, 14, 11, 16), outline=(0, 0, 0, 0), fill=(0, 0, 0, 0))
+    if blockid == 11701:
+        liquid = self.transform_image_top(self.load_image_texture("lava.png"))
+    elif blockid == 11702:
+        liquid = self.transform_image_top(self.load_image_texture("assets/minecraft/textures/block/snow.png"))
+    else:
+        liquid = self.transform_image_top(self.load_image_texture("water.png"))
 
     if data == 0:  # Empty
         img = self.build_full_block(top, side, side, side, side)
     else:  # Part or fully filled
         # Is filled in increments of a third, with data indicating how many thirds are filled
         img = self.build_full_block(None, side, side, None, None)
-        alpha_over(img, water, (0, 12 - data * 4), water)
+        alpha_over(img, liquid, (0, 12 - data * 4), liquid)
         img2 = self.build_full_block(top, None, None, side, side)
         alpha_over(img, img2, (0, 0), img2)
 

--- a/overviewer_core/world.py
+++ b/overviewer_core/world.py
@@ -971,6 +971,10 @@ class RegionSet(object):
             'minecraft:sweet_berry_bush': (11505, 0),
             'minecraft:campfire': (11506, 0),
             'minecraft:bell': (11507, 0),
+            #1.17 blocks
+            'minecraft:lava_cauldron': (11701, 0),
+            'minecraft:powder_snow_cauldron': (11702, 0),
+            'minecraft:water_cauldron': (11703, 0),
             # adding a gap in the numbering of walls to keep them all
             # blocks >= 1792 and <= 2047 are considered walls
             'minecraft:andesite_wall': (1792, 0),
@@ -1366,7 +1370,17 @@ class RegionSet(object):
         elif key == 'minecraft:respawn_anchor':
             data = int(palette_entry['Properties']['charges'])
         elif key == 'minecraft:cauldron':
+            data = 0
+            print(f'Found cauldron:{data}')
+        elif key == 'minecraft:lava_cauldron':
+            data = 3
+            print(f'Found lava cauldron:{data}')
+        elif key == 'minecraft:water_cauldron':
             data = int(palette_entry['Properties'].get('level', '0'))
+            print(f'Found water cauldron:{data}')
+        elif key == 'minecraft:powder_snow_cauldron':
+            data = int(palette_entry['Properties'].get('level', '0'))
+            print(f'Found snow cauldron:{data}')
         elif key == 'minecraft:structure_block':
             block_mode = palette_entry['Properties'].get('mode', 'save')
             data = {'save': 0, 'load': 1, 'corner': 2, 'data': 3}.get(block_mode, 0)


### PR DESCRIPTION
This should work just fine for previous versions, but it may not be transparent between the cauldron's feet.

Leaving the added alpha in just hid the entire block.

I've just seen that this duplicates part of #1963. Do what you will with this.