### PR TITLE
Fix dark chunks - addresses #2029 and #1899, prepares for fix of #2002, #2024, and #2035

### DIFF
--- a/overviewer_core/world.py
+++ b/overviewer_core/world.py
@@ -1711,39 +1711,35 @@ class RegionSet(object):
         chunk_data['NewBiomes'] = (len(biomes.shape) == 3)
 
         unrecognized_block_types = {}
-        for section in chunk_data['Sections']:
 
-            # Turn the skylight array into a 16x16x16 matrix. The array comes
-            # packed 2 elements per byte, so we need to expand it.
+        sections = chunk_data['Sections']
+        # Sometimes, Minecraft loves generating chunks with no light info.
+        # These mostly appear to have those two properties, and in this case
+        # we default to full-bright as it's less jarring to look at than all-black.
+        fullbright = chunk_data.get("Status", "") == "spawn" and 'Lights' in chunk_data
+        if not fullbright and self.get_type() is None:
+            # In the overworld, we also default to fullbright if these is no sky light
+            # in the chunk whatsoever
+            for section in sections:
+                if "SkyLight" in section:
+                    break
+            else:
+                fullbright = True
+
+        for section in sections:
             try:
-                # Sometimes, Minecraft loves generating chunks with no light info.
-                # These mostly appear to have those two properties, and in this case
-                # we default to full-bright as it's less jarring to look at than all-black.
-                if chunk_data.get("Status", "") == "spawn" and 'Lights' in chunk_data:
+                if fullbright:
                     section['SkyLight'] = numpy.full((16,16,16), 255, dtype=numpy.uint8)
+                elif not "SkyLight" in section:
+                    # Special case introduced with 1.14
+                    section['SkyLight'] = numpy.zeros((16,16,16), dtype=numpy.uint8)
                 else:
-                    if 'SkyLight' in section:
-                        skylight = numpy.frombuffer(section['SkyLight'], dtype=numpy.uint8)
-                        skylight = skylight.reshape((16,16,8))
-                    else:   # Special case introduced with 1.14
-                        skylight = numpy.zeros((16,16,8), dtype=numpy.uint8)
-                    skylight_expanded = numpy.empty((16,16,16), dtype=numpy.uint8)
-                    skylight_expanded[:,:,::2] = skylight & 0x0F
-                    skylight_expanded[:,:,1::2] = (skylight & 0xF0) >> 4
-                    del skylight
-                    section['SkyLight'] = skylight_expanded
+                    section['SkyLight'] = self._extract_light_data(section["SkyLight"])
 
-                # Turn the BlockLight array into a 16x16x16 matrix, same as SkyLight
-                if 'BlockLight' in section:
-                    blocklight = numpy.frombuffer(section['BlockLight'], dtype=numpy.uint8)
-                    blocklight = blocklight.reshape((16,16,8))
-                else:   # Special case introduced with 1.14
-                    blocklight = numpy.zeros((16,16,8), dtype=numpy.uint8)
-                blocklight_expanded = numpy.empty((16,16,16), dtype=numpy.uint8)
-                blocklight_expanded[:,:,::2] = blocklight & 0x0F
-                blocklight_expanded[:,:,1::2] = (blocklight & 0xF0) >> 4
-                del blocklight
-                section['BlockLight'] = blocklight_expanded
+                if not 'BlockLight' in section:
+                    section['BlockLight'] = numpy.zeros((16,16,16), dtype=numpy.uint8)
+                else:
+                    section['BlockLight'] = self._extract_light_data(section["BlockLight"])
 
                 if 'block_states' in section:
                     (blocks, data) = self._get_blockdata_v118(section, unrecognized_block_types, longarray_unpacker)
@@ -1769,6 +1765,15 @@ class RegionSet(object):
 
         return chunk_data
 
+    def _extract_light_data(self, data):
+        # Turn the light array into a 16x16x16 matrix. The array comes
+        # packed 2 elements per byte, so we need to expand it.
+        light = numpy.frombuffer(data, dtype=numpy.uint8).reshape((16,16,8))
+        light_expanded = numpy.empty((16,16,16), dtype=numpy.uint8)
+        light_expanded[:,:,::2] = light & 0x0F
+        light_expanded[:,:,1::2] = (light & 0xF0) >> 4
+        del light
+        return light_expanded
 
     def iterate_chunks(self):
         """Returns an iterator over all chunk metadata in this world. Iterates


### PR DESCRIPTION
### The Problem

It is possible for chunks to have no sky light data whatsoever.

This can happen for a number of reasons (see also: #2029, #1899), but in particular, all worlds that have been optimized with `--forceUpgrade` in 1.19 will be completely dark until chunks are loaded ingame.

Also, Minecraft sometimes saves chunks with incomplete light data. These chunks only contain "spillover" light from neighboring chunks, but the sky light from the chunk itself is not taken into account. It is common for these chunks to appear on "version borders", and they are almost completely dark. Screenshots of an example at two different zoom levels:
![Screenshot_20220729_005120](https://user-images.githubusercontent.com/11175367/181650281-4792e333-9a86-4086-8213-18b207766199.png)
![Screenshot_20220729_005036](https://user-images.githubusercontent.com/11175367/181650283-8a80c342-b423-4700-a015-a71be9261fce.png)

### Overview of contents

This PR addresses this issue in two steps:
 - `d521770640198be64061dc2a610dbcdc914477ef` checks all chunks for a section with sky light data. If no such section exists, the chunk will be fully brightened.
 - `57727aead9d612fda22a1c32b5cecd55745e669d` additionally checks chunks that do have sky light for a block with full sky light. If no such block exists, it will assume that the chunk is mostly dark and fully brighten it (detailed explanation below).
 
Also, in order to cleanly implement this change, I did a bit of refactoring.

### Detailed reasoning for the decision to check chunks for a block with full skylight

Two observations:
 - A chunk without "own" skylight that only has skylight data from neighboring chunks "pour in" will never have skylight 15 anywhere.
 - Most chunks with skylight will have full skylight at the top.

These observations together mean that:
 - The heuristic we chose is very good - there are edge cases like a leaf roof at the build limit that would break, but I'd argue that these edge cases are less important than the ugly borders pictured above
 - It is also very fast if we go from top to bottom.
 
In practice, on my test world of slightly over 5000 tiles, a pure python PoC implementation of this heuristic bumped the runtime from 8:35 to 8:50, and the numpy implementation somehow managed to finish rendering faster, in 8:06. While that is based on only one run per implementation, I think it's safe to say that this change does not significantly affect performance.

And in any case, if it is deemed preferable not to do that, we can just yeet the second commit.

### Reverse dependency to rendering 1.18+ chunks properly again

This issue came up in #2051, my first attempt at fixing the rendering of pre-1.18 worlds that were loaded in Minecraft 1.18 or higher. Since these chunks turn out completely dark if they were optimized but not loaded in 1.19 (see above), it makes sense to first fix this lighting issue before making these chunks render.

@cliffmeyers and I agreed to split the change into two PRs to avoid scope creep, so I'd like to get this merged first.

