### PR TITLE
block_class: Complete x86-SIMD

### DIFF
--- a/overviewer_core/src/overviewer.h
+++ b/overviewer_core/src/overviewer.h
@@ -31,7 +31,7 @@
 
 // increment this value if you've made a change to the c extension
 // and want to force users to rebuild
-#define OVERVIEWER_EXTENSION_VERSION 109
+#define OVERVIEWER_EXTENSION_VERSION 110
 
 #include <stdbool.h>
 #include <stdint.h>


### PR DESCRIPTION
Accelerates `block_class_is_subset` with all available x86 simd features
up to AVX512.

This is to complete the scope of #1538