### PR TITLE
[RFC] Make inserted marker text secure-by-default

### DIFF
--- a/overviewer_core/data/js_src/util.js
+++ b/overviewer_core/data/js_src/util.js
@@ -416,7 +416,9 @@ overviewer.util = {
                             }
                             // Add popup to marker
                             if (marker_entry.createInfoWindow && db.text) {
-                                layerObj.bindPopup(db.text);
+                                layerObj.bindPopup(
+                                    document.createTextNode(db.text)
+                                );
                             }
                             // Add the polyline or marker to the layer
                             marker_group.addLayer(layerObj);

--- a/overviewer_core/data/web_assets/leaflet.css
+++ b/overviewer_core/data/web_assets/leaflet.css
@@ -472,6 +472,7 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	padding: 1px;
 	text-align: left;
 	border-radius: 12px;
+	white-space: pre-line;
 	}
 .leaflet-popup-content {
 	margin: 13px 19px;


### PR DESCRIPTION
Per the documentation, Overviewer configuration authors must take special precautions to escape user-generated HTML and/or JavaScript from marker signs. In mide/minecraft-overviewer#117, we learned that:

* This detail may escape the notice of downstream packagers and server deployments.

* It is very straightforward to inject JavaScript into signs on Creative servers. It may also be possible on Survival servers.

Overviewer should conform to MDN's recommendations for [safely inserting](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Safely_inserting_external_content_into_a_page) external content. Failure to protect against injected scripts may allow a malicious actor to gain control of other web resources on the same DNS name (i.e., via session hijacking). In all likelihood, of course, people will just make nuisances of themselves.

A small change in the way text is handled in JavaScript can eliminate the need to invoke `html.escape()` at all in python. The Leaflet [`bindPopup()`](https://leafletjs.com/reference.html#layer-bindpopup) method can accept a DOM node instead of a text string. The leaflet method inserts text strings via an *unsafe* `innerHTML` assignment. DOM nodes are inserted verbatim \[[source](https://github.com/Leaflet/Leaflet/blob/f10b44b3afcd079febe5219f84dc67c68b379b5e/src/layer/DivOverlay.js#L280)\].

This patch creates a text-only DOM node that contains the marker text. Text nodes are not subject to further interpretation, and all HTML characters appear as literals. We use CSS to permit newline characters to render as line breaks. This preserves multi-line sign text if the configuration author elects to keep it.

This patch is marked RFC because there are a number of outstanding considerations not yet addressed, including:

- Documentation

- Examples

- API-breakage:

  - Configurations which previously escaped text in python will print slightly garbled, escaped output on the map. This is safe and will not error, but it will look wrong.
 
  - Deployments might *want* to insert safe HTML into the Leaflet popup.
    - We could enable this by permitting the configuration author to define a template DOM tree into which text nodes can be safely inserted. Inserts should be done using JavaScript which retrieves nodes by ID and sets their `textContent`.
    - Or we could simply include a configuration flag to permit the user to do things "the old way" with their assurances that they've handled escaping.

  - In any event, we need to consider the upgrade path to the new behavior very carefully.

The following test demonstrates this PR:

1. Insert an abusive sign into a test world with Op commands:
    ```txt
   /setblock ~1 ~ ~ minecraft:acacia_sign replace
   /data modify block ~1 ~ ~ Text1 set value '{"text":"<style onload=\\"alert(\'test\');\\"/>"}'
   ```

2. Render and `--genpoi` with a configuration which
   - extracts all signs as markers; and
   - does not escape marker text

3. Test that you are protected against injection attacks by clicking on the sign marker in Leaflet.

As a bonus, this also harmonizes the look of mouseover tooltip text with the popup text itself. In the most straightforward configurations, python's escape would cause the tooltip to be garbled.