### PR TITLE
Update Minecraft Wiki links to new domain

### DIFF
--- a/docs/design/designdoc.rst
+++ b/docs/design/designdoc.rst
@@ -359,7 +359,7 @@ and from back to front.
 
 From the data file on disk, block information in a chunk is a three-dimensional
 array of bytes, each representing a `block id
-<http://www.minecraftwiki.net/wiki/Data_values#Block_IDs_.28Minecraft_Beta.29>`_.
+<http://www.minecraft.wiki/w/Data_values#Block_IDs_.28Minecraft_Beta.29>`_.
 The process of assembling a chunk is simply a matter of iterating over this
 array, reading the blockid values, looking up the appropriate sprite, and
 pasting it on the chunk image at the appropriate location.

--- a/docs/signs.rst
+++ b/docs/signs.rst
@@ -43,7 +43,7 @@ or a player's spawn.  See below for more details.
 In this example, this function returns all 4 lines from the sign
 if the entity is a sign.
 For more information of TileEntities and Entities, see
-the `Chunk Format <http://www.minecraftwiki.net/wiki/Chunk_format>`_ page on
+the `Chunk Format <http://www.minecraft.wiki/w/Chunk_format>`_ page on
 the Minecraft Wiki.
 
 A more complicated filter function can construct a more customized display text::

--- a/overviewer_core/nbt.py
+++ b/overviewer_core/nbt.py
@@ -208,7 +208,7 @@ class NBTFileReader(object):
 
 
 # For reference, the MCR format is outlined at
-# <http://www.minecraftwiki.net/wiki/Beta_Level_Format>
+# <http://www.minecraft.wiki/w/Beta_Level_Format>
 class MCRFileReader(object):
     """A class for reading chunk region files, as introduced in the
     Beta 1.3 update. It provides functions for opening individual


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.