### PR TITLE
Example Map Deadlink

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,9 +26,8 @@ features, including day and night lighting, cave rendering, mineral overlays,
 and many plugins for even more features! It is written mostly in Python with
 critical sections in C as an extension module.
 
-For a simple example of what your renders will look like, head over to `The
-"Exmaple" Map <https://overviewer.org/example/>`_. For more user-contributed
-examples, see `The Example Wiki Page <https://github.com/overviewer/Minecraft-Overviewer/wiki/Map-examples>`_.
+For some examples of what your renders will look like, check out these `user-contributed
+examples <https://github.com/overviewer/Minecraft-Overviewer/wiki/Map-examples>`_.
 
 .. image:: front_page_screenshot.png
     


### PR DESCRIPTION
I removed the original example map as it lead to a 404 page and reformatted the section to be more readable.