### PR TITLE
POIs: Add additional tag to search for entities

### DIFF
--- a/overviewer_core/aux_files/genPOI.py
+++ b/overviewer_core/aux_files/genPOI.py
@@ -130,7 +130,7 @@ def parseBucketChunks(task_tuple):
     for b in bucket:
         try:
             data = rset.get_chunk(b[0], b[1])
-            for poi in itertools.chain(data.get('TileEntities', []), data.get('Entities', [])):
+            for poi in itertools.chain(data.get('TileEntities', []), data.get('Entities', []), data.get('block_entities', [])):
                 if poi['id'] == 'Sign' or poi['id'] == 'minecraft:sign':
                     poi = signWrangler(poi)
                 for name, filter_function in filters:
@@ -183,7 +183,7 @@ def handleEntities(rset, config, config_path, filters, markers):
         for (x, z, mtime) in rset.iterate_chunks():
             try:
                 data = rset.get_chunk(x, z)
-                for poi in itertools.chain(data.get('TileEntities', []), data.get('Entities', [])):
+                for poi in itertools.chain(data.get('TileEntities', []), data.get('Entities', []), data.get('block_entities', [])):
                     if poi['id'] == 'Sign' or poi['id'] == 'minecraft:sign':    # kill me
                         poi = signWrangler(poi)
                     for name, __, filter_function, __, __, __ in filters:


### PR DESCRIPTION
In 1.18, it looks like entities are now stored under the NBT tag `block_entities`. This change adds block_entities to the list of NBT tags POIs are searched for under.

Fixes #2000