### PR TITLE
Add special-case RGBA acceleration for resize_half

### DIFF
--- a/overviewer_core/src/overviewer.h
+++ b/overviewer_core/src/overviewer.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * This file is part of the Minecraft Overviewer.
  *
  * Minecraft Overviewer is free software: you can redistribute it and/or
@@ -31,7 +31,7 @@
 
 // increment this value if you've made a change to the c extension
 // and want to force users to rebuild
-#define OVERVIEWER_EXTENSION_VERSION 113
+#define OVERVIEWER_EXTENSION_VERSION 114
 
 #include <stdbool.h>
 #include <stdint.h>


### PR DESCRIPTION
When both the source and destination images are 32-bit RGBA pixels, which is
typical when resizing a transparent image, then this SWAR-based method is not only
expected to be faster, but it is very trivial for compilers to SIMD for
both x86 and ARM without having to reach out to explicit SIMD
intrinsics. This is part of #1538

![image](https://user-images.githubusercontent.com/644247/175471782-879695f6-8660-4144-a4b9-7ec324e4b961.png)
