### PR TITLE
genpoi: ignore dat files with incomplete player info

### DIFF
--- a/overviewer_core/aux_files/genPOI.py
+++ b/overviewer_core/aux_files/genPOI.py
@@ -331,6 +331,9 @@ def handlePlayers(worldpath, filters, markers):
         except (IOError, TypeError, KeyError, nbt.CorruptNBTError):
             logging.warning("Skipping bad player dat file %r.", playerfile)
             continue
+        if not "_name" in data:
+            logging.warning("Skipping bad player dat file %r (incomplete player info).", playerfile)
+            continue
 
         playername = playerfile.split(".")[0]
         if isSinglePlayer:


### PR DESCRIPTION
This can happen for worlds that are generated by something other than
minecraft.

Closes #2055