### PR TITLE
Correcting Level error in upgraded 1.18 worlds

### DIFF
--- a/overviewer_core/world.py
+++ b/overviewer_core/world.py
@@ -1710,7 +1710,8 @@ class RegionSet(object):
         if not 'sections' in chunk_data:
             # This world was generated pre 21w43a and thus most chunk data is contained
             # in the "Level" key
-            chunk_data = chunk_data['Level']
+            if 'Level' in chunk_data:
+            	chunk_data = chunk_data['Level']
         else:
             # This world was generated post 21w43a
             chunk_data['Sections'] = chunk_data['sections']


### PR DESCRIPTION
Edit suggested by Zevac-ZSF in #2010 corrects render errors that cause the bug.