### PR TITLE
Optimize tile storage by preventing saving of fully transparent images.

### DIFF
--- a/overviewer_core/tileset.py
+++ b/overviewer_core/tileset.py
@@ -28,7 +28,7 @@ import time
 from collections import namedtuple
 from itertools import chain, product
 
-from PIL import Image, ImageColor
+from PIL import Image
 
 from . import c_overviewer
 from . import rendermodes
@@ -1113,8 +1113,7 @@ class TileSet(object):
         # The viewer will fill in this missing tile with the default blank tile created in the
         # AssetManager, so there's no need to spend compute time on compressing and disk space
         # & network traffic on serving a blank image.
-        transparent_color = ImageColor.getrgb(self.options['bgcolor']) + (0,)
-        if tileimg.getcolors() == [(147456, transparent_color)]:
+        if tileimg.getcolors() == [(147456, self.options['bgcolor'])]:
             return
 
         # Create the directory if not exists

--- a/overviewer_core/tileset.py
+++ b/overviewer_core/tileset.py
@@ -984,9 +984,6 @@ class TileSet(object):
                 # Ignore errors if it's "file doesn't exist"
                 if e.errno != errno.ENOENT:
                     raise
-            logging.warning(
-                "Tile %s was requested for render, but no children were found! "
-                "This is probably a bug.", imgpath)
             return
 
         # Create the actual image now


### PR DESCRIPTION
I manage [Redstoner Maps](https://maps.redstoner.com/), which hosts Overviewer renders of 9 worlds, each featuring two tile sets: the standard "Overworld" render and a customized cave render named "Underworld". These 18 tile sets collectively held a staggering 22,681,416 files. While this quantity was warranted given the expansive nature of some of the worlds, it posed logistical challenges during a server migration. Consequently, I took a look at Overviewer to identify optimizations capable of reducing the file count without compromising the final map quality.

Across worlds such as BigPlots, Creative, and Trusted on Redstoner Maps, the Underworld tile sets contain vast regions of complete transparency. These areas were represented by individual transparent tiles generated by Overviewer. Furthermore, I observed that navigating beyond the rendered areas prompted Leaflet to request "blank.png" in response to expected 404 errors, effectively serving as a placeholder for missing tiles.

Building upon this existing functionality, this pull request proposes a straightforward yet effective adjustment: introducing a check during rendering to determine whether tiles are entirely transparent before saving them to disk. Tiles identified as fully transparent are excluded from the saving process.

Upon implementing this pull request, I regenerated all 18 tile sets on Redstoner Maps. The resultant file count went from 22,681,416 to a combined total of 8,184,222 files, marking a substantial ~64% reduction. While 8 million files remains considerable, this reduction notably eased the burden on inode usage and simplified data transfer processes for me. Most importantly, this optimization does not compromise the final product; missing tiles are seamlessly replaced with "blank.png" by Leaflet.

This pull request primarily benefits users of the cave renderer, especially on worlds with sparse cave systems, as they are the most likely to contain fully transparent tiles. Most normal renders will not experience significant benefits from this optimization.